### PR TITLE
fix(player): improve resource management and error handling in playba…

### DIFF
--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlaybackProgressReporter.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlaybackProgressReporter.kt
@@ -73,8 +73,8 @@ internal class PlaybackProgressReporter(
         progressJob = viewModel.viewModelScope.launch {
             while (true) {
                 delay(10_000)
-                val engine = getMediaEngine() ?: continue
-                val itemId = getCurrentItemId() ?: continue
+                val engine = getMediaEngine() ?: break
+                val itemId = getCurrentItemId() ?: break
                 val positionTicks = engine.currentPositionMs * 10_000
                 val isPaused = !engine.isPlaying.value
                 playbackRepository.reportPlaybackProgress(

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlayerSessionManager.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlayerSessionManager.kt
@@ -155,6 +155,7 @@ class PlayerSessionManager(
         startPositionTicks: Long,
         prefs: com.raulshma.jellyplay.core.model.UserPreferences,
     ) {
+        _engine.value?.release()
         val eng = PlayerEngineFactory.create(context, playerType)
         _engine.value = eng
         lastPlayerType = playerType

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/SyncPlayController.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/SyncPlayController.kt
@@ -111,6 +111,7 @@ internal class SyncPlayController(
     }
 
     fun reset() {
+        commandJob?.cancel()
         scheduledCommandJob?.cancel()
         syncCorrectionJob?.cancel()
         syncStateResetJob?.cancel()

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoMiniPlayerState.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoMiniPlayerState.kt
@@ -66,6 +66,10 @@ class VideoMiniPlayerState @Inject constructor() {
         if (!_isMiniMode.value) return null
         if (_itemId.value != itemId) return null
         val engine = _engine
+        job?.cancel()
+        job = null
+        miniScope?.cancel()
+        miniScope = null
         _isMiniMode.value = false
         _engine = null
         _itemId.value = null

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
@@ -266,18 +266,22 @@ fun VideoPlayerScreen(
         }
 
         onDispose {
-            // If we're currently in PiP, don't release the engine or reset the UI.
-            // The engine needs to stay alive until PiP is dismissed or returned to.
             val currentlyInPip = viewModel.playerLifecycleManager.isInPipMode.value
             if (!currentlyInPip) {
                 activity?.let {
-                    it.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                    it.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-                    val window = it.window
-                    val controller = WindowCompat.getInsetsController(window, window.decorView)
-                    controller.show(WindowInsetsCompat.Type.systemBars())
+                    if (!it.isDestroyed && !it.isFinishing) {
+                        it.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                        it.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                        val window = it.window
+                        val controller = WindowCompat.getInsetsController(window, window.decorView)
+                        controller.show(WindowInsetsCompat.Type.systemBars())
+                    }
                 }
-                activity?.let { act -> FrameRateMatcher.restoreOriginalMode(act) }
+                activity?.let { act ->
+                    if (!act.isDestroyed && !act.isFinishing) {
+                        FrameRateMatcher.restoreOriginalMode(act)
+                    }
+                }
                 playerViewRef = null
                 viewModel.release()
             }
@@ -286,38 +290,46 @@ fun VideoPlayerScreen(
 
     LaunchedEffect(uiState.isPlaying) {
         activity?.let {
-            if (uiState.isPlaying) {
-                it.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            } else {
-                it.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            if (!it.isDestroyed && !it.isFinishing) {
+                if (uiState.isPlaying) {
+                    it.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                } else {
+                    it.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                }
             }
         }
     }
 
     LaunchedEffect(Unit) {
         delay(400)
-        activity?.requestedOrientation = when (uiState.defaultOrientation) {
-            OrientationMode.SENSOR_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-            OrientationMode.SENSOR_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
-            OrientationMode.SENSOR -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
-            OrientationMode.LOCKED_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-            OrientationMode.LOCKED_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        activity?.let {
+            if (!it.isDestroyed && !it.isFinishing) {
+                it.requestedOrientation = when (uiState.defaultOrientation) {
+                    OrientationMode.SENSOR_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+                    OrientationMode.SENSOR_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+                    OrientationMode.SENSOR -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                    OrientationMode.LOCKED_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+                    OrientationMode.LOCKED_PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+                }
+            }
         }
     }
 
     LaunchedEffect(uiState.frameRateMatching, uiState.videoFrameRate) {
         if (uiState.frameRateMatching && uiState.videoFrameRate != null) {
-            activity?.let { FrameRateMatcher.matchFrameRate(it, uiState.videoFrameRate) }
+            activity?.let { if (!it.isDestroyed && !it.isFinishing) FrameRateMatcher.matchFrameRate(it, uiState.videoFrameRate) }
         }
     }
 
     LaunchedEffect(uiState.rememberBrightness) {
         if (uiState.rememberBrightness && uiState.brightnessLevel != 0.5f) {
             activity?.let { act ->
-                val layout = act.window.attributes
-                layout.screenBrightness = uiState.brightnessLevel
-                act.window.attributes = layout
-                brightnessOverlay = uiState.brightnessLevel
+                if (!act.isDestroyed && !act.isFinishing) {
+                    val layout = act.window.attributes
+                    layout.screenBrightness = uiState.brightnessLevel
+                    act.window.attributes = layout
+                    brightnessOverlay = uiState.brightnessLevel
+                }
             }
         }
     }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -250,6 +250,7 @@ class VideoPlayerViewModel @Inject constructor(
         subtitleStreamIndex: Int? = null,
         audioStreamIndex: Int? = null,
     ) {
+        released = false
         pendingSubtitleStreamIndex = subtitleStreamIndex
         pendingAudioStreamIndex = audioStreamIndex
         val currentItemId = playerSessionManager.sessionState.value.currentItemId
@@ -591,6 +592,8 @@ class VideoPlayerViewModel @Inject constructor(
         val currentSpeed = _uiState.value.playbackSpeed
         val currentQuality = _uiState.value.streamingQuality
         val maxBitrate = adaptiveBitrateManager.resolveMaxBitrate(currentQuality)?.toInt()
+        progressReporter.cancelJobs()
+        releaseVideoMediaSession()
         _uiState.update {
             it.copy(
                 showPlaybackErrorDialog = false,
@@ -601,6 +604,14 @@ class VideoPlayerViewModel @Inject constructor(
         viewModelScope.launch {
             preferencesStore.setPreferredPlayer(playerType)
             playerSessionManager.reloadWithEngine(playerType, currentPos, currentSpeed, maxBitrate)
+            val sessionState = playerSessionManager.sessionState.value
+            createVideoMediaSession(
+                sessionState.currentItemId ?: "",
+                sessionState.title,
+                sessionState.subtitle,
+            )
+            progressReporter.startPositionTracking()
+            progressReporter.startProgressReporting()
         }
     }
 
@@ -1302,7 +1313,11 @@ class VideoPlayerViewModel @Inject constructor(
         playerLifecycleManager.requestAutoEnterPip(false)
     }
 
+    private var released = false
+
     fun release() {
+        if (released) return
+        released = true
         val itemId = playerSessionManager.sessionState.value.currentItemId
         val sessionId = playSessionId
         val positionTicks = playerSessionManager.engine?.currentPositionMs?.let { it * 10_000 } ?: 0L
@@ -1310,25 +1325,29 @@ class VideoPlayerViewModel @Inject constructor(
         releaseInternals()
         castManager.release()
         if (itemId != null && positionTicks > 0) {
-            viewModelScope.launch {
-                playbackRepository.reportPlaybackStopped(
-                    itemId = itemId,
-                    sessionId = sessionId,
-                    positionTicks = positionTicks,
-                )
+            kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
+                runCatching {
+                    playbackRepository.reportPlaybackStopped(
+                        itemId = itemId,
+                        sessionId = sessionId,
+                        positionTicks = positionTicks,
+                    )
+                }
             }
         }
     }
 
     override fun onCleared() {
         super.onCleared()
+        if (released) return
+        released = true
         val itemId = playerSessionManager.sessionState.value.currentItemId
         val sessionId = playSessionId
         val positionTicks = playerSessionManager.engine?.currentPositionMs?.let { it * 10_000 } ?: 0L
         releaseInternals()
         castManager.release()
         if (itemId != null && positionTicks > 0) {
-            viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            kotlinx.coroutines.runBlocking(kotlinx.coroutines.Dispatchers.IO) {
                 runCatching {
                     playbackRepository.reportPlaybackStopped(itemId, sessionId, positionTicks)
                 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
@@ -149,6 +149,10 @@ class ExoPlayerEngine(
         override fun onCues(cueGroup: androidx.media3.common.text.CueGroup) {
             _currentCues.value = cueGroup.cues.mapNotNull { it.text?.toString() }
         }
+
+        override fun onAudioSessionIdChanged(audioSessionId: Int) {
+            applyAudioEffects()
+        }
     }
 
     override fun load(request: PlaybackRequest) {
@@ -285,6 +289,7 @@ class ExoPlayerEngine(
     }
 
     override fun release() {
+        engineScope.cancel()
         player?.removeListener(listener)
         playerView?.player = null
         playerView = null
@@ -295,7 +300,11 @@ class ExoPlayerEngine(
         currentSubtitleConfigs.clear()
         lastVideoStats = null
         releaseAudioEffects()
-        engineScope.cancel()
+        _playbackState.value = EnginePlaybackState.IDLE
+        _isPlaying.value = false
+        _availableTracks.value = emptyList()
+        _bufferedPositionMs.value = 0L
+        _videoStats.value = EngineVideoStats()
     }
 
     override fun play() {
@@ -361,6 +370,10 @@ class ExoPlayerEngine(
                 )
             } else {
                 val groups = p.currentTracks.groups.filter { it.type == exoType }
+                if (groups.isEmpty()) {
+                    selector.setParameters(params)
+                    return
+                }
                 val groupIndex = index.coerceIn(groups.indices)
                 if (groupIndex in groups.indices) {
                     val fallbackGroup = groups[groupIndex].mediaTrackGroup
@@ -467,10 +480,10 @@ class ExoPlayerEngine(
         val p = player ?: run { close(); return@callbackFlow }
         val posListener = object : Player.Listener {
             override fun onPositionDiscontinuity(oldPosition: Player.PositionInfo, newPosition: Player.PositionInfo, reason: Int) {
-                trySend(p.currentPosition)
+                runCatching { trySend(p.currentPosition) }
             }
             override fun onPlaybackStateChanged(playbackState: Int) {
-                trySend(p.currentPosition)
+                runCatching { trySend(p.currentPosition) }
             }
         }
         p.addListener(posListener)
@@ -480,22 +493,24 @@ class ExoPlayerEngine(
         val ticker = engineScope.launch {
             while (isActive) {
                 delay(500)
-                val currentlyPlaying = p.isPlaying
-                if (currentlyPlaying) {
-                    trySend(p.currentPosition)
-                    _bufferedPositionMs.value = p.bufferedPosition.coerceAtLeast(0L)
-                    updateVideoStats()
-                } else if (currentlyPlaying != lastPlayingState) {
-                    trySend(p.currentPosition)
-                    _bufferedPositionMs.value = p.bufferedPosition.coerceAtLeast(0L)
+                runCatching {
+                    val currentlyPlaying = p.isPlaying
+                    if (currentlyPlaying) {
+                        trySend(p.currentPosition)
+                        _bufferedPositionMs.value = p.bufferedPosition.coerceAtLeast(0L)
+                        updateVideoStats()
+                    } else if (currentlyPlaying != lastPlayingState) {
+                        trySend(p.currentPosition)
+                        _bufferedPositionMs.value = p.bufferedPosition.coerceAtLeast(0L)
+                    }
+                    lastPlayingState = currentlyPlaying
                 }
-                lastPlayingState = currentlyPlaying
             }
         }
 
         awaitClose {
             ticker.cancel()
-            p.removeListener(posListener)
+            try { p.removeListener(posListener) } catch (_: Exception) {}
         }
     }
 

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/LibVlcPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/LibVlcPlayerEngine.kt
@@ -276,8 +276,13 @@ class LibVlcPlayerEngine(
     }
 
     override fun release() {
-        releaseInternal(releaseVlc = true)
         engineScope.cancel()
+        releaseInternal(releaseVlc = true)
+        _playbackState.value = EnginePlaybackState.IDLE
+        _isPlaying.value = false
+        _availableTracks.value = emptyList()
+        _bufferedPositionMs.value = 0L
+        _videoStats.value = EngineVideoStats()
     }
 
     private fun releaseInternal(releaseVlc: Boolean) {
@@ -488,6 +493,9 @@ class LibVlcPlayerEngine(
 
         if (request.headers.isNotEmpty()) {
             media.addOption(":http-user-agent=JellyPlay")
+            request.headers.forEach { (key, value) ->
+                media.addOption(":http-header=${key}: ${value}")
+            }
         }
 
         request.externalSubtitles.forEach { sub ->
@@ -576,15 +584,17 @@ class LibVlcPlayerEngine(
     override val positionFlow: Flow<Long> = callbackFlow {
         trySend(currentPositionMs)
         var lastPlayingState = _isPlaying.value
-        val ticker = engineScope.launch(Dispatchers.Default) {
+        val ticker = engineScope.launch {
             while (isActive) {
                 delay(500)
-                trySend(currentPositionMs)
-                val currentlyPlaying = _isPlaying.value
-                if (currentlyPlaying || currentlyPlaying != lastPlayingState) {
-                    updateBufferAndStats()
+                runCatching {
+                    trySend(currentPositionMs)
+                    val currentlyPlaying = _isPlaying.value
+                    if (currentlyPlaying || currentlyPlaying != lastPlayingState) {
+                        updateBufferAndStats()
+                    }
+                    lastPlayingState = currentlyPlaying
                 }
-                lastPlayingState = currentlyPlaying
             }
         }
         awaitClose { ticker.cancel() }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
@@ -95,9 +95,9 @@ class MpvPlayerEngine(
 
     private var mpvView: PlayerMPVView? = null
     private var pendingRequest: PlaybackRequest? = null
-    private var pendingSubtitles: List<SubtitleSource> = emptyList()
-    private var pendingPreferredSubtitleLanguage: String? = null
-    private var lastLoggedSubtitleText: String? = null
+    @Volatile private var pendingSubtitles: List<SubtitleSource> = emptyList()
+    @Volatile private var pendingPreferredSubtitleLanguage: String? = null
+    @Volatile private var lastLoggedSubtitleText: String? = null
     
     private var currentConfig = EngineConfig()
     private val dialogueBoost = DialogueBoostHelper()
@@ -313,16 +313,21 @@ class MpvPlayerEngine(
         nightMode.detach()
         audioNormalization.detach()
         channelMix.detach()
-        mpvView?.let { view ->
-            view.removeObserver()
-            try { view.destroy() } catch (e: Exception) { Log.w(TAG, "destroy", e) }
-        }
-        mpvView = null
         engineScope.cancel()
+        val view = mpvView
+        mpvView = null
+        view?.let {
+            it.removeObserver()
+            try { it.destroy() } catch (e: Exception) { Log.w(TAG, "destroy", e) }
+        }
+        _playbackState.value = EnginePlaybackState.IDLE
+        _isPlaying.value = false
+        _availableTracks.value = emptyList()
+        _bufferedPositionMs.value = 0L
+        _videoStats.value = EngineVideoStats()
     }
 
     override fun play() {
-        _isPlaying.value = true
         try {
             if (_playbackState.value == EnginePlaybackState.ENDED) {
                 mpvView?.mpv?.command("seek", "0", "absolute")
@@ -332,7 +337,6 @@ class MpvPlayerEngine(
     }
 
     override fun pause() {
-        _isPlaying.value = false
         try { mpvView?.mpv?.setPropertyBoolean("pause", true) } catch (_: Exception) {}
     }
 
@@ -530,7 +534,7 @@ class MpvPlayerEngine(
     override val positionFlow: Flow<Long> = callbackFlow {
         trySend(currentPositionMs)
         var lastPlayingState = _isPlaying.value
-        val ticker = engineScope.launch(Dispatchers.Default) {
+        val ticker = engineScope.launch {
             while (isActive) {
                 delay(500)
                 trySend(currentPositionMs)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the video player feature, focusing on safer resource management, improved player engine state handling, and more robust coroutine/job management. The changes enhance reliability, especially during player lifecycle events such as release, engine switching, and UI disposal.

**Resource and Lifecycle Management Improvements:**

- Added checks to prevent operations on destroyed or finishing activities in `VideoPlayerScreen`, ensuring orientation and window changes are only made when safe. [[1]](diffhunk://#diff-1ef388f54c2d577b0a587412f5615a32b098b139c9fed597fd7ce23821ff6a3bL269-R284) [[2]](diffhunk://#diff-1ef388f54c2d577b0a587412f5615a32b098b139c9fed597fd7ce23821ff6a3bR293-R335)
- Ensured that the player engine is properly released before creating a new one in `PlayerSessionManager`, preventing resource leaks.
- Improved the release logic in `VideoPlayerViewModel` by introducing a `released` flag to avoid duplicate releases and using `runBlocking` for synchronous cleanup/reporting. [[1]](diffhunk://#diff-b9a575e326414f1fe0dbfa35765ef3ead35011aa57f503007211eaa0f9642136R253) [[2]](diffhunk://#diff-b9a575e326414f1fe0dbfa35765ef3ead35011aa57f503007211eaa0f9642136R1316-R1329) [[3]](diffhunk://#diff-b9a575e326414f1fe0dbfa35765ef3ead35011aa57f503007211eaa0f9642136R1338-R1350)

**Player Engine and Playback State Handling:**

- Standardized the engine release process across all player engines (`ExoPlayerEngine`, `LibVlcPlayerEngine`, `MpvPlayerEngine`) to reset state flows, clear tracks, and cancel engine scopes, ensuring a consistent and clean state after release. [[1]](diffhunk://#diff-ad8729a40f9610368a3dc7f840ba1f450d3da7da288022031fecfe7ec7b8e278R292) [[2]](diffhunk://#diff-ad8729a40f9610368a3dc7f840ba1f450d3da7da288022031fecfe7ec7b8e278L298-R307) [[3]](diffhunk://#diff-cbf6fe8dcd086455f06130b1cdcd11dc9d1ccc1450beaeb282b84f57c2bb5925L279-R285) [[4]](diffhunk://#diff-639fed2bb59234a1d1156d69ce50d6965ea15edadeaeb46a82a22841afd49237L316-L325)
- Improved subtitle and audio session handling, including applying audio effects on session changes and making subtitle-related fields volatile for thread safety in `MpvPlayerEngine`. [[1]](diffhunk://#diff-ad8729a40f9610368a3dc7f840ba1f450d3da7da288022031fecfe7ec7b8e278R152-R155) [[2]](diffhunk://#diff-639fed2bb59234a1d1156d69ce50d6965ea15edadeaeb46a82a22841afd49237L98-R100)

**Coroutine and Job Management:**

- Added proper cancellation and nullification of jobs and scopes in `VideoMiniPlayerState` and `SyncPlayController` to prevent memory leaks and unintended behavior. [[1]](diffhunk://#diff-ad6af21867ea02856de264a235f9abefb13e4c3b87ac3eea2cbd1ffab6ecab33R69-R72) [[2]](diffhunk://#diff-8309174077c64425596ab7157969a553375511a430d8f32bd51009e38c6ca24bR114)
- Improved progress reporting and media session management in `VideoPlayerViewModel`, ensuring jobs are cancelled and restarted appropriately during engine reloads or release. [[1]](diffhunk://#diff-b9a575e326414f1fe0dbfa35765ef3ead35011aa57f503007211eaa0f9642136R595-R596) [[2]](diffhunk://#diff-b9a575e326414f1fe0dbfa35765ef3ead35011aa57f503007211eaa0f9642136R607-R614)

**Playback Progress and Reporting:**

- Modified the playback progress reporter to break out of the reporting loop if the engine or item ID is unavailable, avoiding unnecessary work.

**General Robustness Enhancements:**

- Wrapped listener removal and position sending in `runCatching` blocks in player engines to gracefully handle exceptions and avoid crashes. [[1]](diffhunk://#diff-ad8729a40f9610368a3dc7f840ba1f450d3da7da288022031fecfe7ec7b8e278L470-R486) [[2]](diffhunk://#diff-ad8729a40f9610368a3dc7f840ba1f450d3da7da288022031fecfe7ec7b8e278R496) [[3]](diffhunk://#diff-cbf6fe8dcd086455f06130b1cdcd11dc9d1ccc1450beaeb282b84f57c2bb5925L579-R590) [[4]](diffhunk://#diff-cbf6fe8dcd086455f06130b1cdcd11dc9d1ccc1450beaeb282b84f57c2bb5925R599)
- Passed custom HTTP headers to VLC media in `LibVlcPlayerEngine` when present, improving compatibility with certain streams.
- Improved track selection logic in `ExoPlayerEngine` to handle empty track groups safely.

These changes collectively make the video player more robust and reliable, especially during edge cases and lifecycle transitions.