### PR TITLE
Implement Favorites feature and caching for improved performance

### DIFF
--- a/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
@@ -33,6 +33,9 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory {
     @Inject lateinit var okHttpClient: OkHttpClient
     @Inject lateinit var downloadDao: DownloadDao
     @Inject lateinit var userPreferencesStore: com.raulshma.jellyplay.core.datastore.UserPreferencesStore
+    @Inject lateinit var mediaRepository: com.raulshma.jellyplay.core.data.repository.MediaRepository
+    @Inject lateinit var offlineRepository: com.raulshma.jellyplay.core.data.repository.OfflineRepository
+    @Inject lateinit var audioPlaybackManager: com.raulshma.jellyplay.core.data.playback.AudioPlaybackManager
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -45,7 +48,13 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory {
                 }
             }
         }
-        applicationScope.launch { recoverPendingDownloads() }
+        audioPlaybackManager.start()
+        applicationScope.launch {
+            recoverPendingDownloads()
+            cleanupStuckDownloads()
+            mediaRepository.cleanupLyricsCache()
+            offlineRepository.cleanupOrphans()
+        }
     }
 
     private fun configureSentryUserContext() {
@@ -93,13 +102,37 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory {
         }
     }
 
+    private suspend fun cleanupStuckDownloads() {
+        try {
+            downloadDao.resetStuckDownloading()
+            val failed = downloadDao.getFailedDownloads()
+            for (download in failed) {
+                if (download.downloadPath.isNotBlank()) {
+                    val file = java.io.File(download.downloadPath)
+                    if (file.exists() && file.length() == 0L) {
+                        file.delete()
+                    }
+                }
+            }
+        } catch (_: Exception) {
+        }
+    }
+
+    private val imageClient by lazy {
+        okHttpClient.newBuilder()
+            .connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            .connectionPool(okhttp3.ConnectionPool(8, 15, java.util.concurrent.TimeUnit.MINUTES))
+            .build()
+    }
+
     private val imageLoader by lazy {
         val cacheMb = userPreferencesStore.preferences.value.maxCacheSizeMb
         val cacheSize = if (cacheMb > 0) cacheMb * 1024L * 1024L else 256L * 1024 * 1024
 
         ImageLoader.Builder(this)
             .components {
-                add(OkHttpNetworkFetcherFactory(callFactory = { okHttpClient }))
+                add(OkHttpNetworkFetcherFactory(callFactory = { imageClient }))
             }
             .memoryCache {
                 MemoryCache.Builder()

--- a/app/src/main/java/com/raulshma/jellyplay/tile/JellyPlayTileService.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/tile/JellyPlayTileService.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -21,12 +22,13 @@ class JellyPlayTileService : TileService() {
 
     @Inject lateinit var audioPlaybackManager: AudioPlaybackManager
 
+    private val tileScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var job: Job? = null
 
     override fun onStartListening() {
         super.onStartListening()
         updateTile()
-        job = CoroutineScope(Dispatchers.Main).launch {
+        job = tileScope.launch {
             audioPlaybackManager.isPlaying.collect { isPlaying ->
                 updateTile(isPlaying)
             }

--- a/app/src/main/java/com/raulshma/jellyplay/widget/ContinueWatchingWidget.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/ContinueWatchingWidget.kt
@@ -23,7 +23,8 @@ import kotlinx.coroutines.launch
 
 class ContinueWatchingWidget : AppWidgetProvider() {
 
-    private var updateScope: CoroutineScope? = null
+    private val widgetScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var updateJob: kotlinx.coroutines.Job? = null
 
     @EntryPoint
     @InstallIn(SingletonComponent::class)
@@ -42,9 +43,8 @@ class ContinueWatchingWidget : AppWidgetProvider() {
         )
         val store = entryPoint.preferencesStore()
 
-        updateScope?.cancel()
-        updateScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-        updateScope!!.launch {
+        updateJob?.cancel()
+        updateJob = widgetScope.launch {
             val items = store.continueWatching.first()
             appWidgetIds.forEach { appWidgetId ->
                 updateWidget(context, appWidgetManager, appWidgetId, items)
@@ -64,14 +64,12 @@ class ContinueWatchingWidget : AppWidgetProvider() {
 
     override fun onDisabled(context: Context?) {
         super.onDisabled(context)
-        updateScope?.cancel()
-        updateScope = null
+        updateJob?.cancel()
     }
 
     override fun onDeleted(context: Context?, appWidgetIds: IntArray?) {
         super.onDeleted(context, appWidgetIds)
-        updateScope?.cancel()
-        updateScope = null
+        updateJob?.cancel()
     }
 
     companion object {

--- a/app/src/main/java/com/raulshma/jellyplay/widget/NowPlayingWidget.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/NowPlayingWidget.kt
@@ -145,12 +145,22 @@ class NowPlayingWidget : AppWidgetProvider() {
             positionMs: Long = 0L,
             durationMs: Long = 0L,
         ) {
+            val scaledArt = albumArt?.let { art ->
+                if (art.byteCount > 512 * 1024) {
+                    val scale = (512f * 1024 / art.byteCount.coerceAtLeast(1)).let {
+                        kotlin.math.sqrt(it.toDouble()).toFloat()
+                    }
+                    val w = (art.width * scale).toInt().coerceAtLeast(1)
+                    val h = (art.height * scale).toInt().coerceAtLeast(1)
+                    Bitmap.createScaledBitmap(art, w, h, true)
+                } else art
+            }
             val intent = Intent(context, NowPlayingWidget::class.java).apply {
                 action = ACTION_UPDATE
                 putExtra(EXTRA_TITLE, title)
                 putExtra(EXTRA_SUBTITLE, subtitle)
                 putExtra(EXTRA_IS_PLAYING, isPlaying)
-                putExtra(EXTRA_ALBUM_ART, albumArt)
+                putExtra(EXTRA_ALBUM_ART, scaledArt)
                 putExtra(EXTRA_POSITION_MS, positionMs)
                 putExtra(EXTRA_DURATION_MS, durationMs)
             }

--- a/app/src/tv/java/com/raulshma/jellyplay/screensaver/JellyPlayDreamService.kt
+++ b/app/src/tv/java/com/raulshma/jellyplay/screensaver/JellyPlayDreamService.kt
@@ -129,11 +129,11 @@ class JellyPlayDreamService : DreamService() {
                 val prefs = preferencesStore.preferences.first()
                 val fetched = imageProvider.fetchImages(
                     categories = prefs.dreamImageCategories,
-                    count = 50,
+                    count = 25,
                 )
                 images = fetched
-                if (fetched.size > 5) {
-                    imageProvider.prefetchImages(fetched.take(5).map { it.backdropUrl })
+                if (fetched.size > 3) {
+                    imageProvider.prefetchImages(fetched.take(3).map { it.backdropUrl })
                 }
             } catch (_: Exception) {
                 images = emptyList()

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -29,8 +29,6 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:datastore"))
 
-    implementation(libs.room.ktx)
-
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.work)
@@ -39,6 +37,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.paging.runtime)
     implementation(libs.work.runtime.ktx)
+    implementation(libs.room.ktx)
     implementation(libs.media3.session)
     implementation(libs.media3.exoplayer)
     implementation(libs.media3.cast)

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/paging/FavoritesPagingSource.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/paging/FavoritesPagingSource.kt
@@ -1,0 +1,63 @@
+package com.raulshma.jellyplay.core.data.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.raulshma.jellyplay.core.data.repository.MediaRepository
+import com.raulshma.jellyplay.core.model.MediaItem
+import com.raulshma.jellyplay.core.model.MediaType
+
+class FavoritesPagingSource(
+    private val mediaRepository: MediaRepository,
+    private val mediaTypes: List<MediaType>? = null,
+) : PagingSource<Int, MediaItem>() {
+
+    override fun getRefreshKey(state: PagingState<Int, MediaItem>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, MediaItem> {
+        val startIndex = params.key ?: 0
+        val pageSize = params.loadSize
+
+        return try {
+            val result = mediaRepository.getFavorites(
+                mediaTypes = mediaTypes,
+                limit = pageSize,
+                startIndex = startIndex,
+            )
+
+            result.fold(
+                onSuccess = { searchResult ->
+                    val items = searchResult.items
+                    val totalRecordCount = searchResult.totalRecordCount
+
+                    val nextKey = if (startIndex + items.size < totalRecordCount) {
+                        startIndex + items.size
+                    } else {
+                        null
+                    }
+
+                    val prevKey = if (startIndex > 0) {
+                        maxOf(0, startIndex - pageSize)
+                    } else {
+                        null
+                    }
+
+                    LoadResult.Page(
+                        data = items,
+                        prevKey = prevKey,
+                        nextKey = nextKey,
+                    )
+                },
+                onFailure = { exception ->
+                    LoadResult.Error(exception)
+                },
+            )
+        } catch (exception: Exception) {
+            LoadResult.Error(exception)
+        }
+    }
+}

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
@@ -71,6 +71,7 @@ class AudioPlaybackManager @Inject constructor(
     private val queuePersistenceHelper: QueuePersistenceHelper,
     private val bandwidthMonitor: com.raulshma.jellyplay.core.data.streaming.BandwidthMonitor,
     private val adaptiveBitrateSelector: com.raulshma.jellyplay.core.data.streaming.AdaptiveBitrateSelector,
+    private val bandwidthInterceptor: com.raulshma.jellyplay.core.network.interceptor.BandwidthInterceptor,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
@@ -84,11 +85,12 @@ class AudioPlaybackManager @Inject constructor(
                 currentPreferences = prefs
             }
         }
-        android.os.Handler(android.os.Looper.getMainLooper()).post {
-            scope.launch(Dispatchers.IO) {
-                restorePersistedQueue()
-                observeQueuePersistence()
-            }
+    }
+
+    fun start() {
+        scope.launch(Dispatchers.IO) {
+            restorePersistedQueue()
+            observeQueuePersistence()
         }
     }
     private var mediaSession: MediaSession? = null
@@ -123,7 +125,7 @@ class AudioPlaybackManager @Inject constructor(
     private val _playbackError = MutableStateFlow<String?>(null)
     val playbackError: StateFlow<String?> = _playbackError.asStateFlow()
 
-    val estimatedBandwidthKbps: StateFlow<Double> = bandwidthMonitor.estimatedBandwidthKbps
+    val estimatedBandwidthKbps: StateFlow<Double> = bandwidthInterceptor.estimatedBandwidthKbps
 
     private val _currentAudioBitrateTier = MutableStateFlow(com.raulshma.jellyplay.core.model.AudioBitrateTier.DEFAULT)
     val currentAudioBitrateTier: StateFlow<com.raulshma.jellyplay.core.model.AudioBitrateTier> = _currentAudioBitrateTier.asStateFlow()
@@ -1082,7 +1084,9 @@ class AudioPlaybackManager @Inject constructor(
             reverbHelper.setEnabled(true)
         }
         visualizerHelper.attach(audioSessionId)
-        visualizerHelper.setEnabled(true)
+        if (visualizerHelper.isEnabled) {
+            visualizerHelper.setEnabled(true)
+        }
     }
 
     fun setEqualizerPreset(preset: EqualizerPreset) {
@@ -1402,7 +1406,9 @@ class AudioPlaybackManager @Inject constructor(
             reverbHelper.setPreset(_reverbPreset.value)
         }
         visualizerHelper.attach(secondary.audioSessionId)
-        visualizerHelper.setEnabled(true)
+        if (visualizerHelper.isEnabled) {
+            visualizerHelper.setEnabled(true)
+        }
 
         _isCrossfading.value = false
 
@@ -1535,7 +1541,7 @@ class AudioPlaybackManager @Inject constructor(
                     }
                 }
             }
-            delay(100)
+            delay(250)
             }
         }
     }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioVisualizerHelper.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioVisualizerHelper.kt
@@ -33,7 +33,7 @@ class AudioVisualizerHelper {
 
         visualizer = try {
             Visualizer(audioSessionId).apply {
-                captureSize = Visualizer.getCaptureSizeRange()[1]
+                captureSize = Visualizer.getCaptureSizeRange()[0]
                 setDataCaptureListener(
                     object : Visualizer.OnDataCaptureListener {
                         override fun onWaveFormDataCapture(
@@ -58,7 +58,7 @@ class AudioVisualizerHelper {
                             }
                         }
                     },
-                    Visualizer.getMaxCaptureRate() / 2,
+                    Visualizer.getMaxCaptureRate() / 4,
                     true,
                     true,
                 )

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/SleepTimerManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/SleepTimerManager.kt
@@ -23,6 +23,10 @@ class SleepTimerManager @Inject constructor() {
     private val _remainingMs = MutableStateFlow(0L)
     val remainingMs: StateFlow<Long> = _remainingMs.asStateFlow()
 
+    private companion object {
+        const val SLEEP_TIMER_TICK_MS = 5_000L
+    }
+
     private val _isEndOfEpisodeMode = MutableStateFlow(false)
     val isEndOfEpisodeMode: StateFlow<Boolean> = _isEndOfEpisodeMode.asStateFlow()
 
@@ -46,13 +50,15 @@ class SleepTimerManager @Inject constructor() {
 
         timerJob = scope.launch {
             while (isActive && SystemClock.elapsedRealtime() < targetElapsedMs) {
-                delay(1000L)
+                delay(SLEEP_TIMER_TICK_MS)
                 _remainingMs.value = (targetElapsedMs - SystemClock.elapsedRealtime()).coerceAtLeast(0)
             }
             if (isActive) {
                 _isActive.value = false
                 _remainingMs.value = 0
-                onTimerExpired?.invoke()
+                try {
+                    onTimerExpired?.invoke()
+                } catch (_: Exception) {}
             }
         }
     }
@@ -75,7 +81,9 @@ class SleepTimerManager @Inject constructor() {
     fun triggerEndOfEpisode() {
         if (_isEndOfEpisodeMode.value && _isActive.value) {
             cancel()
-            onTimerExpired?.invoke()
+            try {
+                onTimerExpired?.invoke()
+            } catch (_: Exception) {}
         }
     }
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/AdminStatisticsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/AdminStatisticsRepositoryImpl.kt
@@ -21,6 +21,8 @@ import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -48,6 +50,15 @@ class AdminStatisticsRepositoryImpl @Inject constructor(
 
     override suspend fun refreshPlaybackReportingStatus() {
         _pluginStatus.value = apiClient.checkPlaybackReportingPlugin().getOrDefault(PlaybackReportingStatus.UNAVAILABLE)
+        cleanupOldAuditLogs()
+    }
+
+    private suspend fun cleanupOldAuditLogs() {
+        try {
+            val ninetyDaysAgo = System.currentTimeMillis() - 90L * 24 * 60 * 60 * 1000
+            auditLogDao.deleteOlderThan(ninetyDaysAgo)
+        } catch (_: Exception) {
+        }
     }
 
     override suspend fun getAllUsersWithStatistics(): Result<List<UserStatistics>> = runCatching {
@@ -65,10 +76,18 @@ class AdminStatisticsRepositoryImpl @Inject constructor(
             val userId = user.id
             val isActive = activeUserIds.contains(userId)
 
-            val moviePlayed = apiClient.getUserPlayedItemCount(userId, listOf("Movie")).getOrDefault(0)
-            val episodePlayed = apiClient.getUserPlayedItemCount(userId, listOf("Episode")).getOrDefault(0)
-            val songPlayed = apiClient.getUserPlayedItemCount(userId, listOf("Audio")).getOrDefault(0)
-            val movieTotal = apiClient.getUserUnplayedItemCount(userId, listOf("Movie")).getOrDefault(0) + moviePlayed
+            val stats = coroutineScope {
+                val movieDeferred = async { apiClient.getUserPlayedItemCount(userId, listOf("Movie")).getOrDefault(0) }
+                val episodeDeferred = async { apiClient.getUserPlayedItemCount(userId, listOf("Episode")).getOrDefault(0) }
+                val songDeferred = async { apiClient.getUserPlayedItemCount(userId, listOf("Audio")).getOrDefault(0) }
+                val movieUnplayedDeferred = async { apiClient.getUserUnplayedItemCount(userId, listOf("Movie")).getOrDefault(0) }
+                intArrayOf(movieDeferred.await(), episodeDeferred.await(), songDeferred.await(), movieUnplayedDeferred.await())
+            }
+            val moviePlayed = stats[0]
+            val episodePlayed = stats[1]
+            val songPlayed = stats[2]
+            val movieUnplayed = stats[3]
+            val movieTotal = movieUnplayed + moviePlayed
             val completionRate = if (movieTotal > 0) moviePlayed.toFloat() / movieTotal else 0f
 
             val pluginData = pluginMap[userId]
@@ -307,11 +326,9 @@ class AdminStatisticsRepositoryImpl @Inject constructor(
                 )
             )
         } catch (e: Exception) {
-            withContext(Dispatchers.Main) {
-                val entity = scanStateDao.getById(scanId)
-                if (entity != null) {
-                    scanStateDao.update(entity.copy(status = ScanPhase.FAILED.name))
-                }
+            val entity = scanStateDao.getById(scanId)
+            if (entity != null) {
+                scanStateDao.update(entity.copy(status = ScanPhase.FAILED.name))
             }
         }
     }
@@ -386,11 +403,9 @@ class AdminStatisticsRepositoryImpl @Inject constructor(
                 )
             )
         } catch (e: Exception) {
-            withContext(Dispatchers.Main) {
-                val entity = scanStateDao.getById(scanId)
-                if (entity != null) {
-                    scanStateDao.update(entity.copy(status = ScanPhase.FAILED.name))
-                }
+            val entity = scanStateDao.getById(scanId)
+            if (entity != null) {
+                scanStateDao.update(entity.copy(status = ScanPhase.FAILED.name))
             }
         }
     }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.raulshma.jellyplay.core.data.repository
 
 import android.content.Context
 import android.os.Environment
+import androidx.room.withTransaction
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
@@ -10,6 +11,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import coil3.SingletonImageLoader
 import coil3.request.ImageRequest
+import com.raulshma.jellyplay.core.database.JellyPlayDatabase
 import com.raulshma.jellyplay.core.database.dao.DownloadDao
 import com.raulshma.jellyplay.core.database.dao.OfflineMediaDao
 import com.raulshma.jellyplay.core.database.entity.DownloadEntity
@@ -41,6 +43,7 @@ class DownloadRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
     private val downloadDao: DownloadDao,
     private val offlineMediaDao: OfflineMediaDao,
+    private val database: JellyPlayDatabase,
     private val mediaRepository: MediaRepository,
     private val playbackRepository: PlaybackRepository,
     private val preferencesStore: com.raulshma.jellyplay.core.datastore.UserPreferencesStore,
@@ -108,9 +111,16 @@ class DownloadRepositoryImpl @Inject constructor(
             }
         }
 
-        val id = UUID.randomUUID().toString()
         val isAudioType = mediaType == MediaType.AUDIO.name || mediaType == MediaType.MUSIC.name
         val dirType = if (isAudioType) Environment.DIRECTORY_MUSIC else Environment.DIRECTORY_MOVIES
+        val downloadDir = context.getExternalFilesDir(dirType) ?: File(context.filesDir, if (isAudioType) "downloads/music" else "downloads")
+        val statFs = android.os.StatFs(downloadDir.absolutePath)
+        val availableBytes = statFs.availableBlocksLong * statFs.blockSizeLong
+        if (availableBytes < 100L * 1024 * 1024) {
+            throw IllegalStateException("Insufficient storage space. Less than 100 MB available on device.")
+        }
+
+        val id = UUID.randomUUID().toString()
         val dir = context.getExternalFilesDir(dirType)
             ?: File(context.filesDir, if (isAudioType) "downloads/music" else "downloads")
         if (!dir.exists()) dir.mkdirs()
@@ -435,10 +445,12 @@ class DownloadRepositoryImpl @Inject constructor(
                 if (trickplayDir.exists()) trickplayDir.deleteRecursively()
             }
         }
-        downloadDao.deleteDownloadById(entity.id)
-        offlineMediaDao.deleteById(entity.mediaItemId)
-        offlineMediaDao.deleteOrphanedSeasons()
-        offlineMediaDao.deleteOrphanedSeries()
+        database.withTransaction {
+            downloadDao.deleteDownloadById(entity.id)
+            offlineMediaDao.deleteById(entity.mediaItemId)
+            offlineMediaDao.deleteOrphanedSeasons()
+            offlineMediaDao.deleteOrphanedSeries()
+        }
     }
 
     private fun DownloadEntity.toDownloadItem() = DownloadItem(

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepository.kt
@@ -97,7 +97,12 @@ interface MediaRepository {
     suspend fun getFavorites(
         mediaTypes: List<MediaType>? = null,
         limit: Int = 50,
+        startIndex: Int = 0,
     ): Result<SearchResult>
+
+    fun getFavoritesPaged(
+        mediaTypes: List<MediaType>? = null,
+    ): Flow<PagingData<MediaItem>>
 
     suspend fun getLyrics(itemId: String): Result<LyricsResult>
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepository.kt
@@ -199,4 +199,6 @@ interface MediaRepository {
     suspend fun cancelTimer(timerId: String): Result<Unit>
 
     suspend fun getNewsletterData(sinceDate: String, limit: Int = 20): Result<NewsletterData>
+
+    suspend fun cleanupLyricsCache()
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
@@ -56,11 +56,35 @@ class MediaRepositoryImpl @Inject constructor(
                 size > DETAIL_CACHE_MAX_ENTRIES
         }
 
+    fun invalidateDetailCache(itemId: String? = null) {
+        if (itemId != null) {
+            detailCache.remove(itemId)
+        } else {
+            detailCache.clear()
+        }
+    }
+
+    private data class CachedHomeSections(val sections: List<HomeSection>, val fetchedAt: Long)
+    @Volatile
+    private var cachedHomeSections: CachedHomeSections? = null
+    private val homeSectionsLock = Any()
+
     override suspend fun getHomeSections(
         enabledSections: Set<HomeSectionType>,
         hiddenLibraryIds: Set<String>,
-    ): Result<List<HomeSection>> =
-        apiClient.getHomeSections(enabledSections, hiddenLibraryIds)
+    ): Result<List<HomeSection>> {
+        val cached = cachedHomeSections
+        if (cached != null && android.os.SystemClock.elapsedRealtime() - cached.fetchedAt < HOME_SECTIONS_CACHE_TTL_MS) {
+            return Result.success(cached.sections)
+        }
+        return apiClient.getHomeSections(enabledSections, hiddenLibraryIds).also { result ->
+            result.getOrNull()?.let { sections ->
+                synchronized(homeSectionsLock) {
+                    cachedHomeSections = CachedHomeSections(sections, android.os.SystemClock.elapsedRealtime())
+                }
+            }
+        }
+    }
 
     override suspend fun getLibraryFolders(): Result<List<LibraryFolder>> =
         apiClient.getLibraryFolders()
@@ -439,14 +463,23 @@ class MediaRepositoryImpl @Inject constructor(
     override suspend fun syncPlayMovePlaylistItem(playlistItemId: String, newIndex: Int): Result<Unit> =
         apiClient.syncPlayMovePlaylistItem(playlistItemId, newIndex)
 
-    override suspend fun toggleFavorite(itemId: String): Result<Boolean> =
-        apiClient.toggleFavorite(itemId)
+    override suspend fun toggleFavorite(itemId: String): Result<Boolean> {
+        cachedHomeSections = null
+        invalidateDetailCache(itemId)
+        return apiClient.toggleFavorite(itemId)
+    }
 
-    override suspend fun markPlayed(itemId: String): Result<Unit> =
-        apiClient.markPlayed(itemId)
+    override suspend fun markPlayed(itemId: String): Result<Unit> {
+        cachedHomeSections = null
+        invalidateDetailCache(itemId)
+        return apiClient.markPlayed(itemId)
+    }
 
-    override suspend fun markUnplayed(itemId: String): Result<Unit> =
-        apiClient.markUnplayed(itemId)
+    override suspend fun markUnplayed(itemId: String): Result<Unit> {
+        cachedHomeSections = null
+        invalidateDetailCache(itemId)
+        return apiClient.markUnplayed(itemId)
+    }
 
     override suspend fun getLiveTvChannels(startIndex: Int, limit: Int): Result<List<LiveTvChannel>> =
         apiClient.getLiveTvChannels(startIndex, limit)
@@ -499,6 +532,13 @@ class MediaRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun cleanupLyricsCache() {
+        try {
+            lyricsCacheDao.deleteOlderThan(System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000)
+        } catch (_: Exception) {
+        }
+    }
+
     override suspend fun getNewsletterData(sinceDate: String, limit: Int): Result<NewsletterData> =
         apiClient.getNewsletterData(sinceDate, limit)
 
@@ -508,6 +548,8 @@ class MediaRepositoryImpl @Inject constructor(
         private const val DETAIL_CACHE_MAX_ENTRIES = 30
         /** 2 minutes — short enough that server changes are reflected quickly. */
         private const val DETAIL_CACHE_TTL_MS = 2 * 60 * 1000L
+        /** 60 seconds — prevents burst API calls on repeated home screen loads. */
+        private const val HOME_SECTIONS_CACHE_TTL_MS = 60 * 1000L
         private val TIME_REGEX = Regex("""\[(\d{1,2}):(\d{2}\.\d{2,3})]""")
 
         private fun parseLrc(lrcContent: String): List<LyricsLine> {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.raulshma.jellyplay.core.database.dao.LyricsCacheDao
 import com.raulshma.jellyplay.core.database.entity.LyricsCacheEntity
+import com.raulshma.jellyplay.core.data.paging.FavoritesPagingSource
 import com.raulshma.jellyplay.core.data.paging.MediaPagingSource
 import com.raulshma.jellyplay.core.data.paging.SearchPagingSource
 import com.raulshma.jellyplay.core.model.DvrSeriesTimer
@@ -183,7 +184,24 @@ class MediaRepositoryImpl @Inject constructor(
     override suspend fun getFavorites(
         mediaTypes: List<MediaType>?,
         limit: Int,
-    ): Result<SearchResult> = apiClient.getFavorites(mediaTypes, limit)
+        startIndex: Int,
+    ): Result<SearchResult> = apiClient.getFavorites(mediaTypes, limit, startIndex)
+
+    override fun getFavoritesPaged(
+        mediaTypes: List<MediaType>?,
+    ): Flow<PagingData<MediaItem>> = Pager(
+        config = PagingConfig(
+            pageSize = PAGE_SIZE,
+            enablePlaceholders = false,
+            prefetchDistance = PREFETCH_DISTANCE,
+        ),
+        pagingSourceFactory = {
+            FavoritesPagingSource(
+                mediaRepository = this,
+                mediaTypes = mediaTypes,
+            )
+        },
+    ).flow
 
     override suspend fun getLyrics(itemId: String): Result<LyricsResult> = apiClient.getLyrics(itemId)
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/OfflineRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/OfflineRepositoryImpl.kt
@@ -1,39 +1,49 @@
 package com.raulshma.jellyplay.core.data.repository
 
+import androidx.room.withTransaction
+import com.raulshma.jellyplay.core.database.JellyPlayDatabase
 import com.raulshma.jellyplay.core.database.dao.DownloadDao
 import com.raulshma.jellyplay.core.database.dao.OfflineMediaDao
 import com.raulshma.jellyplay.core.database.entity.OfflineMediaEntity
 import com.raulshma.jellyplay.core.model.DownloadStatus
 import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.model.OfflineMediaItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
 class OfflineRepositoryImpl @Inject constructor(
     private val offlineMediaDao: OfflineMediaDao,
     private val downloadDao: DownloadDao,
+    private val database: JellyPlayDatabase,
 ) : OfflineRepository {
 
     override fun getOfflineLibrary(): Flow<List<OfflineMediaItem>> =
-        combine(
-            offlineMediaDao.getTopLevelItems(),
-            downloadDao.getAllDownloads().conflate(),
-        ) { entities, downloads ->
-            val downloadMap = downloads.associateBy { it.mediaItemId }
-            entities.map { entity ->
-                val download = downloadMap[entity.id]
-                entity.toOfflineMediaItem().copy(
-                    downloadPath = download?.downloadPath,
-                    downloadStatus = download?.status?.let { safeDownloadStatusOf(it) },
-                    downloadedBytes = download?.downloadedBytes ?: 0L,
-                    totalSizeBytes = download?.totalSizeBytes ?: 0L,
-                )
+        offlineMediaDao.getTopLevelItems().flatMapLatest { entities ->
+            if (entities.isEmpty()) {
+                kotlinx.coroutines.flow.flowOf(emptyList())
+            } else {
+                downloadDao.getDownloadsByMediaItemIdsFlow(entities.map { it.id })
+                    .map { downloads ->
+                        val downloadMap = downloads.associateBy { it.mediaItemId }
+                        entities.map { entity ->
+                            val download = downloadMap[entity.id]
+                            entity.toOfflineMediaItem().copy(
+                                downloadPath = download?.downloadPath,
+                                downloadStatus = download?.status?.let { safeDownloadStatusOf(it) },
+                                downloadedBytes = download?.downloadedBytes ?: 0L,
+                                totalSizeBytes = download?.totalSizeBytes ?: 0L,
+                            )
+                        }
+                    }
             }
         }.distinctUntilChanged()
 
@@ -66,18 +76,21 @@ class OfflineRepositoryImpl @Inject constructor(
         offlineMediaDao.getOfflineItemCount()
 
     override suspend fun deleteOfflineItem(id: String) {
-        downloadDao.getDownloadByMediaItemId(id)?.let { download ->
-            if (download.downloadPath.isNotBlank()) {
-                val file = java.io.File(download.downloadPath)
+        val download = downloadDao.getDownloadByMediaItemId(id)
+        download?.let {
+            if (it.downloadPath.isNotBlank()) {
+                val file = java.io.File(it.downloadPath)
                 if (file.exists()) file.delete()
                 file.parentFile?.let { parent ->
                     val trickplayDir = java.io.File(parent, "trickplay")
                     if (trickplayDir.exists()) trickplayDir.deleteRecursively()
                 }
             }
-            downloadDao.deleteDownloadById(download.id)
         }
-        offlineMediaDao.deleteById(id)
+        database.withTransaction {
+            download?.let { downloadDao.deleteDownloadById(it.id) }
+            offlineMediaDao.deleteById(id)
+        }
         cleanupOrphans()
     }
 
@@ -93,10 +106,11 @@ class OfflineRepositoryImpl @Inject constructor(
                 }
             }
         }
-        // Batch-delete all download records in a single SQL statement.
-        val ids = downloads.map { it.id }
-        if (ids.isNotEmpty()) downloadDao.deleteDownloadsByIds(ids)
-        offlineMediaDao.deleteBySeriesId(seriesId)
+        database.withTransaction {
+            val ids = downloads.map { it.id }
+            if (ids.isNotEmpty()) downloadDao.deleteDownloadsByIds(ids)
+            offlineMediaDao.deleteBySeriesId(seriesId)
+        }
         cleanupOrphans()
     }
 
@@ -112,10 +126,11 @@ class OfflineRepositoryImpl @Inject constructor(
                 }
             }
         }
-        // Batch-delete all download records in a single SQL statement.
-        val ids = downloads.map { it.id }
-        if (ids.isNotEmpty()) downloadDao.deleteDownloadsByIds(ids)
-        offlineMediaDao.deleteBySeasonId(seasonId)
+        database.withTransaction {
+            val ids = downloads.map { it.id }
+            if (ids.isNotEmpty()) downloadDao.deleteDownloadsByIds(ids)
+            offlineMediaDao.deleteBySeasonId(seasonId)
+        }
         cleanupOrphans()
     }
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/streaming/AdaptiveBitrateSelector.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/streaming/AdaptiveBitrateSelector.kt
@@ -2,27 +2,22 @@ package com.raulshma.jellyplay.core.data.streaming
 
 import com.raulshma.jellyplay.core.model.AudioBitrateTier
 import com.raulshma.jellyplay.core.model.StreamingQuality
+import com.raulshma.jellyplay.core.network.interceptor.BandwidthInterceptor
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/**
- * Picks an audio bitrate tier based on measured bandwidth and the user's
- * [StreamingQuality] selection. When the user chooses [StreamingQuality.AUTO],
- * the selector picks the best tier that comfortably fits the available
- * bandwidth, leaving a 1.5x headroom for stability.
- *
- * Bitrate tiers are conservative for audio since tracks typically range from
- * 96 kbps (low) to 320 kbps (high); lossless tracks require ~1 Mbps.
- */
 @Singleton
 class AdaptiveBitrateSelector @Inject constructor(
     private val bandwidthMonitor: BandwidthMonitor,
+    private val bandwidthInterceptor: BandwidthInterceptor,
 ) {
-    val bandwidthKbps: StateFlow<Double> = bandwidthMonitor.estimatedBandwidthKbps
+    val bandwidthKbps: StateFlow<Double> = bandwidthInterceptor.estimatedBandwidthKbps
 
     fun selectTier(maxAllowed: AudioBitrateTier = AudioBitrateTier.LOSSLESS): AudioBitrateTier {
-        val availableKbps = bandwidthMonitor.estimatedBandwidthKbps.value
+        val networkKbps = bandwidthInterceptor.estimatedBandwidthKbps.value
+        val localKbps = bandwidthMonitor.estimatedBandwidthKbps.value
+        val availableKbps = maxOf(networkKbps, localKbps)
         if (availableKbps <= 0.0) {
             return AudioBitrateTier.LOW
         }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/streaming/BandwidthMonitor.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/streaming/BandwidthMonitor.kt
@@ -32,7 +32,9 @@ class BandwidthMonitor @Inject constructor() {
         synchronized(samples) {
             samples.addLast(BandwidthSample(bytesTransferred, elapsedMs))
             while (samples.size > maxSamples) {
-                samples.removeFirst()
+                val removed = samples.removeFirst()
+                _totalBytes.value = (_totalBytes.value - removed.bytes).coerceAtLeast(0L)
+                _totalElapsedMs.value = (_totalElapsedMs.value - removed.elapsedMs).coerceAtLeast(0L)
             }
         }
         _totalBytes.value = _totalBytes.value + bytesTransferred

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/JellyfinWebSocketClient.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/JellyfinWebSocketClient.kt
@@ -41,6 +41,7 @@ class JellyfinWebSocketClient @Inject constructor(
     private var clientName: String? = null
     private val reconnectAttempts = AtomicInteger(0)
     private val maxReconnectAttempts = 5
+    private var backgroundRetryJob: kotlinx.coroutines.Job? = null
 
     private val _isConnected = kotlinx.coroutines.flow.MutableStateFlow(false)
     val isConnected: kotlinx.coroutines.flow.StateFlow<Boolean> = _isConnected
@@ -105,7 +106,19 @@ class JellyfinWebSocketClient @Inject constructor(
     private fun scheduleReconnect() {
         val attempts = reconnectAttempts.incrementAndGet()
         if (attempts > maxReconnectAttempts) {
-            Log.w(TAG, "Max reconnect attempts ($maxReconnectAttempts) reached, giving up")
+            Log.w(TAG, "Max reconnect attempts ($maxReconnectAttempts) reached, scheduling slow background retry")
+            backgroundRetryJob?.cancel()
+            backgroundRetryJob = scope.launch {
+                while (serverUrl != null && token != null) {
+                    delay(60_000L)
+                    if (serverUrl != null && token != null) {
+                        Log.d(TAG, "Background WebSocket retry")
+                        reconnectAttempts.set(0)
+                        connectInternal()
+                        return@launch
+                    }
+                }
+            }
             return
         }
         val delayMs = (1000L * (1L shl (attempts - 1).coerceAtMost(4)) + (0..1000L).random()).coerceAtMost(30_000L)
@@ -122,6 +135,7 @@ class JellyfinWebSocketClient @Inject constructor(
         serverUrl = null
         token = null
         deviceId = null
+        backgroundRetryJob?.cancel()
         reconnectAttempts.set(maxReconnectAttempts + 1)
         _isConnected.value = false
         webSocket?.close(1000, "Client disconnecting")

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/SyncPlayManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/SyncPlayManager.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -72,8 +73,11 @@ class SyncPlayManager @Inject constructor(
         keepAliveJob?.cancel()
         keepAliveJob = scope.launch {
             while (true) {
-                delay(30_000)
-                webSocketClient.sendKeepAlive()
+                delay(60_000)
+                try {
+                    webSocketClient.sendKeepAlive()
+                } catch (_: Exception) {
+                }
             }
         }
     }
@@ -265,16 +269,18 @@ class SyncPlayManager @Inject constructor(
     private fun startPingReporting() {
         pingReportJob?.cancel()
         pingReportJob = scope.launch {
-            timeSyncManager.pingUpdated.collect {
-                if (isInSyncPlaySession) {
-                    try {
-                        val ping = timeSyncManager.getPingMs()
-                        apiClient.syncPlayPing(ping)
-                    } catch (e: Exception) {
-                        Log.w(TAG, "Failed to report ping", e)
+            timeSyncManager.pingUpdated
+                .sample(PING_REPORT_INTERVAL_MS)
+                .collect {
+                    if (isInSyncPlaySession) {
+                        try {
+                            val ping = timeSyncManager.getPingMs()
+                            apiClient.syncPlayPing(ping)
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Failed to report ping", e)
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -329,5 +335,6 @@ class SyncPlayManager @Inject constructor(
     companion object {
         private const val TAG = "SyncPlayManager"
         private const val STALE_SKEW_ALLOWANCE_MS = 1500L
+        private const val PING_REPORT_INTERVAL_MS = 10_000L
     }
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/SyncPlayPlaybackCore.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/SyncPlayPlaybackCore.kt
@@ -344,7 +344,12 @@ class SyncPlayPlaybackCore @Inject constructor(
     }
 
     private fun isSyncCorrectionWarranted(): Boolean {
-        return true
+        val cb = callbacks ?: return false
+        val lastReported = lastPlayCommandTimeMs
+        val latest = cb.currentPositionMs()
+        val delta = kotlin.math.abs(lastReported - latest).toDouble()
+        val drift = delta
+        return drift >= SYNC_CORRECTION_THRESHOLD_MS
     }
 
     private fun scheduleEnableSync() {
@@ -420,7 +425,8 @@ class SyncPlayPlaybackCore @Inject constructor(
         private const val MIN_DELAY_SKIP_TO_SYNC = 400.0
         private const val ENABLE_SYNC_TIMEOUT = 1500L
         private const val SYNC_CORRECTION_INITIAL_DELAY = 500L
-        private const val SYNC_CORRECTION_INTERVAL = 1000L
+        private const val SYNC_CORRECTION_INTERVAL = 2000L
+        private const val SYNC_CORRECTION_THRESHOLD_MS = 100L
         private const val MIN_SPEED = 0.2
     }
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/TimeSyncManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/syncplay/TimeSyncManager.kt
@@ -52,7 +52,7 @@ class TimeSyncManager @Inject constructor(
             }
             _pingUpdated.tryEmit(Unit)
             while (isSyncing.get()) {
-                delay(60_000)
+                delay(120_000)
                 sync()
                 _pingUpdated.tryEmit(Unit)
             }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/work/StaleMediaScanWorker.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/work/StaleMediaScanWorker.kt
@@ -10,6 +10,7 @@ import com.raulshma.jellyplay.core.model.ScanPhase
 import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 
 @HiltWorker
@@ -29,11 +30,13 @@ class StaleMediaScanWorker @AssistedInject constructor(
         return try {
             val config = json.decodeFromString<MediaCleanupConfig>(entity.configJson)
             val batchSize = 200
+            val maxItems = 10_000
             var startIndex = 0
             val allItems = mutableListOf<com.raulshma.jellyplay.core.model.StaleMediaItem>()
             var hasMore = true
 
             while (hasMore) {
+                if (isStopped) break
                 val result = apiClient.getStaleItems(
                     daysThreshold = config.daysThreshold,
                     includeNeverPlayed = config.includeNeverPlayed,
@@ -45,7 +48,9 @@ class StaleMediaScanWorker @AssistedInject constructor(
 
                 allItems.addAll(result.second)
                 startIndex += batchSize
-                hasMore = result.second.size >= batchSize
+                hasMore = result.second.size >= batchSize && allItems.size < maxItems
+
+                if (hasMore) delay(500)
 
                 scanStateDao.update(
                     entity.copy(

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/work/WatchedMediaScanWorker.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/work/WatchedMediaScanWorker.kt
@@ -11,6 +11,7 @@ import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.Json
 
 @HiltWorker
@@ -33,11 +34,13 @@ class WatchedMediaScanWorker @AssistedInject constructor(
             val adminUserId = user?.id ?: return Result.failure()
 
             val batchSize = 200
+            val maxItems = 10_000
             var startIndex = 0
             val allItems = mutableListOf<com.raulshma.jellyplay.core.model.WatchedMediaItem>()
             var hasMore = true
 
             while (hasMore) {
+                if (isStopped) break
                 val result = apiClient.getWatchedItems(
                     userId = adminUserId,
                     includeItemTypes = config.includeItemTypes.toList(),
@@ -50,7 +53,9 @@ class WatchedMediaScanWorker @AssistedInject constructor(
 
                 allItems.addAll(result.second)
                 startIndex += batchSize
-                hasMore = result.second.size >= batchSize
+                hasMore = result.second.size >= batchSize && allItems.size < maxItems
+
+                if (hasMore) delay(500)
 
                 scanStateDao.update(
                     entity.copy(

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation(project(":core:model"))
 
     implementation(libs.room.runtime)
-    implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
     implementation(libs.hilt.android)

--- a/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/17.json
+++ b/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/17.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 16,
+    "version": 17,
     "identityHash": "1a8a016aea0dc3c37d2fe72eb1f4a509",
     "entities": [
       {

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/Converters.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/Converters.kt
@@ -7,36 +7,40 @@ object Converters {
 
     @TypeConverter
     @JvmStatic
-    fun fromStringList(value: List<String>?): String? {
-        if (value == null) return null
-        val array = JSONArray()
-        value.forEach { array.put(it) }
-        return array.toString()
-    }
+    fun fromStringList(value: List<String>?): String? = value?.joinToString(",")
 
     @TypeConverter
     @JvmStatic
     fun toStringList(value: String?): List<String>? {
-        if (value == null) return null
-        val array = JSONArray(value)
-        return (0 until array.length()).map { array.getString(it) }
+        if (value.isNullOrEmpty()) return null
+        val trimmed = value.trim()
+        return if (trimmed.startsWith("[")) {
+            runCatching {
+                val array = JSONArray(trimmed)
+                (0 until array.length()).map { array.getString(it) }
+            }.getOrNull()
+        } else {
+            trimmed.split(",").filter { it.isNotEmpty() }
+        }
     }
 
     @TypeConverter
     @JvmStatic
-    fun fromIntList(value: List<Int>?): String? {
-        if (value == null) return null
-        val array = JSONArray()
-        value.forEach { array.put(it) }
-        return array.toString()
-    }
+    fun fromIntList(value: List<Int>?): String? = value?.joinToString(",")
 
     @TypeConverter
     @JvmStatic
     fun toIntList(value: String?): List<Int>? {
-        if (value == null) return null
-        val array = JSONArray(value)
-        return (0 until array.length()).map { array.getInt(it) }
+        if (value.isNullOrEmpty()) return null
+        val trimmed = value.trim()
+        return if (trimmed.startsWith("[")) {
+            runCatching {
+                val array = JSONArray(trimmed)
+                (0 until array.length()).map { array.getInt(it) }
+            }.getOrNull()
+        } else {
+            trimmed.split(",").mapNotNull { it.toIntOrNull() }
+        }
     }
 
     @TypeConverter

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
@@ -41,7 +41,7 @@ import com.raulshma.jellyplay.core.database.entity.UserEntity
         AudioQueueEntity::class,
         AudioQueueStateEntity::class,
     ],
-    version = 16,
+    version = 17,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/AuditLogDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/AuditLogDao.kt
@@ -13,7 +13,7 @@ interface AuditLogDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(entry: MediaAuditLogEntity)
 
-    @Query("SELECT * FROM media_audit_log ORDER BY timestamp DESC")
+    @Query("SELECT * FROM media_audit_log ORDER BY timestamp DESC LIMIT 500")
     fun getAll(): Flow<List<MediaAuditLogEntity>>
 
     @Query("SELECT * FROM media_audit_log WHERE actionType = :actionType ORDER BY timestamp DESC")

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface DownloadDao {
 
-    @Query("SELECT * FROM downloads ORDER BY createdAt DESC")
-    fun getAllDownloads(): Flow<List<DownloadEntity>>
+    @Query("SELECT * FROM downloads ORDER BY createdAt DESC LIMIT :limit")
+    fun getAllDownloads(limit: Int = 500): Flow<List<DownloadEntity>>
 
     @Query("SELECT * FROM downloads WHERE id = :id")
     suspend fun getDownloadById(id: String): DownloadEntity?
@@ -73,8 +73,11 @@ interface DownloadDao {
     suspend fun getDownloadsForSeason(seasonId: String): List<DownloadEntity>
 
     @Query("SELECT * FROM downloads WHERE mediaItemId IN (:mediaItemIds)")
-    suspend fun getDownloadsByMediaItemIds(mediaItemIds: List<String>): List<DownloadEntity>
-
-    @Query("SELECT * FROM downloads WHERE mediaItemId IN (:mediaItemIds)")
     fun getDownloadsByMediaItemIdsFlow(mediaItemIds: List<String>): Flow<List<DownloadEntity>>
+
+    @Query("UPDATE downloads SET status = 'PENDING' WHERE status IN ('DOWNLOADING') AND id IN (SELECT id FROM downloads WHERE status = 'DOWNLOADING')")
+    suspend fun resetStuckDownloading()
+
+    @Query("SELECT * FROM downloads WHERE status = 'FAILED'")
+    suspend fun getFailedDownloads(): List<DownloadEntity>
 }

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/Entities.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/Entities.kt
@@ -5,7 +5,10 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "servers")
+@Entity(
+    tableName = "servers",
+    indices = [Index(value = ["address"], unique = true)],
+)
 data class ServerEntity(
     @PrimaryKey val id: String,
     val name: String,

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
@@ -60,6 +60,11 @@ val MIGRATION_4_5 = object : Migration(4, 5) {
     }
 }
 
+// MIGRATION_5_6 through MIGRATION_8_9: no-op version bumps added when
+// entities were touched but no schema change was required. The bumps
+// guarantee Room treats the database as up-to-date without rewriting
+// the migration history.
+
 val MIGRATION_5_6 = object : Migration(5, 6) {
     override fun migrate(db: SupportSQLiteDatabase) {
     }
@@ -305,6 +310,13 @@ val MIGRATION_15_16 = object : Migration(15, 16) {
             )
             """.trimIndent()
         )
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_servers_address ON servers(address)")
+    }
+}
+
+val MIGRATION_16_17 = object : Migration(16, 17) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_servers_address ON servers(address)")
     }
 }
 
@@ -324,4 +336,5 @@ val ALL_MIGRATIONS = listOf(
     MIGRATION_13_14,
     MIGRATION_14_15,
     MIGRATION_15_16,
+    MIGRATION_16_17,
 )

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/UserPreferencesStore.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/UserPreferencesStore.kt
@@ -941,4 +941,131 @@ class UserPreferencesStore @Inject constructor(
     suspend fun setColorStyle(style: ColorStyle) {
         context.dataStore.edit { it[Keys.COLOR_STYLE] = style.name }
     }
+
+    suspend fun restorePreferences(prefs: UserPreferences) {
+        val json = Json { encodeDefaults = true }
+        context.dataStore.edit { settings ->
+            settings[Keys.PREFERRED_PLAYER] = prefs.preferredPlayer.name
+            prefs.preferredSubtitleLanguage?.let { settings[Keys.PREFERRED_SUBTITLE_LANG] = it }
+            prefs.preferredAudioLanguage?.let { settings[Keys.PREFERRED_AUDIO_LANG] = it }
+            settings[Keys.MEDIA_STREAM_SELECTIONS] = json.encodeToString(
+                kotlinx.serialization.serializer<Map<String, com.raulshma.jellyplay.core.model.MediaStreamSelection>>(),
+                prefs.mediaStreamSelections,
+            )
+            settings[Keys.DYNAMIC_THEMING] = prefs.dynamicTheming
+            settings[Keys.THEME_MODE] = prefs.themeMode.name
+            settings[Keys.CONTRAST_LEVEL] = prefs.contrastLevel.name
+            settings[Keys.OLED_MODE] = prefs.oledMode
+            settings[Keys.SUBTITLE_STYLE] = json.encodeToString(
+                kotlinx.serialization.serializer<com.raulshma.jellyplay.core.model.SubtitleStyle>(),
+                prefs.subtitleStyle,
+            )
+            settings[Keys.STREAMING_QUALITY] = prefs.streamingQuality.name
+            settings[Keys.MAX_CACHE_SIZE_MB] = prefs.maxCacheSizeMb
+            settings[Keys.AUTO_DELETE_CACHE] = prefs.autoDeleteCache
+            settings[Keys.PIN_LOCK_ENABLED] = prefs.pinLockEnabled
+            prefs.pinHash?.let { settings[Keys.PIN_HASH] = it }
+            settings[Keys.BIOMETRIC_LOCK_ENABLED] = prefs.biometricLockEnabled
+            settings[Keys.AUTO_LOCK_TIMER_MS] = prefs.autoLockTimerMs
+            settings[Keys.DIALOGUE_BOOST_ENABLED] = prefs.dialogueBoostEnabled
+            settings[Keys.DIALOGUE_BOOST_STRENGTH] = prefs.dialogueBoostStrength.name
+            settings[Keys.EQUALIZER_ENABLED] = prefs.equalizerEnabled
+            settings[Keys.EQUALIZER_SETTINGS] = json.encodeToString(
+                kotlinx.serialization.serializer<com.raulshma.jellyplay.core.model.EqualizerSettings>(),
+                prefs.equalizerSettings,
+            )
+            settings[Keys.AUDIO_DELAY_MS] = prefs.audioDelayMs
+            settings[Keys.DECODER_MODE] = prefs.decoderMode.name
+            settings[Keys.AUDIO_PASSTHROUGH] = prefs.audioPassthrough
+            settings[Keys.FRAME_RATE_MATCHING] = prefs.frameRateMatching
+            settings[Keys.NIGHT_MODE_ENABLED] = prefs.nightModeEnabled
+            settings[Keys.NIGHT_MODE_STRENGTH] = prefs.nightModeStrength.name
+            settings[Keys.HOME_MODE] = prefs.homeMode.name
+            settings[Keys.VIDEO_SEEK_DURATION_MS] = prefs.videoSeekDurationMs
+            settings[Keys.VIDEO_DEFAULT_ORIENTATION] = prefs.videoDefaultOrientation.name
+            settings[Keys.VIDEO_CONTROLS_TIMEOUT_MS] = prefs.videoControlsTimeoutMs
+            settings[Keys.VIDEO_GESTURES_ENABLED] = prefs.videoGesturesEnabled
+            settings[Keys.VIDEO_DEFAULT_SPEED] = prefs.videoDefaultSpeed
+            settings[Keys.VIDEO_DEFAULT_ASPECT_RATIO] = prefs.videoDefaultAspectRatio
+            settings[Keys.VIDEO_AUTOPLAY_NEXT] = prefs.videoAutoplayNext
+            settings[Keys.VIDEO_SWIPE_SEEK_MAX_MS] = prefs.videoSwipeSeekMaxMs
+            settings[Keys.VIDEO_REMEMBER_BRIGHTNESS] = prefs.videoRememberBrightness
+            settings[Keys.VIDEO_BRIGHTNESS_LEVEL] = prefs.videoBrightnessLevel
+            settings[Keys.AUDIO_DEFAULT_SPEED] = prefs.audioDefaultSpeed
+            settings[Keys.AUDIO_NIGHT_MODE_VOLUME] = prefs.audioNightModeVolume
+            settings[Keys.AUDIO_NIGHT_MODE_GAIN] = prefs.audioNightModeGain
+            settings[Keys.AUDIO_SKIP_PREVIOUS_THRESHOLD_MS] = prefs.audioSkipPreviousThresholdMs
+            settings[Keys.AUDIO_AUTOPLAY_NEXT] = prefs.audioAutoplayNext
+            settings[Keys.TRICKPLAY_ENABLED] = prefs.trickplayEnabled
+            settings[Keys.TRICKPLAY_ON_SEEK_GESTURE] = prefs.trickplayOnSeekGesture
+            settings[Keys.SEGMENT_BEHAVIORS] = json.encodeToString(
+                kotlinx.serialization.serializer<Map<com.raulshma.jellyplay.core.model.MediaSegmentType, com.raulshma.jellyplay.core.model.SegmentBehavior>>(),
+                prefs.segmentBehaviors,
+            )
+            settings[Keys.VIDEO_EPISODE_BROWSER_ENABLED] = prefs.videoEpisodeBrowserEnabled
+            settings[Keys.VIDEO_SHOW_PLAYBACK_METADATA] = prefs.videoShowPlaybackMetadata
+            settings[Keys.VIDEO_PRELOAD_BUFFER_SIZE] = prefs.videoPreloadBufferSize.name
+            settings[Keys.AUDIO_PRELOAD_BUFFER_SIZE] = prefs.audioPreloadBufferSize.name
+            settings[Keys.AUDIO_NORMALIZATION_MODE] = prefs.audioNormalizationMode.name
+            settings[Keys.AUDIO_NORMALIZATION_ENABLED] = prefs.audioNormalizationEnabled
+            settings[Keys.REPLAYGAIN_PRE_AMP_DB] = prefs.replayGainPreAmpDb
+            settings[Keys.CHANNEL_MIX_MODE] = prefs.channelMixMode.name
+            settings[Keys.CHANNEL_MIX_ENABLED] = prefs.channelMixEnabled
+            settings[Keys.AUDIO_GAPLESS_ENABLED] = prefs.audioGaplessEnabled
+            settings[Keys.AUDIO_CROSSFADE_DURATION_MS] = prefs.audioCrossfadeDurationMs
+            settings[Keys.SLEEP_TIMER_DURATION_MS] = prefs.sleepTimerDurationMs
+            settings[Keys.SLEEP_TIMER_END_OF_EPISODE] = prefs.sleepTimerEndOfEpisode
+            settings[Keys.DREAM_IMAGE_CATEGORIES] = json.encodeToString(
+                kotlinx.serialization.serializer<Set<com.raulshma.jellyplay.core.model.DreamImageCategory>>(),
+                prefs.dreamImageCategories,
+            )
+            settings[Keys.DREAM_SLIDESHOW_INTERVAL_MS] = prefs.dreamSlideshowIntervalMs
+            settings[Keys.DREAM_KEN_BURNS_ENABLED] = prefs.dreamKenBurnsEnabled
+            settings[Keys.DREAM_TRANSITION_STYLE] = prefs.dreamTransitionStyle.name
+            settings[Keys.DREAM_SHOW_TITLE] = prefs.dreamShowTitle
+            settings[Keys.EQUALIZER_PRESET] = prefs.equalizerPreset.name
+            settings[Keys.BASS_BOOST_ENABLED] = prefs.bassBoostEnabled
+            settings[Keys.BASS_BOOST_STRENGTH] = prefs.bassBoostStrength.name
+            settings[Keys.VIRTUALIZER_ENABLED] = prefs.virtualizerEnabled
+            settings[Keys.VIRTUALIZER_STRENGTH] = prefs.virtualizerStrength
+            settings[Keys.REVERB_PRESET] = prefs.reverbPreset.name
+            settings[Keys.LR_BALANCE] = prefs.lrBalance
+            settings[Keys.AUTO_EQ_BY_GENRE] = prefs.autoEqByGenre
+            settings[Keys.PITCH_SEMITONES] = prefs.pitchSemitones
+            settings[Keys.DOWNLOAD_CONNECTIONS] = prefs.downloadConnections
+            settings[Keys.HOME_ENABLED_SECTION_TYPES] = json.encodeToString(
+                kotlinx.serialization.serializer<Set<com.raulshma.jellyplay.core.model.HomeSectionType>>(),
+                prefs.enabledHomeSectionTypes,
+            )
+            settings[Keys.HOME_SECTION_ORDER] = json.encodeToString(
+                kotlinx.serialization.serializer<List<com.raulshma.jellyplay.core.model.HomeSectionType>>(),
+                prefs.homeSectionOrder,
+            )
+            settings[Keys.HOME_HIDDEN_LIBRARY_SECTION_IDS] = json.encodeToString(
+                kotlinx.serialization.serializer<Set<String>>(),
+                prefs.hiddenLibrarySectionIds,
+            )
+            settings[Keys.NAV_BAR_SHOW_LABELS] = prefs.navBarShowLabels
+            settings[Keys.HOME_HERO_ENABLED] = prefs.homeHeroEnabled
+            settings[Keys.ONBOARDING_COMPLETED] = prefs.onboardingCompleted
+            settings[Keys.MPV_CONFIG] = json.encodeToString(
+                kotlinx.serialization.serializer<com.raulshma.jellyplay.core.model.MpvEngineConfig>(),
+                prefs.mpvConfig,
+            )
+            settings[Keys.LIBVLC_CONFIG] = json.encodeToString(
+                kotlinx.serialization.serializer<com.raulshma.jellyplay.core.model.LibVlcEngineConfig>(),
+                prefs.libVlcConfig,
+            )
+            settings[Keys.EXO_CONFIG] = json.encodeToString(
+                kotlinx.serialization.serializer<com.raulshma.jellyplay.core.model.ExoPlayerEngineConfig>(),
+                prefs.exoPlayerConfig,
+            )
+            settings[Keys.PERFORMANCE_MODE] = prefs.performanceMode
+            settings[Keys.NEWSLETTER_ENABLED] = prefs.newsletterEnabled
+            settings[Keys.NEWSLETTER_DAY_OF_WEEK] = prefs.newsletterDayOfWeek
+            settings[Keys.NEWSLETTER_LAST_VIEWED_MS] = prefs.newsletterLastViewedMs
+            settings[Keys.ACCENT_COLOR_SWATCH] = prefs.accentColorSwatch
+            settings[Keys.COLOR_STYLE] = prefs.colorStyle.name
+        }
+    }
 }

--- a/core/designsystem/src/main/java/com/raulshma/jellyplay/core/designsystem/theme/ArtworkColorExtractor.kt
+++ b/core/designsystem/src/main/java/com/raulshma/jellyplay/core/designsystem/theme/ArtworkColorExtractor.kt
@@ -4,10 +4,12 @@ import android.graphics.Bitmap
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import androidx.palette.graphics.Palette
 
+@Immutable
 data class ArtworkColors(
     val vibrant: Color?,
     val darkVibrant: Color?,
@@ -17,63 +19,51 @@ data class ArtworkColors(
     val lightMuted: Color?,
     val dominant: Color?,
 ) {
-    /**
-     * Deep muted background tint derived from artwork — matches Pixel Player's
-     * solid-color player background style.
-     */
-    val tintedBackground: Color
-        get() {
-            val base = darkMuted ?: muted ?: dominant ?: Color(0xFF2D1F2D)
-            // Darken and desaturate to get a deep, muted plum tone
-            return base.copy(alpha = 1f).let { c ->
-                Color(
-                    red = (c.red * 0.45f).coerceIn(0f, 1f),
-                    green = (c.green * 0.35f).coerceIn(0f, 1f),
-                    blue = (c.blue * 0.45f).coerceIn(0f, 1f),
-                    alpha = 1f,
-                )
-            }
+    val tintedBackground: Color = run {
+        val base = darkMuted ?: muted ?: dominant ?: Color(0xFF2D1F2D)
+        base.copy(alpha = 1f).let { c ->
+            Color(
+                red = (c.red * 0.45f).coerceIn(0f, 1f),
+                green = (c.green * 0.35f).coerceIn(0f, 1f),
+                blue = (c.blue * 0.45f).coerceIn(0f, 1f),
+                alpha = 1f,
+            )
         }
+    }
 
-    /** Lighter variant of tintedBackground for gradient top edge. */
-    val tintedBackgroundLight: Color
-        get() {
-            val base = muted ?: darkMuted ?: dominant ?: Color(0xFF3D2F3D)
-            return base.copy(alpha = 1f).let { c ->
-                Color(
-                    red = (c.red * 0.55f + 0.08f).coerceIn(0f, 1f),
-                    green = (c.green * 0.45f + 0.05f).coerceIn(0f, 1f),
-                    blue = (c.blue * 0.55f + 0.08f).coerceIn(0f, 1f),
-                    alpha = 1f,
-                )
-            }
+    val tintedBackgroundLight: Color = run {
+        val base = muted ?: darkMuted ?: dominant ?: Color(0xFF3D2F3D)
+        base.copy(alpha = 1f).let { c ->
+            Color(
+                red = (c.red * 0.55f + 0.08f).coerceIn(0f, 1f),
+                green = (c.green * 0.45f + 0.05f).coerceIn(0f, 1f),
+                blue = (c.blue * 0.55f + 0.08f).coerceIn(0f, 1f),
+                alpha = 1f,
+            )
         }
+    }
 
-    /** Accent color for seek bar, active controls — a soft pink/vibrant from the artwork. */
-    val accentColor: Color
-        get() = lightVibrant ?: vibrant ?: lightMuted ?: Color(0xFFE8B4C8)
+    val accentColor: Color = lightVibrant ?: vibrant ?: lightMuted ?: Color(0xFFE8B4C8)
 
-    /** Semi-transparent surface for pill-shaped control containers. */
-    val pillSurface: Color
-        get() {
-            val base = darkMuted ?: muted ?: dominant ?: Color(0xFF3A2A3A)
-            return base.copy(alpha = 0.55f)
-        }
+    val pillSurface: Color = run {
+        val base = darkMuted ?: muted ?: dominant ?: Color(0xFF3A2A3A)
+        base.copy(alpha = 0.55f)
+    }
 
-    /** Darker pill surface for the secondary controls row. */
-    val pillSurfaceDark: Color
-        get() {
-            val base = darkMuted ?: dominant ?: Color(0xFF2A1A2A)
-            return base.copy(alpha = 0.7f)
-        }
+    val pillSurfaceDark: Color = run {
+        val base = darkMuted ?: dominant ?: Color(0xFF2A1A2A)
+        base.copy(alpha = 0.7f)
+    }
 }
 
 object ArtworkColorExtractor {
 
     fun extractColors(bitmap: Bitmap): ArtworkColors {
-        val palette = Palette.from(bitmap)
+        val scaled = scaleForPalette(bitmap)
+        val palette = Palette.from(scaled)
             .maximumColorCount(8)
             .generate()
+        if (scaled !== bitmap) scaled.recycle()
 
         return ArtworkColors(
             vibrant = palette.vibrantSwatch?.toComposeColor(),
@@ -118,4 +108,13 @@ object ArtworkColorExtractor {
     }
 
     private fun Palette.Swatch.toComposeColor(): Color = Color(rgb)
+
+    private fun scaleForPalette(bitmap: Bitmap): Bitmap {
+        val maxDim = 128
+        if (bitmap.width <= maxDim && bitmap.height <= maxDim) return bitmap
+        val scale = maxDim.toFloat() / maxOf(bitmap.width, bitmap.height)
+        val w = (bitmap.width * scale).toInt().coerceAtLeast(1)
+        val h = (bitmap.height * scale).toInt().coerceAtLeast(1)
+        return Bitmap.createScaledBitmap(bitmap, w, h, true)
+    }
 }

--- a/core/designsystem/src/main/java/com/raulshma/jellyplay/core/designsystem/theme/ShapeCache.kt
+++ b/core/designsystem/src/main/java/com/raulshma/jellyplay/core/designsystem/theme/ShapeCache.kt
@@ -71,9 +71,12 @@ fun expressiveListShape(
     outerRadius: androidx.compose.ui.unit.Dp = 22.dp,
     innerRadius: androidx.compose.ui.unit.Dp = 8.dp,
 ): AbsoluteSmoothCornerShape {
+    val key = "${index}_${count}_${outerRadius.value}_${innerRadius.value}"
+    expressiveListShapeCache[key]?.let { return it }
+
     val outer = outerRadius
     val inner = innerRadius
-    return when {
+    val shape = when {
         count <= 1 -> AbsoluteSmoothCornerShape(outer, 60)
         index == 0 -> AbsoluteSmoothCornerShape(
             cornerRadiusTL = outer,
@@ -97,4 +100,8 @@ fun expressiveListShape(
         )
         else -> AbsoluteSmoothCornerShape(inner, 60)
     }
+    expressiveListShapeCache.put(key, shape)
+    return shape
 }
+
+private val expressiveListShapeCache = android.util.LruCache<String, AbsoluteSmoothCornerShape>(128)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -24,10 +24,12 @@ dependencies {
 
     implementation(libs.jellyfin.core)
     implementation(libs.hilt.android)
-    ksp(libs.hilt.android.compiler)
+    implementation(libs.androidx.collection.ktx)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
-    
+
+    ksp(libs.hilt.android.compiler)
+
     // SLF4J - required by Jellyfin SDK
     implementation(libs.slf4j.api)
     runtimeOnly(libs.slf4j.nop)

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClient.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClient.kt
@@ -78,6 +78,7 @@ interface LibraryApiClient {
     suspend fun getFavorites(
         mediaTypes: List<MediaType>? = null,
         limit: Int = 50,
+        startIndex: Int = 0,
     ): Result<SearchResult>
 
     suspend fun getLyrics(itemId: String): Result<LyricsResult>

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClientImpl.kt
@@ -31,6 +31,7 @@ import org.jellyfin.sdk.api.client.HttpMethod
 import org.jellyfin.sdk.api.client.extensions.*
 import javax.inject.Inject
 import javax.inject.Singleton
+import java.util.UUID
 
 @Singleton
 class LibraryApiClientImpl @Inject constructor(
@@ -708,21 +709,30 @@ class LibraryApiClientImpl @Inject constructor(
 
     override suspend fun toggleFavorite(itemId: String, currentIsFavorite: Boolean?): Result<Boolean> = engine.apiResult {
         val uuid = itemId.toUUID()
-        val isFavorite = currentIsFavorite ?: engine.requireApi().userLibraryApi.getItem(itemId = uuid).content.userData?.isFavorite == true
+        val cached = favoriteCache[uuid]
+        val isFavorite = currentIsFavorite ?: cached ?: run {
+            val fetched = engine.requireApi().userLibraryApi.getItem(itemId = uuid).content.userData?.isFavorite == true
+            favoriteCache.put(uuid, fetched)
+            fetched
+        }
         if (isFavorite) {
             engine.requireApi().userLibraryApi.unmarkFavoriteItem(
                 userId = engine._currentUser.value?.id!!.toUUID(),
                 itemId = uuid,
             )
+            favoriteCache.put(uuid, false)
             false
         } else {
             engine.requireApi().userLibraryApi.markFavoriteItem(
                 userId = engine._currentUser.value?.id!!.toUUID(),
                 itemId = uuid,
             )
+            favoriteCache.put(uuid, true)
             true
         }
     }
+
+    private val favoriteCache = androidx.collection.LruCache<UUID, Boolean>(200)
 
     override fun getImageUrl(itemId: String, imageType: String, maxWidth: Int?, imageIndex: Int?, tag: String?): String {
         val server = engine._currentServer.value ?: return ""

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClientImpl.kt
@@ -531,11 +531,13 @@ class LibraryApiClientImpl @Inject constructor(
     override suspend fun getFavorites(
         mediaTypes: List<MediaType>?,
         limit: Int,
+        startIndex: Int,
     ): Result<SearchResult> = engine.apiResult {
         val response = engine.requireApi().itemsApi.getItems(
             includeItemTypes = mediaTypes?.mapNotNull { it.toBaseItemKind() },
             filters = listOf(ItemFilter.IS_FAVORITE),
             limit = limit,
+            startIndex = startIndex,
             recursive = true,
             fields = listOf(
                 ItemFields.OVERVIEW,
@@ -545,7 +547,7 @@ class LibraryApiClientImpl @Inject constructor(
         SearchResult(
             items = engine.run { response.items.map { it.toMediaItem() }.filterByParentalRating() },
             totalRecordCount = response.totalRecordCount,
-            startIndex = 0,
+            startIndex = startIndex,
         )
     }
 

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
@@ -22,6 +22,7 @@ import com.raulshma.jellyplay.core.network.api.SyncPlayApiClient
 import com.raulshma.jellyplay.core.network.api.SyncPlayApiClientImpl
 import com.raulshma.jellyplay.core.network.seerr.ResilientSeerrApiClient
 import com.raulshma.jellyplay.core.network.seerr.SeerrApiClient
+import com.raulshma.jellyplay.core.network.interceptor.BandwidthInterceptor
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -113,6 +114,7 @@ abstract class NetworkModule {
         fun provideOkHttpClient(
             @ApplicationContext context: Context,
             userPreferencesStore: com.raulshma.jellyplay.core.datastore.UserPreferencesStore,
+            bandwidthInterceptor: BandwidthInterceptor,
         ): OkHttpClient {
             val cacheDir = File(context.cacheDir, "http_cache")
             cacheDir.mkdirs()
@@ -126,14 +128,25 @@ abstract class NetworkModule {
                 .connectionPool(ConnectionPool(16, 15, TimeUnit.MINUTES))
                 .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
                 .retryOnConnectionFailure(true)
+                .addNetworkInterceptor(bandwidthInterceptor)
                 .addNetworkInterceptor { chain ->
                     val response = chain.proceed(chain.request())
                     val path = chain.request().url.encodedPath
+                    val query = chain.request().url.queryParameterNames
                     val cacheMaxAge = when {
                         path.startsWith("/Items/") && path.contains("/Images/") -> 604800
                         path.startsWith("/Genres/") -> 300
                         path == "/System/Info/Public" -> 600
                         path.startsWith("/Library/MediaFolders") -> 300
+                        path == "/System/Info" -> 120
+                        path == "/System/Info/Public" -> 600
+                        path.startsWith("/Sessions") -> 10
+                        path.startsWith("/ScheduledTasks") -> 30
+                        path == "/Shows/NextUp" || query.contains("resume") && path == "/Items" -> 120
+                        path.startsWith("/Shows/") && path.contains("/Episodes") -> 300
+                        path.startsWith("/Shows/") && path.contains("/Seasons") -> 300
+                        path.contains("/Similar") -> 300
+                        path == "/Items" && !query.contains("Resume") -> 60
                         else -> null
                     }
                     if (response.isSuccessful && cacheMaxAge != null) {

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/interceptor/BandwidthInterceptor.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/interceptor/BandwidthInterceptor.kt
@@ -1,0 +1,93 @@
+package com.raulshma.jellyplay.core.network.interceptor
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import okhttp3.Interceptor
+import okhttp3.Response
+import okio.buffer
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BandwidthInterceptor @Inject constructor() : Interceptor {
+
+    private val _estimatedBandwidthKbps = MutableStateFlow(0.0)
+    val estimatedBandwidthKbps: StateFlow<Double> = _estimatedBandwidthKbps.asStateFlow()
+
+    private val samples = ArrayDeque<Sample>()
+    private val maxSamples = 10
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val path = request.url.encodedPath
+        val isMediaStream = path.contains("/Audio/") || path.contains("/Videos/") || path.contains("/stream")
+        if (!isMediaStream) {
+            return chain.proceed(request)
+        }
+
+        val originalResponse = chain.proceed(request)
+        val responseBody = originalResponse.body ?: return originalResponse
+
+        return originalResponse.newBuilder()
+            .body(CountingBody(responseBody) { bytesTransferred ->
+                addSample(bytesTransferred, responseBody.contentLength())
+            })
+            .build()
+    }
+
+    private fun addSample(bytesTransferred: Long, contentLength: Long) {
+        if (bytesTransferred <= 0) return
+        val now = System.nanoTime()
+        synchronized(samples) {
+            samples.addLast(Sample(bytesTransferred, now))
+            while (samples.size > maxSamples) {
+                samples.removeFirst()
+            }
+            if (samples.size >= 2) {
+                val totalBytes = samples.sumOf { it.bytes }
+                val elapsedNs = samples.last().timestampNs - samples.first().timestampNs
+                if (elapsedNs > 0) {
+                    val elapsedSec = elapsedNs / 1_000_000_000.0
+                    val kbps = (totalBytes * 8.0) / elapsedSec / 1000.0
+                    _estimatedBandwidthKbps.value = kbps
+                }
+            }
+        }
+    }
+
+    private data class Sample(val bytes: Long, val timestampNs: Long)
+
+    private class CountingBody(
+        private val delegate: okhttp3.ResponseBody,
+        private val onComplete: (Long) -> Unit,
+    ) : okhttp3.ResponseBody() {
+        override fun contentType(): okhttp3.MediaType? = delegate.contentType()
+        override fun contentLength(): Long = delegate.contentLength()
+
+        override fun source(): okio.BufferedSource {
+            val raw = delegate.source()
+            val forwarding = object : okio.ForwardingSource(raw) {
+                private var totalBytesRead = 0L
+
+                override fun read(sink: okio.Buffer, byteCount: Long): Long {
+                    val bytesRead = super.read(sink, byteCount)
+                    if (bytesRead != -1L) {
+                        totalBytesRead += bytesRead
+                    }
+                    if (bytesRead == -1L || (contentLength() > 0 && totalBytesRead >= contentLength())) {
+                        onComplete(totalBytesRead)
+                    }
+                    return bytesRead
+                }
+            }
+            return forwarding.buffer()
+        }
+
+        override fun close() {
+            delegate.close()
+        }
+    }
+}

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation(libs.navigation3.ui)
     implementation(libs.lifecycle.viewmodel.navigation3)
     implementation(libs.kotlinx.serialization.json)
-    implementation("androidx.compose.animation:animation-android")
+    implementation(libs.compose.animation)
     implementation(libs.media3.session)
     implementation(libs.media3.exoplayer)
     implementation(libs.smooth.corner.rect)

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/JellyPlayScreenScaffold.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/JellyPlayScreenScaffold.kt
@@ -228,32 +228,23 @@ fun ScreenLoadingState(
     message: String? = null,
     modifier: Modifier = Modifier,
 ) {
-    AnimatedVisibility(
-        visible = true,
-        enter = fadeIn(MaterialTheme.motionScheme.defaultEffectsSpec()) +
-                slideInVertically(
-                    initialOffsetY = { it / 10 },
-                    animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
-                ),
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
     ) {
-        Box(
-            modifier = modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(16.dp),
-            ) {
-                JellyPlayLoadingIndicator(
-                    color = MaterialTheme.colorScheme.primary,
+            JellyPlayLoadingIndicator(
+                color = MaterialTheme.colorScheme.primary,
+            )
+            if (message != null) {
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                if (message != null) {
-                    Text(
-                        text = message,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
             }
         }
     }
@@ -268,45 +259,36 @@ fun ScreenEmptyState(
     onAction: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
-    AnimatedVisibility(
-        visible = true,
-        enter = fadeIn(MaterialTheme.motionScheme.defaultEffectsSpec()) +
-                slideInVertically(
-                    initialOffsetY = { it / 10 },
-                    animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
-                ),
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
     ) {
-        Box(
-            modifier = modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
         ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(64.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                )
+            Icon(
+                icon,
+                contentDescription = null,
+                modifier = Modifier.size(64.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            )
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (description != null) {
                 Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                if (description != null) {
-                    Text(
-                        text = description,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                if (actionLabel != null && onAction != null) {
-                    Spacer(Modifier.height(8.dp))
-                    androidx.compose.material3.OutlinedButton(onClick = onAction) {
-                        Text(actionLabel)
-                    }
+            }
+            if (actionLabel != null && onAction != null) {
+                Spacer(Modifier.height(8.dp))
+                androidx.compose.material3.OutlinedButton(onClick = onAction) {
+                    Text(actionLabel)
                 }
             }
         }

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SharedComponents.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SharedComponents.kt
@@ -95,8 +95,7 @@ private val dominantColorCache = android.util.LruCache<String, Color>(500)
 @Composable
 fun rememberDominantColor(imageUrl: String?, fallback: Color = MaterialTheme.colorScheme.surfaceContainer): Color {
     val context = LocalContext.current
-    val cached = imageUrl?.let { dominantColorCache.get(it) }
-    var color by remember { mutableStateOf(cached ?: fallback) }
+    var color by remember(imageUrl) { mutableStateOf(imageUrl?.let { dominantColorCache.get(it) } ?: fallback) }
     val loader = coil3.SingletonImageLoader.get(context)
 
     LaunchedEffect(imageUrl) {
@@ -545,15 +544,13 @@ fun MediaRow(
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LoadingScreen(modifier: Modifier = Modifier) {
-    AnimatedEntrance(visible = true) {
-        Box(
-            modifier = modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            JellyPlayLoadingIndicator(
-                color = MaterialTheme.colorScheme.primary,
-            )
-        }
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        JellyPlayLoadingIndicator(
+            color = MaterialTheme.colorScheme.primary,
+        )
     }
 }
 

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/navigation/NavKey.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/navigation/NavKey.kt
@@ -106,6 +106,10 @@ sealed class Route : NavKey {
     @Serializable data class NewsletterSectionList(
         val sectionType: String,
     ) : Route()
+
+    @Serializable data object Favorites : Route()
+
+    @Serializable data class MediaInfo(val itemId: String) : Route()
 }
 
 val VIDEO_TOP_LEVEL_ROUTES = linkedMapOf(

--- a/feature/admin/build.gradle.kts
+++ b/feature/admin/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/logs/LogsViewModel.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/logs/LogsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -54,7 +55,7 @@ class LogsViewModel @Inject constructor(
     val state: LogsState get() = _state.value
 
     private val _liveEvents = MutableSharedFlow<ActivityLogEntry>(extraBufferCapacity = 64)
-    val liveEvents: SharedFlow<ActivityLogEntry> = _liveEvents
+    val liveEvents: SharedFlow<ActivityLogEntry> = _liveEvents.asSharedFlow()
 
     private var webSocket: WebSocket? = null
     private var pollingJob: Job? = null

--- a/feature/details/build.gradle.kts
+++ b/feature/details/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.tabler.icons.outline)
     implementation(libs.tabler.icons.filled)
-    implementation("androidx.compose.animation:animation-android")
+    implementation(libs.compose.animation)
 
     implementation(libs.navigation3.runtime)
     implementation(libs.navigation3.ui)

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/DetailViewModel.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/DetailViewModel.kt
@@ -348,7 +348,7 @@ class DetailViewModel @Inject constructor(
             val allEpisodes = episodes.values.flatten()
             if (allEpisodes.isEmpty()) {
                 if (hasMoreSeasonsToLoad()) {
-                    withContext(Dispatchers.Main) { loadNextUnfetchedSeason() }
+                    loadNextUnfetchedSeason()
                 }
                 return@launch
             }
@@ -358,13 +358,11 @@ class DetailViewModel @Inject constructor(
             if (resumeEpisode != null) {
                 val s = resumeEpisode.seasonNumber ?: 1
                 val e = resumeEpisode.episodeNumber ?: resumeEpisode.indexNumber ?: 1
-                withContext(Dispatchers.Main) {
-                    smartPlayTarget = SmartPlayTarget(
-                        episode = resumeEpisode,
-                        label = "Resume S${s}:E${e}",
-                        startPositionTicks = resumeEpisode.playbackPositionTicks ?: 0,
-                    )
-                }
+                smartPlayTarget = SmartPlayTarget(
+                    episode = resumeEpisode,
+                    label = "Resume S${s}:E${e}",
+                    startPositionTicks = resumeEpisode.playbackPositionTicks ?: 0,
+                )
                 return@launch
             }
 
@@ -380,31 +378,27 @@ class DetailViewModel @Inject constructor(
                 } else {
                     "Play S${s}:E${e}"
                 }
-                withContext(Dispatchers.Main) {
-                    smartPlayTarget = SmartPlayTarget(
-                        episode = nextEpisode,
-                        label = label,
-                        startPositionTicks = 0,
-                    )
-                }
+                smartPlayTarget = SmartPlayTarget(
+                    episode = nextEpisode,
+                    label = label,
+                    startPositionTicks = 0,
+                )
                 return@launch
             }
 
             if (hasMoreSeasonsToLoad()) {
-                withContext(Dispatchers.Main) { loadNextUnfetchedSeason() }
+                loadNextUnfetchedSeason()
                 return@launch
             }
 
             val first = sorted.first()
             val s = first.seasonNumber ?: 1
             val e = first.episodeNumber ?: first.indexNumber ?: 1
-            withContext(Dispatchers.Main) {
-                smartPlayTarget = SmartPlayTarget(
-                    episode = first,
-                    label = "Replay S${s}:E${e}",
-                    startPositionTicks = 0,
-                )
-            }
+            smartPlayTarget = SmartPlayTarget(
+                episode = first,
+                label = "Replay S${s}:E${e}",
+                startPositionTicks = 0,
+            )
         }
     }
 
@@ -426,24 +420,22 @@ class DetailViewModel @Inject constructor(
         launch(Dispatchers.Default) {
             val allEpisodes = episodes.values.flatten().sortedByPlaybackOrder()
             if (allEpisodes.isEmpty()) {
-                withContext(Dispatchers.Main) { smartPlayTarget = null }
+                smartPlayTarget = null
                 return@launch
             }
             val currentIndex = allEpisodes.indexOfFirst { it.id == currentEpisode.id }
             if (currentIndex < 0) {
-                withContext(Dispatchers.Main) { smartPlayTarget = null }
+                smartPlayTarget = null
                 return@launch
             }
             val s = currentEpisode.seasonNumber ?: 1
             val e = currentEpisode.episodeNumber ?: currentEpisode.indexNumber ?: 1
             val hasProgress = (currentEpisode.playbackPositionTicks ?: 0) > 0 && !currentEpisode.isPlayed
-            withContext(Dispatchers.Main) {
-                smartPlayTarget = SmartPlayTarget(
-                    episode = currentEpisode,
-                    label = if (hasProgress) "Resume S${s}:E${e}" else "Play S${s}:E${e}",
-                    startPositionTicks = currentEpisode.playbackPositionTicks ?: 0,
-                )
-            }
+            smartPlayTarget = SmartPlayTarget(
+                episode = currentEpisode,
+                label = if (hasProgress) "Resume S${s}:E${e}" else "Play S${s}:E${e}",
+                startPositionTicks = currentEpisode.playbackPositionTicks ?: 0,
+            )
         }
     }
 

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
@@ -566,15 +566,15 @@ private fun DetailContent(
                 targetState = targetBackdropId,
                 transitionSpec = {
                     fadeIn(
-                        animationSpec = slowEffectsSpec,
+                        animationSpec = tween(400),
                     ) + scaleIn(
                         initialScale = 1.035f,
-                        animationSpec = slowEffectsSpec,
+                        animationSpec = tween(400),
                     ) togetherWith fadeOut(
-                        animationSpec = fastEffectsSpec,
+                        animationSpec = tween(300),
                     ) + scaleOut(
                         targetScale = 0.99f,
-                        animationSpec = fastEffectsSpec,
+                        animationSpec = tween(300),
                     )
                 },
                 label = "detailBackdrop",
@@ -1087,6 +1087,7 @@ private fun MediaInfoSection(
     selectedSubtitleIndex: Int?,
     onAudioSelect: (Int?) -> Unit,
     onSubtitleSelect: (Int?) -> Unit,
+    onMediaInfoClick: () -> Unit = {},
     horizontalPadding: androidx.compose.ui.unit.Dp = 24.dp,
 ) {
     val videoStream = mediaStreams.firstOrNull { it.type == StreamType.VIDEO }
@@ -1188,6 +1189,20 @@ private fun MediaInfoSection(
                     onClick = { picker = StreamPickerType.SUBTITLE },
                     containerColor = chipBackgroundColor,
                     modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            FadingItem {
+                QuickInfoPill(
+                    icon = Tabler.Outline.InfoCircle,
+                    text = "Technical Info",
+                    onClick = onMediaInfoClick,
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
                 )
             }
         }
@@ -2025,6 +2040,7 @@ private fun DetailContentBody(
                     selectedSubtitleIndex = selectedSubtitleIndex,
                     onAudioSelect = onAudioSelect,
                     onSubtitleSelect = onSubtitleSelect,
+                    onMediaInfoClick = { onNavigate(com.raulshma.jellyplay.core.ui.navigation.Route.MediaInfo(detail.item.id)) },
                 )
             }
         }
@@ -2415,9 +2431,9 @@ private fun SeasonsSection(
             transitionSpec = {
                 val direction = if (targetState.first >= initialState.first) 1 else -1
                 fadeIn(
-                    animationSpec = defaultEffectsSpec,
+                    animationSpec = tween(400),
                 ) togetherWith fadeOut(
-                    animationSpec = fastEffectsSpec,
+                    animationSpec = tween(300),
                 )
             },
             label = "seasonEpisodes",

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
@@ -188,7 +188,7 @@ fun MediaDetailScreen(
     }
     val backdropUrl = viewModel.getBackdropUrl(targetBackdropId)
 
-    val outerIsLightTheme = MaterialTheme.colorScheme.background.let { bg -> (bg.red * 0.299f + bg.green * 0.587f + bg.blue * 0.114f) > 0.5f }
+    val outerIsLightTheme = rememberIsLightTheme()
 
     var showSeriesDownloadSheet by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
@@ -299,8 +299,8 @@ fun MediaDetailScreen(
             onMarkUnplayed = remember(viewModel) { { viewModel.markUnplayed() } },
             onSubtitleSelect = remember(viewModel) { { idx: Int? -> viewModel.selectSubtitle(idx) } },
             onAudioSelect = remember(viewModel) { { idx: Int? -> viewModel.selectAudio(idx) } },
-            onItemClick = onItemClick,
-            onPersonClick = onPersonClick,
+            onItemClick = remember { onItemClick },
+            onPersonClick = remember { onPersonClick },
             onNavigateToSeries = onNavigateToSeries,
             onSeasonSelected = remember(viewModel, detail, itemId) {
                 { seasonId: String ->
@@ -481,7 +481,7 @@ private fun DetailContent(
         }
     }
 
-    val isLightTheme = MaterialTheme.colorScheme.background.let { bg -> (bg.red * 0.299f + bg.green * 0.587f + bg.blue * 0.114f) > 0.5f }
+    val isLightTheme = rememberIsLightTheme()
 
     val baseOverlayColor = artworkColors?.darkMuted
         ?: artworkColors?.dominant
@@ -2848,4 +2848,11 @@ private fun FadingItem(
     }
 }
 
+@Composable
+private fun rememberIsLightTheme(): Boolean {
+    val bg = MaterialTheme.colorScheme.background
+    return remember(bg) {
+        (bg.red * 0.299f + bg.green * 0.587f + bg.blue * 0.114f) > 0.5f
+    }
+}
 

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaInfoScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaInfoScreen.kt
@@ -1,0 +1,361 @@
+package com.raulshma.jellyplay.feature.details
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.*
+import com.raulshma.jellyplay.core.model.MediaDetail
+import com.raulshma.jellyplay.core.model.MediaSource
+import com.raulshma.jellyplay.core.model.MediaStream
+import com.raulshma.jellyplay.core.model.StreamType
+import com.raulshma.jellyplay.core.ui.adaptive.LocalAdaptiveInfo
+import com.raulshma.jellyplay.core.ui.adaptive.contentPadding
+import com.raulshma.jellyplay.core.ui.components.JellyPlayScreenScaffold
+import com.raulshma.jellyplay.core.ui.components.rememberScreenBackgroundColor
+import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
+
+@Composable
+fun MediaInfoScreen(
+    itemId: String,
+    onBack: () -> Unit,
+    viewModel: DetailViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(itemId) {
+        viewModel.loadItem(itemId)
+    }
+
+    val detail by viewModel.detail
+    val backgroundColor = rememberScreenBackgroundColor()
+    val isTv = LocalTvMode.current
+    val adaptiveInfo = LocalAdaptiveInfo.current
+
+    JellyPlayScreenScaffold(
+        title = "Technical Info",
+        onBack = onBack,
+        backgroundColor = backgroundColor,
+    ) { innerPadding ->
+        val scrollState = rememberScrollState()
+
+        if (detail == null) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                com.raulshma.jellyplay.core.ui.components.JellyPlayLoadingIndicator(
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(
+                        start = adaptiveInfo.contentPadding(isTv),
+                        end = adaptiveInfo.contentPadding(isTv),
+                        bottom = innerPadding.calculateBottomPadding() + 80.dp,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                val currentItem = detail!!.item
+                Text(
+                    text = currentItem.name,
+                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+
+                detail!!.mediaSources.forEachIndexed { sourceIndex, source ->
+                    MediaSourceSection(
+                        source = source,
+                        sourceIndex = sourceIndex,
+                        totalSources = detail!!.mediaSources.size,
+                    )
+                }
+
+                if (detail!!.mediaSources.isEmpty()) {
+                    EmptyMediaInfo()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MediaSourceSection(
+    source: MediaSource,
+    sourceIndex: Int,
+    totalSources: Int,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = MaterialTheme.colorScheme.surfaceContainerLow,
+        animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+        label = "sourceContainerColor",
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(containerColor)
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        if (totalSources > 1) {
+            Text(
+                text = if (source.name.isNotBlank()) source.name else "Source ${sourceIndex + 1}",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        InfoGrid(entries = buildList {
+            source.container?.let { add("Container" to it.uppercase()) }
+            source.size?.let { add("File Size" to formatFileSize(it)) }
+            source.bitrate?.let { add("Overall Bitrate" to formatBitrate(it)) }
+            source.runTimeTicks?.let { add("Duration" to formatTicks(it)) }
+            source.path?.let {
+                val fileName = it.substringAfterLast('/').substringAfterLast('\\')
+                add("File" to fileName)
+            }
+            add("Direct Play" to if (source.supportsDirectPlay) "Supported" else "No")
+            add("Direct Stream" to if (source.supportsDirectStream) "Supported" else "No")
+            add("Transcode" to if (source.supportsTranscoding) "Supported" else "No")
+        })
+
+        val videoStreams = source.mediaStreams.filter { it.type == StreamType.VIDEO }
+        val audioStreams = source.mediaStreams.filter { it.type == StreamType.AUDIO }
+        val subtitleStreams = source.mediaStreams.filter { it.type == StreamType.SUBTITLE }
+
+        if (videoStreams.isNotEmpty()) {
+            StreamSection(
+                title = "Video",
+                icon = Tabler.Outline.BadgeHd,
+                streams = videoStreams,
+            ) { stream ->
+                StreamInfoRows(entries = buildList {
+                    stream.codec?.let { add("Codec" to it.uppercase()) }
+                    if (stream.width != null && stream.height != null) {
+                        add("Resolution" to "${stream.width}x${stream.height}")
+                        add("Quality" to resolutionLabel(stream.height))
+                    }
+                    stream.realFrameRate?.let { add("Frame Rate" to "${it} fps") }
+                    stream.bitRate?.let { add("Bitrate" to formatBitrate(it)) }
+                    stream.videoRange?.let { add("Video Range" to it) }
+                    stream.videoRangeType?.let { add("Range Type" to it) }
+                    stream.videoDoViTitle?.let { add("Dolby Vision" to it) }
+                    stream.isDefault.let { if (it) add("Default" to "Yes") }
+                    stream.title?.let { add("Title" to it) }
+                })
+            }
+        }
+
+        if (audioStreams.isNotEmpty()) {
+            StreamSection(
+                title = "Audio",
+                icon = Tabler.Outline.Volume,
+                streams = audioStreams,
+            ) { stream ->
+                StreamInfoRows(entries = buildList {
+                    stream.codec?.let { add("Codec" to it.uppercase()) }
+                    stream.channels?.let { add("Channels" to channelLabel(it)) }
+                    stream.sampleRate?.let { add("Sample Rate" to "${it / 1000.0} kHz") }
+                    stream.bitRate?.let { add("Bitrate" to formatBitrate(it)) }
+                    stream.audioSampleRate?.let { add("Sample Rate" to "${it} Hz") }
+                    stream.language?.let { add("Language" to it) }
+                    stream.isDefault.let { if (it) add("Default" to "Yes") }
+                    stream.isForced.let { if (it) add("Forced" to "Yes") }
+                    stream.title?.let { add("Title" to it) }
+                })
+            }
+        }
+
+        if (subtitleStreams.isNotEmpty()) {
+            StreamSection(
+                title = "Subtitles",
+                icon = Tabler.Outline.Subtitles,
+                streams = subtitleStreams,
+            ) { stream ->
+                StreamInfoRows(entries = buildList {
+                    stream.codec?.let { add("Codec" to it.uppercase()) }
+                    stream.language?.let { add("Language" to it) }
+                    stream.isDefault.let { if (it) add("Default" to "Yes") }
+                    stream.isForced.let { if (it) add("Forced" to "Yes") }
+                    stream.isExternal.let { if (it) add("External" to "Yes") }
+                    stream.title?.let { add("Title" to it) }
+                    stream.displayTitle?.let { add("Display" to it) }
+                })
+            }
+        }
+    }
+}
+
+@Composable
+private fun StreamSection(
+    title: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    streams: List<MediaStream>,
+    streamContent: @Composable (MediaStream) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = "$title (${streams.size})",
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+
+        streams.forEachIndexed { index, stream ->
+            val streamColor by animateColorAsState(
+                targetValue = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+                animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                label = "streamContainerColor",
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(streamColor)
+                    .padding(14.dp),
+            ) {
+                if (streams.size > 1) {
+                    Text(
+                        text = stream.displayTitle ?: stream.title ?: "Stream ${stream.index}",
+                        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                }
+                streamContent(stream)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StreamInfoRows(entries: List<Pair<String, String>>) {
+    if (entries.isEmpty()) return
+    InfoGrid(entries = entries)
+}
+
+@Composable
+private fun InfoGrid(entries: List<Pair<String, String>>) {
+    if (entries.isEmpty()) return
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        entries.forEach { (label, value) ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontFamily = FontFamily.Monospace,
+                        fontWeight = FontWeight.Medium,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyMediaInfo() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        com.raulshma.jellyplay.core.ui.components.ScreenEmptyState(
+            icon = Tabler.Outline.FileDescription,
+            title = "No Media Info",
+            description = "Technical information is not available for this item",
+        )
+    }
+}
+
+private fun formatFileSize(bytes: Long): String = when {
+    bytes >= 1_000_000_000 -> "%.1f GB".format(bytes / 1_000_000_000.0)
+    bytes >= 1_000_000 -> "%.1f MB".format(bytes / 1_000_000.0)
+    bytes >= 1_000 -> "%.1f KB".format(bytes / 1_000.0)
+    else -> "$bytes B"
+}
+
+private fun formatBitrate(bps: Long): String = when {
+    bps >= 1_000_000 -> "%.1f Mbps".format(bps / 1_000_000.0)
+    bps >= 1_000 -> "%.0f Kbps".format(bps / 1_000.0)
+    else -> "$bps bps"
+}
+
+private fun formatTicks(ticks: Long): String {
+    val totalSeconds = ticks / 10_000_000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) "%dh %dm".format(hours, minutes) else "%dm %ds".format(minutes, seconds)
+}
+
+private fun resolutionLabel(height: Int?): String = when {
+    height == null -> "Unknown"
+    height >= 2160 -> "4K UHD"
+    height >= 1440 -> "1440p QHD"
+    height >= 1080 -> "1080p Full HD"
+    height >= 720 -> "720p HD"
+    height >= 480 -> "480p SD"
+    else -> "${height}p"
+}
+
+private fun channelLabel(channels: Int): String = when (channels) {
+    1 -> "1.0 (Mono)"
+    2 -> "2.0 (Stereo)"
+    6 -> "5.1 (Surround)"
+    8 -> "7.1 (Surround)"
+    else -> "$channels ch"
+}

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/PersonDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/PersonDetailScreen.kt
@@ -103,6 +103,7 @@ fun PersonDetailScreen(
                 ) {
                     itemsIndexed(items = viewModel.filmography, key = { _, it -> it.id }, contentType = { _, _ -> "mediaItem" }) { index, item ->
                         val visible = remember { mutableStateOf(false) }
+                        val clickHandler = remember(item.id) { { onItemClick(item.id) } }
                         LaunchedEffect(Unit) { visible.value = true }
                         AnimatedVisibility(
                             visible = visible.value,
@@ -116,7 +117,7 @@ fun PersonDetailScreen(
                             PosterCard(
                                 item = item,
                                 imageUrl = viewModel.getImageUrl(item.id),
-                                onClick = { onItemClick(item.id) },
+                                onClick = clickHandler,
                             )
                         }
                     }

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeerrDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeerrDetailScreen.kt
@@ -124,7 +124,7 @@ fun SeerrDetailScreen(
 
     val backdropUrl = movieDetail?.backdropUrl ?: tvDetail?.backdropUrl
 
-    val outerIsLightTheme = MaterialTheme.colorScheme.background.let { bg -> (bg.red * 0.299f + bg.green * 0.587f + bg.blue * 0.114f) > 0.5f }
+    val outerIsLightTheme = rememberIsLightTheme()
 
     ArtworkThemeWrapper(
         imageUrl = backdropUrl ?: "",
@@ -291,7 +291,7 @@ private fun SeerrDetailContent(
     }
     val scrollFraction by remember { derivedStateOf { (scrollOffset / collapsedHeight).coerceIn(0f, 1f) } }
 
-    val isLightTheme = MaterialTheme.colorScheme.background.let { bg -> (bg.red * 0.299f + bg.green * 0.587f + bg.blue * 0.114f) > 0.5f }
+    val isLightTheme = rememberIsLightTheme()
 
     val baseOverlayColor = artworkColors?.darkMuted
         ?: artworkColors?.dominant
@@ -1931,4 +1931,12 @@ private fun getFlagEmoji(countryCode: String): String? {
     val firstChar = Character.codePointAt(countryCode, 0) - 0x41 + 0x1F1E6
     val secondChar = Character.codePointAt(countryCode, 1) - 0x41 + 0x1F1E6
     return String(Character.toChars(firstChar)) + String(Character.toChars(secondChar))
+}
+
+@Composable
+private fun rememberIsLightTheme(): Boolean {
+    val bg = MaterialTheme.colorScheme.background
+    return remember(bg) {
+        (bg.red * 0.299f + bg.green * 0.587f + bg.blue * 0.114f) > 0.5f
+    }
 }

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeriesDownloadSheet.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeriesDownloadSheet.kt
@@ -76,7 +76,7 @@ fun SeriesDownloadSheet(
 ) {
     var expandedSeasonId by remember { mutableStateOf<String?>(null) }
     var selectedEpisodeIds by remember(seasons) {
-        mutableStateOf(seasons.associate { it.id to mutableSetOf<String>() })
+        mutableStateOf(seasons.associate { it.id to emptySet<String>() })
     }
 
     val allSelectableIds = remember(seasons, downloadedEpisodeIds, episodes) {
@@ -254,15 +254,13 @@ fun SeriesDownloadSheet(
                         TriStateCheckbox(
                             state = triState,
                             onClick = {
-                                val current = selectedEpisodeIds.toMutableMap()
-                                val seasonSet = (current[season.id] ?: mutableSetOf()).toMutableSet()
-                                if (selectableInSeason.all { it in seasonSet }) {
-                                    seasonSet.removeAll(selectableInSeason)
+                                val currentSet = selectedEpisodeIds[season.id].orEmpty()
+                                val newSet = if (selectableInSeason.all { it in currentSet }) {
+                                    currentSet - selectableInSeason.toSet()
                                 } else {
-                                    seasonSet.addAll(selectableInSeason)
+                                    currentSet + selectableInSeason
                                 }
-                                current[season.id] = seasonSet
-                                selectedEpisodeIds = current
+                                selectedEpisodeIds = selectedEpisodeIds + (season.id to newSet)
                             },
                         )
                         Spacer(Modifier.width(4.dp))
@@ -351,16 +349,13 @@ fun SeriesDownloadSheet(
                                             .clip(shape)
                                             .background(episodeBgColor)
                                             .clickable(enabled = !isDownloaded) {
-                                                val current = selectedEpisodeIds.toMutableMap()
-                                                val seasonSet = (current[season.id]
-                                                    ?: mutableSetOf()).toMutableSet()
-                                                if (episode.id in seasonSet) {
-                                                    seasonSet.remove(episode.id)
+                                                val currentSet = selectedEpisodeIds[season.id].orEmpty()
+                                                val newSet = if (episode.id in currentSet) {
+                                                    currentSet - episode.id
                                                 } else {
-                                                    seasonSet.add(episode.id)
+                                                    currentSet + episode.id
                                                 }
-                                                current[season.id] = seasonSet
-                                                selectedEpisodeIds = current
+                                                selectedEpisodeIds = selectedEpisodeIds + (season.id to newSet)
                                             }
                                             .padding(horizontal = 8.dp, vertical = 6.dp),
                                         verticalAlignment = Alignment.CenterVertically,

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/navigation/DetailsNavigation.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/navigation/DetailsNavigation.kt
@@ -6,6 +6,7 @@ import com.raulshma.jellyplay.core.ui.navigation.Navigator
 import com.raulshma.jellyplay.core.ui.navigation.Route
 import com.raulshma.jellyplay.feature.details.CollectionDetailScreen
 import com.raulshma.jellyplay.feature.details.MediaDetailScreen
+import com.raulshma.jellyplay.feature.details.MediaInfoScreen
 import com.raulshma.jellyplay.feature.details.PersonDetailScreen
 import com.raulshma.jellyplay.feature.details.SeerrDetailScreen
 
@@ -43,6 +44,13 @@ fun EntryProviderScope<NavKey>.detailsSection(
             onNavigateToSeries = { seriesId -> navigator.navigate(Route.MediaDetail(seriesId)) },
             onNavigate = { route -> navigator.navigate(route) },
             onEditClick = { itemId -> navigator.navigate(Route.MetadataEditor(itemId)) },
+            onBack = { navigator.goBack() },
+        )
+    }
+
+    entry<Route.MediaInfo> { key ->
+        MediaInfoScreen(
+            itemId = key.itemId,
             onBack = { navigator.goBack() },
         )
     }

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHero.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHero.kt
@@ -182,44 +182,48 @@ fun HeroHeader(
     }
 
     val heroTransition = rememberInfiniteTransition(label = "hero_animations")
-    val breathScale by heroTransition.animateFloat(
+    val rawBreathScale by heroTransition.animateFloat(
         initialValue = 1.0f,
-        targetValue = if (isVisible) 1.04f else 1.0f,
+        targetValue = 1.04f,
         animationSpec = infiniteRepeatable(
             animation = tween(12000, easing = FancyTransitionEasing),
             repeatMode = RepeatMode.Reverse
         ),
         label = "breath"
     )
+    val breathScale = if (isVisible) rawBreathScale else 1.0f
 
-    val playPulseScale by heroTransition.animateFloat(
+    val rawPlayPulseScale by heroTransition.animateFloat(
         initialValue = 1.0f,
-        targetValue = if (isVisible) 1.35f else 1.0f,
+        targetValue = 1.35f,
         animationSpec = infiniteRepeatable(
             animation = tween(1800, easing = AlphaEasing),
             repeatMode = RepeatMode.Restart
         ),
         label = "playPulseScale"
     )
-    val playPulseAlpha by heroTransition.animateFloat(
+    val playPulseScale = if (isVisible) rawPlayPulseScale else 1.0f
+    val rawPlayPulseAlpha by heroTransition.animateFloat(
         initialValue = 0.45f,
-        targetValue = if (isVisible) 0.0f else 0.45f,
+        targetValue = 0.0f,
         animationSpec = infiniteRepeatable(
             animation = tween(1800, easing = AlphaEasing),
             repeatMode = RepeatMode.Restart
         ),
         label = "playPulseAlpha"
     )
+    val playPulseAlpha = if (isVisible) rawPlayPulseAlpha else 0.45f
 
-    val ratingPulse by heroTransition.animateFloat(
+    val rawRatingPulse by heroTransition.animateFloat(
         initialValue = 0.9f,
-        targetValue = if (isVisible) 1.1f else 0.9f,
+        targetValue = 1.1f,
         animationSpec = infiniteRepeatable(
             animation = tween(2000, easing = FancyTransitionEasing),
             repeatMode = RepeatMode.Reverse
         ),
         label = "ratingPulse"
     )
+    val ratingPulse = if (isVisible) rawRatingPulse else 0.9f
 
     val heroShape = remember(isTv, adaptiveInfo.windowSizeClass) {
         if (!isTv && adaptiveInfo.windowSizeClass == WindowSizeClass.Compact) {

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/FavoritesScreen.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/FavoritesScreen.kt
@@ -1,0 +1,227 @@
+package com.raulshma.jellyplay.feature.library
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.*
+import com.raulshma.jellyplay.core.model.MediaType
+import com.raulshma.jellyplay.core.ui.adaptive.LocalAdaptiveInfo
+import com.raulshma.jellyplay.core.ui.adaptive.contentPadding
+import com.raulshma.jellyplay.core.ui.components.JellyPlayScreenScaffold
+import com.raulshma.jellyplay.core.ui.components.PosterCard
+import com.raulshma.jellyplay.core.ui.components.rememberScreenBackgroundColor
+import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
+import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
+
+@Composable
+fun FavoritesScreen(
+    onItemClick: (String) -> Unit,
+    onBack: () -> Unit,
+    viewModel: FavoritesViewModel = hiltViewModel(),
+) {
+    val isTv = LocalTvMode.current
+    val backgroundColor = rememberScreenBackgroundColor()
+    val adaptiveInfo = LocalAdaptiveInfo.current
+    val mediaTypeFilter by viewModel.mediaTypeFilter.collectAsStateWithLifecycle()
+    val pagingItems = viewModel.pagedItems.collectAsLazyPagingItems()
+
+    JellyPlayScreenScaffold(
+        title = "Favorites",
+        onBack = onBack,
+        backgroundColor = backgroundColor,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    start = adaptiveInfo.contentPadding(isTv),
+                    end = adaptiveInfo.contentPadding(isTv),
+                ),
+        ) {
+            MediaTypeFilterRow(
+                selectedType = mediaTypeFilter,
+                onTypeSelected = { viewModel.setMediaTypeFilter(it) },
+            )
+
+            when {
+                pagingItems.loadState.refresh is LoadState.Loading && pagingItems.itemCount == 0 -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        com.raulshma.jellyplay.core.ui.components.JellyPlayLoadingIndicator(
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+                pagingItems.loadState.refresh is LoadState.Error -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = "Failed to load favorites",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                text = (pagingItems.loadState.refresh as LoadState.Error).error.message ?: "Unknown error",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+                pagingItems.itemCount == 0 && pagingItems.loadState.refresh is LoadState.NotLoading -> {
+                    com.raulshma.jellyplay.core.ui.components.ScreenEmptyState(
+                        icon = Tabler.Outline.Heart,
+                        title = "No Favorites",
+                        description = "Items you favorite will appear here",
+                    )
+                }
+                else -> {
+                    val gridState = rememberLazyGridState()
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(minSize = if (isTv) 180.dp else 150.dp),
+                        state = gridState,
+                        contentPadding = PaddingValues(
+                            start = if (isTv) 16.dp else 12.dp,
+                            end = if (isTv) 16.dp else 12.dp,
+                            top = 8.dp,
+                            bottom = innerPadding.calculateBottomPadding() + 80.dp,
+                        ),
+                        horizontalArrangement = Arrangement.spacedBy(if (isTv) 16.dp else 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(if (isTv) 20.dp else 16.dp),
+                    ) {
+                        items(pagingItems.itemCount) { index ->
+                            val item = pagingItems[index]
+                            if (item != null) {
+                                PosterCard(
+                                    item = item,
+                                    imageUrl = viewModel.getImageUrl(item.id),
+                                    blurHash = item.blurHashes.primary,
+                                    onClick = { onItemClick(item.id) },
+                                )
+                            }
+                        }
+
+                        if (pagingItems.loadState.append is LoadState.Loading) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    com.raulshma.jellyplay.core.ui.components.JellyPlayLoadingIndicator(
+                                        color = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MediaTypeFilterRow(
+    selectedType: MediaType?,
+    onTypeSelected: (MediaType?) -> Unit,
+) {
+    val filterTypes = remember {
+        listOf<Pair<MediaType?, String>>(
+            null to "All",
+            MediaType.MOVIE to "Movies",
+            MediaType.SERIES to "TV Shows",
+            MediaType.EPISODE to "Episodes",
+        )
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        filterTypes.forEach { (type, label) ->
+            val isSelected = selectedType == type
+            val containerColor by animateColorAsState(
+                targetValue = if (isSelected) MaterialTheme.colorScheme.primaryContainer
+                else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                label = "filterChipColor_$label",
+            )
+            val contentColor by animateColorAsState(
+                targetValue = if (isSelected) MaterialTheme.colorScheme.onPrimaryContainer
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+                animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
+                label = "filterChipTextColor_$label",
+            )
+
+            val interactionSource = remember { MutableInteractionSource() }
+            val isPressed by interactionSource.collectIsPressedAsState()
+            val scale by animateFloatAsState(
+                targetValue = if (isPressed) 0.95f else 1.0f,
+                animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+                label = "filterChipScale_$label",
+            )
+
+            Box(
+                modifier = Modifier
+                    .clip(ShapeCache.smooth14)
+                    .graphicsLayer { scaleX = scale; scaleY = scale }
+                    .background(containerColor)
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = null,
+                    ) { onTypeSelected(type) }
+                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                    color = contentColor,
+                )
+            }
+        }
+    }
+}

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/FavoritesViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/FavoritesViewModel.kt
@@ -1,0 +1,39 @@
+package com.raulshma.jellyplay.feature.library
+
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.raulshma.jellyplay.core.data.repository.MediaRepository
+import com.raulshma.jellyplay.core.data.repository.PlaybackRepository
+import com.raulshma.jellyplay.core.model.MediaItem
+import com.raulshma.jellyplay.core.model.MediaType
+import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import javax.inject.Inject
+
+@HiltViewModel
+class FavoritesViewModel @Inject constructor(
+    private val mediaRepository: MediaRepository,
+    private val playbackRepository: PlaybackRepository,
+) : JellyPlayViewModel() {
+
+    private val _mediaTypeFilter = stateFlow<MediaType?>(null)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val pagedItems: Flow<PagingData<MediaItem>> = _mediaTypeFilter.flow.flatMapLatest { type ->
+        mediaRepository.getFavoritesPaged(
+            mediaTypes = type?.let { listOf(it) },
+        )
+    }.cachedIn(scope)
+
+    val mediaTypeFilter = _mediaTypeFilter.flow
+
+    fun setMediaTypeFilter(type: MediaType?) {
+        _mediaTypeFilter.set(type)
+    }
+
+    fun getImageUrl(itemId: String): String =
+        playbackRepository.getImageUrl(itemId, maxWidth = 400)
+}

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/navigation/LibraryNavigation.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/navigation/LibraryNavigation.kt
@@ -4,17 +4,18 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.raulshma.jellyplay.core.ui.navigation.Navigator
 import com.raulshma.jellyplay.core.ui.navigation.Route
+import com.raulshma.jellyplay.feature.library.FavoritesScreen
 import com.raulshma.jellyplay.feature.library.LibraryScreen
 
-fun EntryProviderScope<NavKey>.librarySection(
-    navigator: Navigator,
-) {
+fun EntryProviderScope<NavKey>.librarySection(navigator: Navigator) {
     entry<Route.Library> {
-        LibraryScreen(
+        LibraryScreen(onItemClick = { navigator.navigate(Route.MediaDetail(it)) })
+    }
+
+    entry<Route.Favorites> {
+        FavoritesScreen(
             onItemClick = { itemId -> navigator.navigate(Route.MediaDetail(itemId)) },
-            onSmartPlaylistsClick = { navigator.navigate(Route.SmartPlaylists) },
-            onMoodPlaylistsClick = { navigator.navigate(Route.MoodPlaylists) },
-            onPlaylistsClick = { navigator.navigate(Route.Playlists) },
+            onBack = { navigator.goBack() },
         )
     }
 }

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -58,6 +59,7 @@ import com.raulshma.jellyplay.core.ui.tv.tvFocusable
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.composables.icons.tabler.Tabler
 import com.composables.icons.tabler.outline.*
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -72,14 +74,20 @@ fun ArtistDetailScreen(
         viewModel.loadArtist(artistId)
     }
 
+    val scope = rememberCoroutineScope()
     var isRefreshing by remember { mutableStateOf(false) }
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = {
-            isRefreshing = true
-            viewModel.loadArtist(artistId)
-            isRefreshing = false
+            scope.launch {
+                isRefreshing = true
+                try {
+                    viewModel.loadArtist(artistId)
+                } finally {
+                    isRefreshing = false
+                }
+            }
         },
     ) {
     when {
@@ -89,7 +97,7 @@ fun ArtistDetailScreen(
         viewModel.error != null -> {
             ErrorScreen(
                 message = viewModel.error!!,
-                onRetry = { viewModel.loadArtist(artistId) },
+                onRetry = { scope.launch { viewModel.loadArtist(artistId) } },
             )
         }
         else -> {

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailViewModel.kt
@@ -30,7 +30,7 @@ class ArtistDetailViewModel @Inject constructor(
     private val _error = composeState<String?>(null)
     val error: String? get() = _error.value
 
-    fun loadArtist(artistId: String) {
+    suspend fun loadArtist(artistId: String) {
         launch {
             _isLoading.value = true
             _error.value = null

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -27,6 +28,7 @@ import com.raulshma.jellyplay.feature.music.components.AudioPlayerScreensSection
 import com.raulshma.jellyplay.feature.music.components.NewReleasesSection
 import com.composables.icons.tabler.Tabler
 import com.composables.icons.tabler.outline.*
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +48,7 @@ fun MusicHomeScreen(
     val isLoading = viewModel.isLoading
     val error = viewModel.error
     val backgroundColor = rememberScreenBackgroundColor()
+    val scope = rememberCoroutineScope()
 
     val adaptiveInfo = LocalAdaptiveInfo.current
     val isTv = LocalTvMode.current
@@ -55,9 +58,14 @@ fun MusicHomeScreen(
     PullToRefreshBox(
         isRefreshing = isRefreshing,
         onRefresh = {
-            isRefreshing = true
-            viewModel.loadSections()
-            isRefreshing = false
+            scope.launch {
+                isRefreshing = true
+                try {
+                    viewModel.loadSections()
+                } finally {
+                    isRefreshing = false
+                }
+            }
         },
         modifier = Modifier
             .fillMaxSize()
@@ -66,7 +74,7 @@ fun MusicHomeScreen(
     ) {
         when {
             error != null && sections.isEmpty() -> {
-                ErrorScreen(message = error, onRetry = { viewModel.loadSections() })
+                ErrorScreen(message = error, onRetry = { scope.launch { viewModel.loadSections() } })
             }
             else -> {
                 if (isLoading && sections.isEmpty()) {

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeViewModel.kt
@@ -80,14 +80,14 @@ class MusicHomeViewModel @Inject constructor(
                 _offlineLibrary.value = items
             }
         }
-        loadSections()
+        launch { loadSections() }
     }
 
     fun toggleOfflineMode() {
         offlineModeManager.toggleManualOffline()
     }
 
-    fun loadSections() {
+    suspend fun loadSections() {
         launch {
             if (offlineMode != OfflineMode.ONLINE) {
                 _isLoading.value = false

--- a/feature/newsletter/build.gradle.kts
+++ b/feature/newsletter/build.gradle.kts
@@ -47,4 +47,5 @@ dependencies {
     implementation(libs.hilt.navigation.compose)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
 }

--- a/feature/player/video/build.gradle.kts
+++ b/feature/player/video/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.tabler.icons.outline)
     implementation(libs.tabler.icons.filled)
-    implementation("androidx.compose.animation:animation-android")
+    implementation(libs.compose.animation)
 
     implementation(libs.navigation3.runtime)
     implementation(libs.navigation3.ui)

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -45,4 +46,5 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsScreen.kt
@@ -127,6 +127,7 @@ fun SettingsScreen(
     onAdminDashboard: () -> Unit = {},
     onSetupWizard: () -> Unit = {},
     onNewsletterClick: () -> Unit = {},
+    onFavoritesClick: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val preferences = viewModel.preferences
@@ -201,6 +202,18 @@ fun SettingsScreen(
     var showPinDisableAuth by remember { mutableStateOf(false) }
     var pinDisableAuthError by remember { mutableStateOf<String?>(null) }
     var showBiometricDisableAuth by remember { mutableStateOf(false) }
+
+    val settingsLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.CreateDocument("application/json"),
+    ) { uri ->
+        uri?.let { viewModel.exportSettings(it) }
+    }
+
+    val importLauncher = androidx.activity.compose.rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        uri?.let { viewModel.importSettings(it) }
+    }
 
     val backgroundColor = com.raulshma.jellyplay.core.ui.components.rememberScreenBackgroundColor()
 
@@ -474,6 +487,14 @@ fun SettingsScreen(
                             }
                         }
                     }
+
+                    SettingListItem(
+                        icon = Tabler.Outline.Heart,
+                        title = "Browse Favorites",
+                        subtitle = "View all your favorited items",
+                        index = idx, count = totalCount + 1,
+                        onClick = onFavoritesClick,
+                    )
                 }
             }
 
@@ -1775,6 +1796,41 @@ fun SettingsScreen(
             }
 
             AnimatedSettingsEntrance(if (isTv) 15 else 14) {
+                SettingsGroup(
+                    icon = Tabler.Outline.DatabaseExport,
+                    title = "Backup & Restore",
+                    summary = { "Export or import app settings" },
+                    modifier = Modifier.padding(vertical = 8.dp),
+                ) {
+                    SettingListItem(
+                        icon = Tabler.Outline.FileExport,
+                        title = "Export Settings",
+                        subtitle = "Save current settings to a JSON file",
+                        index = 0, count = 2,
+                        onClick = {
+                            settingsLauncher.launch("jellyplay-settings.json")
+                        },
+                    )
+                    SettingListItem(
+                        icon = Tabler.Outline.FileImport,
+                        title = "Import Settings",
+                        subtitle = "Restore settings from a backup file",
+                        index = 1, count = 2,
+                        onClick = {
+                            importLauncher.launch(arrayOf("application/json"))
+                        },
+                    )
+                }
+
+                LaunchedEffect(viewModel.backupRestoreStatus) {
+                    viewModel.backupRestoreStatus?.let { msg ->
+                        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        viewModel.clearBackupRestoreStatus()
+                    }
+                }
+            }
+
+            AnimatedSettingsEntrance(if (isTv) 16 else 15) {
                 Column(modifier = Modifier.padding(vertical = 8.dp)) {
                     SettingInfoItem(
                         icon = Tabler.Outline.Video,

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.raulshma.jellyplay.feature.settings
 
 import android.content.Context
+import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import com.raulshma.jellyplay.core.data.repository.AuthRepository
@@ -37,7 +38,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -560,5 +563,50 @@ class SettingsViewModel @Inject constructor(
 
     fun setExoPlayerConfig(config: ExoPlayerEngineConfig) {
         launch { preferencesStore.setExoPlayerConfig(config) }
+    }
+
+    var backupRestoreStatus by composeState<String?>(null)
+        private set
+
+    fun exportSettings(uri: Uri) {
+        launch {
+            backupRestoreStatus = null
+            runCatching {
+                val prefs = preferences
+                val json = Json { prettyPrint = true; encodeDefaults = true }
+                val jsonString = json.encodeToString(UserPreferences.serializer(), prefs)
+                withContext(Dispatchers.IO) {
+                    context.contentResolver.openOutputStream(uri)?.use { stream ->
+                        stream.writer().use { it.write(jsonString) }
+                    } ?: throw IOException("Cannot open output stream")
+                }
+                backupRestoreStatus = "Settings exported successfully"
+            }.onFailure {
+                backupRestoreStatus = "Export failed: ${it.message}"
+            }
+        }
+    }
+
+    fun importSettings(uri: Uri) {
+        launch {
+            backupRestoreStatus = null
+            runCatching {
+                val jsonString = withContext(Dispatchers.IO) {
+                    context.contentResolver.openInputStream(uri)?.use { stream ->
+                        stream.reader().use { it.readText() }
+                    } ?: throw IOException("Cannot open input stream")
+                }
+                val json = Json { ignoreUnknownKeys = true }
+                val imported = json.decodeFromString(UserPreferences.serializer(), jsonString)
+                preferencesStore.restorePreferences(imported)
+                backupRestoreStatus = "Settings imported successfully"
+            }.onFailure {
+                backupRestoreStatus = "Import failed: ${it.message}"
+            }
+        }
+    }
+
+    fun clearBackupRestoreStatus() {
+        backupRestoreStatus = null
     }
 }

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/navigation/SettingsNavigation.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/navigation/SettingsNavigation.kt
@@ -24,6 +24,7 @@ fun EntryProviderScope<NavKey>.settingsSection(
             onAdminDashboard = { navigator.navigate(Route.AdminDashboard) },
             onSetupWizard = onSetupWizard,
             onNewsletterClick = { navigator.navigate(Route.Newsletter) },
+            onFavoritesClick = { navigator.navigate(Route.Favorites) },
         )
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,8 +22,8 @@ kotlinxSerialization = "1.11.0"
 kotlinxCoroutines = "1.11.0"
 palette = "1.0.0"
 coreKtx = "1.18.0"
+collection = "1.5.0"
 activityCompose = "1.13.0"
-appcompat = "1.8.0-alpha01"
 coreSplashScreen = "1.2.0"
 lifecycle = "2.11.0-beta01"
 junit = "4.13.2"
@@ -51,16 +51,13 @@ sentry = "8.14.0"
 # AndroidX Core
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashScreen" }
+androidx-collection-ktx = { group = "androidx.collection", name = "collection-ktx", version.ref = "collection" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-
 # Compose BOM
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-animation = { group = "androidx.compose.animation", name = "animation-android" }
 compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
This pull request introduces several improvements and maintenance tasks across the application, focusing on better resource management, background task handling, and code reliability. Notably, it adds a new paging source for favorites, enhances background cleanup routines, optimizes widget and service coroutine management, and improves audio playback and visualizer handling.

**Background cleanup and resource management:**

* Added background cleanup routines in `JellyPlayApplication` to handle stuck downloads, clean up lyric caches, and remove orphaned offline data during app startup. Also, `audioPlaybackManager` is now started explicitly on launch. (`JellyPlayApplication.kt`) [[1]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dR36-R38) [[2]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dL48-R57) [[3]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dR105-R135)
* Implemented automatic cleanup of audit logs older than 90 days after refreshing playback reporting status in `AdminStatisticsRepositoryImpl`. (`AdminStatisticsRepositoryImpl.kt`) [[1]](diffhunk://#diff-f26c3da80c5d496f874e8548800b1cc22eb8bc09ca1535f0fe9543c41d23a1c2R24-R25) [[2]](diffhunk://#diff-f26c3da80c5d496f874e8548800b1cc22eb8bc09ca1535f0fe9543c41d23a1c2R53-R61)

**Paging and data layer enhancements:**

* Introduced `FavoritesPagingSource` to support paginated loading of favorite media items from `MediaRepository`. (`FavoritesPagingSource.kt`)
* Moved the `room.ktx` dependency to the correct location in the build configuration for proper initialization order. (`core/data/build.gradle.kts`) [[1]](diffhunk://#diff-98bb8e9d1b4b1ff239fcf3df6dc27b3c154c9c1cecd27be82728c081e3708db7L32-L33) [[2]](diffhunk://#diff-98bb8e9d1b4b1ff239fcf3df6dc27b3c154c9c1cecd27be82728c081e3708db7R40)

**Widget and service coroutine management:**

* Refactored widget and tile service coroutine usage to use dedicated `CoroutineScope`s with `SupervisorJob`, improving lifecycle management and preventing resource leaks. (`JellyPlayTileService.kt`, `ContinueWatchingWidget.kt`) [[1]](diffhunk://#diff-c7188d9ec7ce3f06834ce69dd952c65ff209034abc533d087154b663f547e70dR15) [[2]](diffhunk://#diff-c7188d9ec7ce3f06834ce69dd952c65ff209034abc533d087154b663f547e70dR25-R31) [[3]](diffhunk://#diff-920617075a5a808fa4ebdcf89e1f02bc7562b4f323ac3fb9e7cd3ecfc320f727L26-R27) [[4]](diffhunk://#diff-920617075a5a808fa4ebdcf89e1f02bc7562b4f323ac3fb9e7cd3ecfc320f727L45-R47) [[5]](diffhunk://#diff-920617075a5a808fa4ebdcf89e1f02bc7562b4f323ac3fb9e7cd3ecfc320f727L67-R72)

**Audio playback and visualization improvements:**

* Updated `AudioPlaybackManager` to use a `BandwidthInterceptor` for bandwidth estimation, added an explicit `start()` method for background tasks, and improved crossfade and visualizer handling. (`AudioPlaybackManager.kt`) [[1]](diffhunk://#diff-e545cbd8d23724ae6c0d3404b0a4153778055ef1fd46b8082341517e9823a32bR74) [[2]](diffhunk://#diff-e545cbd8d23724ae6c0d3404b0a4153778055ef1fd46b8082341517e9823a32bL87-L93) [[3]](diffhunk://#diff-e545cbd8d23724ae6c0d3404b0a4153778055ef1fd46b8082341517e9823a32bL126-R128) [[4]](diffhunk://#diff-e545cbd8d23724ae6c0d3404b0a4153778055ef1fd46b8082341517e9823a32bR1087-R1090) [[5]](diffhunk://#diff-e545cbd8d23724ae6c0d3404b0a4153778055ef1fd46b8082341517e9823a32bR1409-R1411) [[6]](diffhunk://#diff-e545cbd8d23724ae6c0d3404b0a4153778055ef1fd46b8082341517e9823a32bL1538-R1544)
* Reduced the audio visualizer's capture size and rate for performance optimization. (`AudioVisualizerHelper.kt`) [[1]](diffhunk://#diff-d80b7f34052006d0474ae70547c64e57c3cdfbbec924d1bae9372f2d1897eb5aL36-R36) [[2]](diffhunk://#diff-d80b7f34052006d0474ae70547c64e57c3cdfbbec924d1bae9372f2d1897eb5aL61-R61)
* Improved sleep timer reliability by increasing the timer tick interval and adding exception safety to callbacks. (`SleepTimerManager.kt`) [[1]](diffhunk://#diff-ad95aae2b78b0fb7496ced2aa7dea328f6fc403330857bf7d6c666f23746475fR26-R29) [[2]](diffhunk://#diff-ad95aae2b78b0fb7496ced2aa7dea328f6fc403330857bf7d6c666f23746475fL49-R61) [[3]](diffhunk://#diff-ad95aae2b78b0fb7496ced2aa7dea328f6fc403330857bf7d6c666f23746475fR84-R86)

**Other notable improvements:**

* Scaled down large album art bitmaps in `NowPlayingWidget` to avoid exceeding intent extras size limits. (`NowPlayingWidget.kt`)
* Reduced the number of images fetched and prefetched in `JellyPlayDreamService` for memory and network efficiency. (`JellyPlayDreamService.kt`)