### PR TITLE
feat(app): improve cache invalidation, playback reporting, and refres…

### DIFF
--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
@@ -1233,6 +1233,10 @@ class AudioPlaybackManager @Inject constructor(
         }
 
         if (targetIndex >= 0) {
+            val prevItemId = currentItemId
+            val prevSessionId = playSessionId
+            val prevPosTicks = if (_currentPosition.value > 0) _currentPosition.value * 10_000 else _duration.value * 10_000
+
             _currentIndex.value = targetIndex
             val nextItem = queueItems[targetIndex]
             currentItemId = nextItem.id
@@ -1245,7 +1249,11 @@ class AudioPlaybackManager @Inject constructor(
             effectsProcessor.applyReplayGain(nextItem.normalizationGain, _shuffleMode.value)
 
             scope.launch {
-                progressReporter.reportStopped()
+                progressReporter.reportStopped(
+                    itemId = prevItemId,
+                    sessionId = prevSessionId,
+                    positionTicks = prevPosTicks,
+                )
 
                 val detail = mediaRepository.getMediaDetail(nextItem.id)
                 detail.onSuccess { d ->
@@ -1269,6 +1277,16 @@ class AudioPlaybackManager @Inject constructor(
     }
 
     private suspend fun onCrossfadeTransition(secondary: ExoPlayer, nextIndex: Int, nextItem: AudioQueueItem) {
+        val prevItemId = currentItemId
+        val prevSessionId = playSessionId
+        val prevPosTicks = if (_currentPosition.value > 0) _currentPosition.value * 10_000 else _duration.value * 10_000
+
+        progressReporter.reportStopped(
+            itemId = prevItemId,
+            sessionId = prevSessionId,
+            positionTicks = prevPosTicks,
+        )
+
         exoPlayer = secondary
 
         _currentIndex.value = nextIndex

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioProgressReporter.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioProgressReporter.kt
@@ -19,35 +19,44 @@ class AudioProgressReporter(
     private val playSessionIdSetter: (String) -> Unit,
 ) {
     private var progressJob: Job? = null
+    private var lastPausedPositionTicks: Long = -1L
 
     fun start() {
         progressJob?.cancel()
+        lastPausedPositionTicks = -1L
         if (remoteSessionActive()) return
         progressJob = scope.launch {
             while (true) {
                 delay(10_000)
                 val player = exoPlayerProvider() ?: continue
                 val itemId = itemIdProvider() ?: continue
+                val positionTicks = player.currentPosition * 10_000
+                val isPaused = !player.isPlaying
+                if (isPaused && positionTicks == lastPausedPositionTicks) continue
+                if (isPaused) lastPausedPositionTicks = positionTicks else lastPausedPositionTicks = -1L
                 playbackRepository.reportPlaybackProgress(
                     PlaybackProgress(
                         itemId = itemId,
                         sessionId = playSessionIdProvider(),
-                        positionTicks = player.currentPosition * 10_000,
-                        isPaused = !player.isPlaying,
+                        positionTicks = positionTicks,
+                        isPaused = isPaused,
                     )
                 )
             }
         }
     }
 
-    fun reportStopped() {
-        val player = exoPlayerProvider() ?: return
-        val itemId = itemIdProvider() ?: return
-        val sid = playSessionIdProvider()
-        val pos = player.currentPosition * 10_000
-        if (pos > 0) {
+    fun reportStopped(
+        itemId: String? = null,
+        sessionId: String? = null,
+        positionTicks: Long? = null
+    ) {
+        val finalItemId = itemId ?: itemIdProvider() ?: return
+        val finalSessionId = sessionId ?: playSessionIdProvider()
+        val finalPos = positionTicks ?: (exoPlayerProvider()?.currentPosition?.let { it * 10_000 } ?: 0L)
+        if (finalPos > 0) {
             scope.launch {
-                playbackRepository.reportPlaybackStopped(itemId, sid, pos)
+                playbackRepository.reportPlaybackStopped(finalItemId, finalSessionId, finalPos)
             }
         }
         playSessionIdSetter(UUID.randomUUID().toString())

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepository.kt
@@ -148,5 +148,7 @@ interface MediaRepository : LiveTvRepository, SyncPlayRepository, NewsletterRepo
      */
     suspend fun invalidateCaches()
 
+    fun invalidateDetailCache(itemId: String? = null)
+
     suspend fun getPhotoFolderChildImageUrls(folderId: String, limit: Int = 4): List<String>
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
@@ -68,7 +68,7 @@ class MediaRepositoryImpl @Inject constructor(
     private val studiosCache = TtlCache<List<Studio>>(maxSize = 64, ttlMs = FOLDERS_CACHE_TTL_MS)
     private val latestMediaCache = TtlCache<List<MediaItem>>(maxSize = 64, ttlMs = LATEST_CACHE_TTL_MS)
 
-    fun invalidateDetailCache(itemId: String? = null) {
+    override fun invalidateDetailCache(itemId: String?) {
         if (itemId != null) {
             detailCache.remove(itemId)
         } else {

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/AudioProgressReporterTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/AudioProgressReporterTest.kt
@@ -1,0 +1,245 @@
+package com.raulshma.jellyplay.core.data.playback
+
+import androidx.media3.exoplayer.ExoPlayer
+import com.raulshma.jellyplay.core.data.repository.PlaybackRepository
+import com.raulshma.jellyplay.core.model.PlaybackProgress
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AudioProgressReporterTest {
+
+    private lateinit var playbackRepository: PlaybackRepository
+    private lateinit var exoPlayer: ExoPlayer
+    private var remoteSessionActive = false
+    private var currentItemId: String? = "item-1"
+    private var playSessionId = "session-1"
+
+    @Before
+    fun setUp() {
+        playbackRepository = mockk(relaxed = true)
+        io.mockk.coEvery { playbackRepository.reportPlaybackProgress(any()) } returns Result.success(Unit)
+        io.mockk.coEvery { playbackRepository.reportPlaybackStopped(any(), any(), any()) } returns Result.success(Unit)
+        exoPlayer = mockk(relaxed = true)
+        remoteSessionActive = false
+        currentItemId = "item-1"
+        playSessionId = "session-1"
+    }
+
+    private fun createReporter(scope: CoroutineScope) = AudioProgressReporter(
+        scope = scope,
+        playbackRepository = playbackRepository,
+        remoteSessionActive = { remoteSessionActive },
+        exoPlayerProvider = { exoPlayer },
+        itemIdProvider = { currentItemId },
+        playSessionIdProvider = { playSessionId },
+        playSessionIdSetter = { playSessionId = it }
+    )
+
+    @Test
+    fun `start progress reporting does not run when remote session is active`() = runTest {
+        val reporter = createReporter(this)
+        remoteSessionActive = true
+        reporter.start()
+
+        advanceTimeBy(11_000)
+        runCurrent()
+
+        coVerify(exactly = 0) {
+            playbackRepository.reportPlaybackProgress(any())
+        }
+        reporter.cancel()
+    }
+
+    @Test
+    fun `start progress reporting runs and reports progress every 10 seconds`() = runTest {
+        val reporter = createReporter(this)
+        every { exoPlayer.currentPosition } returns 5_000L
+        every { exoPlayer.isPlaying } returns true
+
+        reporter.start()
+        runCurrent()
+
+        // Before 10s: no reports
+        advanceTimeBy(5_000)
+        runCurrent()
+        coVerify(exactly = 0) {
+            playbackRepository.reportPlaybackProgress(any())
+        }
+
+        // At 10s: first report
+        advanceTimeBy(5_000)
+        runCurrent()
+
+        val progressList1 = mutableListOf<PlaybackProgress>()
+        coVerify(exactly = 1) {
+            playbackRepository.reportPlaybackProgress(capture(progressList1))
+        }
+        assertEquals(1, progressList1.size)
+        assertEquals("item-1", progressList1[0].itemId)
+        assertEquals("session-1", progressList1[0].sessionId)
+        assertEquals(50_000_000L, progressList1[0].positionTicks)
+        assertEquals(false, progressList1[0].isPaused)
+
+        // At 20s: second report
+        every { exoPlayer.currentPosition } returns 15_000L
+        advanceTimeBy(10_000)
+        runCurrent()
+
+        val progressList2 = mutableListOf<PlaybackProgress>()
+        coVerify(exactly = 2) {
+            playbackRepository.reportPlaybackProgress(capture(progressList2))
+        }
+        assertEquals(2, progressList2.size)
+        assertEquals("item-1", progressList2[1].itemId)
+        assertEquals("session-1", progressList2[1].sessionId)
+        assertEquals(150_000_000L, progressList2[1].positionTicks)
+        assertEquals(false, progressList2[1].isPaused)
+
+        reporter.cancel()
+    }
+
+    @Test
+    fun `progress reporting loop skips duplicate paused reports`() = runTest {
+        val reporter = createReporter(this)
+        every { exoPlayer.currentPosition } returns 5_000L
+        every { exoPlayer.isPlaying } returns false
+
+        reporter.start()
+        runCurrent()
+
+        // 10s: first paused report
+        advanceTimeBy(10_000)
+        runCurrent()
+
+        val progressList1 = mutableListOf<PlaybackProgress>()
+        coVerify(exactly = 1) {
+            playbackRepository.reportPlaybackProgress(capture(progressList1))
+        }
+        assertEquals(1, progressList1.size)
+        assertEquals("item-1", progressList1[0].itemId)
+        assertEquals("session-1", progressList1[0].sessionId)
+        assertEquals(50_000_000L, progressList1[0].positionTicks)
+        assertEquals(true, progressList1[0].isPaused)
+
+        // 20s: second paused report at same position is skipped
+        advanceTimeBy(10_000)
+        runCurrent()
+        coVerify(exactly = 1) {
+            playbackRepository.reportPlaybackProgress(any())
+        }
+
+        // 30s: position changes while paused, it should report again
+        every { exoPlayer.currentPosition } returns 6_000L
+        advanceTimeBy(10_000)
+        runCurrent()
+
+        val progressList2 = mutableListOf<PlaybackProgress>()
+        coVerify(exactly = 2) {
+            playbackRepository.reportPlaybackProgress(capture(progressList2))
+        }
+        assertEquals(2, progressList2.size)
+        assertEquals("item-1", progressList2[1].itemId)
+        assertEquals("session-1", progressList2[1].sessionId)
+        assertEquals(60_000_000L, progressList2[1].positionTicks)
+        assertEquals(true, progressList2[1].isPaused)
+
+        reporter.cancel()
+    }
+
+    @Test
+    fun `reportStopped rotates playSessionId and reports stopped if position positive`() = runTest {
+        val reporter = createReporter(this)
+        every { exoPlayer.currentPosition } returns 12_000L
+        val originalSessionId = playSessionId
+
+        reporter.reportStopped()
+        runCurrent()
+
+        val itemIdSlot = slot<String>()
+        val sessionIdSlot = slot<String>()
+        val positionSlot = slot<Long>()
+        coVerify(exactly = 1) {
+            playbackRepository.reportPlaybackStopped(capture(itemIdSlot), capture(sessionIdSlot), capture(positionSlot))
+        }
+        assertEquals("item-1", itemIdSlot.captured)
+        assertEquals(originalSessionId, sessionIdSlot.captured)
+        assertEquals(120_000_000L, positionSlot.captured)
+
+        assertNotEquals(originalSessionId, playSessionId)
+        reporter.cancel()
+    }
+
+    @Test
+    fun `reportStopped with explicit overrides uses them and rotates session ID`() = runTest {
+        val reporter = createReporter(this)
+        val originalSessionId = playSessionId
+
+        reporter.reportStopped(
+            itemId = "override-item",
+            sessionId = "override-session",
+            positionTicks = 990_000_000L
+        )
+        runCurrent()
+
+        val itemIdSlot = slot<String>()
+        val sessionIdSlot = slot<String>()
+        val positionSlot = slot<Long>()
+        coVerify(exactly = 1) {
+            playbackRepository.reportPlaybackStopped(capture(itemIdSlot), capture(sessionIdSlot), capture(positionSlot))
+        }
+        assertEquals("override-item", itemIdSlot.captured)
+        assertEquals("override-session", sessionIdSlot.captured)
+        assertEquals(990_000_000L, positionSlot.captured)
+
+        assertNotEquals(originalSessionId, playSessionId)
+        reporter.cancel()
+    }
+
+    @Test
+    fun `reportStopped does not report stopped if position is zero or negative but still rotates session ID`() = runTest {
+        val reporter = createReporter(this)
+        every { exoPlayer.currentPosition } returns 0L
+        val originalSessionId = playSessionId
+
+        reporter.reportStopped()
+        runCurrent()
+
+        coVerify(exactly = 0) {
+            playbackRepository.reportPlaybackStopped(any(), any(), any())
+        }
+        assertNotEquals(originalSessionId, playSessionId)
+        reporter.cancel()
+    }
+
+    @Test
+    fun `cancel stops progress reporting loop`() = runTest {
+        val reporter = createReporter(this)
+        every { exoPlayer.currentPosition } returns 5_000L
+        every { exoPlayer.isPlaying } returns true
+
+        reporter.start()
+        runCurrent()
+        advanceTimeBy(10_000) // first report sent
+        runCurrent()
+
+        reporter.cancel()
+        advanceTimeBy(10_000) // should be skipped because cancelled
+        runCurrent()
+
+        coVerify(exactly = 1) {
+            playbackRepository.reportPlaybackProgress(any())
+        }
+    }
+}

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailActionButtons.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailActionButtons.kt
@@ -34,7 +34,6 @@ import com.composables.icons.tabler.filled.Heart
 import com.composables.icons.tabler.outline.Eye
 import com.composables.icons.tabler.outline.EyeOff
 import com.composables.icons.tabler.outline.Heart
-import com.composables.icons.tabler.outline.InfoCircle
 import com.composables.icons.tabler.outline.PlayerPlay
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.MediaDetail
@@ -63,7 +62,7 @@ internal fun DetailActionButtons(
     onToggleFavorite: () -> Unit,
     onMarkPlayed: () -> Unit,
     onMarkUnplayed: () -> Unit,
-    onMediaInfoClick: () -> Unit = {},
+
     modifier: Modifier = Modifier,
     vertical: Boolean = false,
     contentFocusRequester: FocusRequester? = null,
@@ -251,26 +250,6 @@ internal fun DetailActionButtons(
                         )
                     }
                 }
-                val infoVTvFocusState = rememberTvFocusState(focusedScale = 1.08f)
-                FadingItem(modifier = Modifier.weight(1f)) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(48.dp)
-                            .clip(ShapeCache.smooth12)
-                            .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f))
-                            .then(infoVTvFocusState.focusModifier)
-                            .then(Modifier.tvFocusIndicator(infoVTvFocusState, ShapeCache.smooth12))
-                            .clickable { onMediaInfoClick() }
-                    ) {
-                        Icon(
-                            Tabler.Outline.InfoCircle,
-                            contentDescription = "Technical Info",
-                            tint = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
-                }
             }
         }
     } else {
@@ -388,25 +367,6 @@ internal fun DetailActionButtons(
                 }
             }
 
-            val infoHFocusState = rememberTvFocusState(focusedScale = 1.08f)
-            FadingItem {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .size(56.dp)
-                        .clip(ShapeCache.smooth16)
-                        .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f))
-                        .then(infoHFocusState.focusModifier)
-                        .then(Modifier.tvFocusIndicator(infoHFocusState, ShapeCache.smooth16))
-                        .clickable { onMediaInfoClick() }
-                ) {
-                    Icon(
-                        Tabler.Outline.InfoCircle,
-                        contentDescription = "Technical Info",
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
-            }
 
             }
     }

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailBody.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailBody.kt
@@ -409,7 +409,6 @@ internal fun DetailContentBody(
                 onToggleFavorite = onToggleFavorite,
                 onMarkPlayed = onMarkPlayed,
                 onMarkUnplayed = onMarkUnplayed,
-                onMediaInfoClick = { onNavigate(com.raulshma.jellyplay.core.ui.navigation.Route.MediaInfo(detail.item.id)) },
                 vertical = false,
                 contentFocusRequester = contentFocusRequester,
             )

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
@@ -804,7 +804,6 @@ private fun DetailContent(
                                         onToggleFavorite = onToggleFavorite,
                                         onMarkPlayed = onMarkPlayed,
                                         onMarkUnplayed = onMarkUnplayed,
-                                        onMediaInfoClick = { onNavigate(com.raulshma.jellyplay.core.ui.navigation.Route.MediaInfo(item.id)) },
                                         vertical = true,
                                         contentFocusRequester = contentFocusRequester,
                                     )
@@ -1129,6 +1128,16 @@ private fun DetailContent(
                                         Icon(Tabler.Outline.EyeOff, contentDescription = null)
                                     }
                                 )
+                                DropdownMenuItem(
+                                    text = { Text("Technical Info") },
+                                    onClick = {
+                                        menuExpanded = false
+                                        onNavigate(com.raulshma.jellyplay.core.ui.navigation.Route.MediaInfo(itemId))
+                                    },
+                                    leadingIcon = {
+                                        Icon(Tabler.Outline.InfoCircle, contentDescription = null)
+                                    }
+                                )
                             }
                         }
                     }
@@ -1288,6 +1297,14 @@ private fun DetailContent(
                     onClick = {
                         showTvOptionsMenu = false
                         onHideFromContinueWatching()
+                    },
+                )
+                TvOptionItem(
+                    icon = Tabler.Outline.InfoCircle,
+                    label = "Technical Info",
+                    onClick = {
+                        showTvOptionsMenu = false
+                        onNavigate(com.raulshma.jellyplay.core.ui.navigation.Route.MediaInfo(itemId))
                     },
                 )
             }

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeViewModel.kt
@@ -316,6 +316,7 @@ class HomeViewModel @Inject constructor(
             resetHomeScrollPosition()
             resetHomeFocusPosition()
             _uiState.update { it.copy(sections = emptyList(), favorites = emptyList(), discoverSections = emptyMap(), error = null) }
+            mediaRepository.invalidateCaches()
             fetchAndUpdateSections()
             startPeriodicRefresh()
         }
@@ -324,6 +325,7 @@ class HomeViewModel @Inject constructor(
     private fun pullToRefresh() {
         launch {
             _uiState.update { it.copy(isRefreshing = true, error = null) }
+            mediaRepository.invalidateCaches()
             fetchAndUpdateSections()
             startPeriodicRefresh()
         }

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
@@ -399,8 +399,11 @@ fun LibraryScreen(
                 }
 
                 PullToRefreshBox(
-                    isRefreshing = pagedItems.loadState.refresh is LoadState.Loading,
-                    onRefresh = { pagedItems.refresh() },
+                    isRefreshing = pagedItems.loadState.refresh is LoadState.Loading || isLoading,
+                    onRefresh = {
+                        viewModel.refresh()
+                        pagedItems.refresh()
+                    },
                     enabled = !isTv,
                     modifier = Modifier.fillMaxSize(),
                 ) {

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
@@ -241,7 +241,12 @@ class LibraryViewModel @Inject constructor(
     }
 
     fun refresh() {
-        loadFolders()
+        launch {
+            mediaRepository.invalidateCaches()
+            loadFolders()
+            loadGenres()
+            loadTags()
+        }
     }
 
     fun getImageUrl(itemId: String): String =

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albumdetail/AlbumDetailScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albumdetail/AlbumDetailScreen.kt
@@ -89,8 +89,6 @@ fun AlbumDetailScreen(
     }
 
     val trackDownloads by viewModel.trackDownloads.collectAsStateWithLifecycle()
-    var isRefreshing by remember { mutableStateOf(false) }
-
     // TV focus-on-launch: focus the first track once content arrives so D-pad input lands on
     // content, not the navigation drawer.
     val listFocusRequester = remember { FocusRequester() }
@@ -101,11 +99,9 @@ fun AlbumDetailScreen(
     )
 
     PullToRefreshBox(
-        isRefreshing = isRefreshing,
+        isRefreshing = viewModel.isLoading && viewModel.detail != null,
         onRefresh = {
-            isRefreshing = true
-            viewModel.loadAlbum(albumId)
-            isRefreshing = false
+            viewModel.refreshAlbum(albumId)
         },
     ) {
     when {

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albumdetail/AlbumDetailViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albumdetail/AlbumDetailViewModel.kt
@@ -57,6 +57,13 @@ class AlbumDetailViewModel @Inject constructor(
         }
     }
 
+    fun refreshAlbum(albumId: String) {
+        launch {
+            mediaRepository.invalidateDetailCache(albumId)
+            loadAlbum(albumId)
+        }
+    }
+
     fun playAlbum(tracks: List<MediaItem>, startIndex: Int = 0) {
         if (tracks.isEmpty()) return
         val queueItems = tracks.map { track ->

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailScreen.kt
@@ -93,20 +93,10 @@ fun ArtistDetailScreen(
         }
     }
 
-    val scope = rememberCoroutineScope()
-    var isRefreshing by remember { mutableStateOf(false) }
-
     PullToRefreshBox(
-        isRefreshing = isRefreshing,
+        isRefreshing = viewModel.isLoading && viewModel.artistName.isNotEmpty(),
         onRefresh = {
-            scope.launch {
-                isRefreshing = true
-                try {
-                    viewModel.loadArtist(artistId)
-                } finally {
-                    isRefreshing = false
-                }
-            }
+            viewModel.refreshArtist(artistId)
         },
     ) {
     when {
@@ -116,7 +106,7 @@ fun ArtistDetailScreen(
         viewModel.error != null -> {
             ErrorScreen(
                 message = viewModel.error!!,
-                onRetry = { scope.launch { viewModel.loadArtist(artistId) } },
+                onRetry = { viewModel.loadArtist(artistId) },
             )
         }
         else -> {

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artistdetail/ArtistDetailViewModel.kt
@@ -58,6 +58,13 @@ class ArtistDetailViewModel @Inject constructor(
         }
     }
 
+    fun refreshArtist(artistId: String) {
+        launch {
+            mediaRepository.invalidateDetailCache(artistId)
+            loadArtist(artistId)
+        }
+    }
+
     fun getImageUrl(itemId: String): String =
         playbackRepository.getImageUrl(itemId, maxWidth = 400)
 

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/genres/GenresScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/genres/GenresScreen.kt
@@ -49,8 +49,6 @@ fun GenresScreen(
         networkStatus = networkStatus,
     )
 
-    var isRefreshing by remember { mutableStateOf(false) }
-
     JellyPlayScreenScaffold(
         title = "Genres",
         onBack = onBack,
@@ -62,11 +60,9 @@ fun GenresScreen(
         },
     ) { _ ->
         PullToRefreshBox(
-            isRefreshing = isRefreshing,
+            isRefreshing = isLoading && genres.isNotEmpty(),
             onRefresh = {
-                isRefreshing = true
                 viewModel.refresh()
-                isRefreshing = false
             },
             modifier = Modifier.fillMaxSize(),
         ) {

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/genres/GenresViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/genres/GenresViewModel.kt
@@ -35,6 +35,9 @@ class GenresViewModel @Inject constructor(
     }
 
     fun refresh() {
-        loadGenres()
+        launch {
+            mediaRepository.invalidateCaches()
+            loadGenres()
+        }
     }
 }

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeScreen.kt
@@ -57,8 +57,6 @@ fun MusicHomeScreen(
     val adaptiveInfo = LocalAdaptiveInfo.current
     val isTv = LocalTvMode.current
 
-    var isRefreshing by remember { mutableStateOf(false) }
-
     val initialFocusRequester = remember { FocusRequester() }
 
     // Focus groups for each section to build a vertical chain
@@ -86,16 +84,9 @@ fun MusicHomeScreen(
     )
 
     PullToRefreshBox(
-        isRefreshing = isRefreshing,
+        isRefreshing = viewModel.isLoading && sections.isNotEmpty(),
         onRefresh = {
-            scope.launch {
-                isRefreshing = true
-                try {
-                    viewModel.loadSections()
-                } finally {
-                    isRefreshing = false
-                }
-            }
+            viewModel.refresh()
         },
         modifier = Modifier
             .fillMaxSize()

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/musichome/MusicHomeViewModel.kt
@@ -165,6 +165,13 @@ class MusicHomeViewModel @Inject constructor(
         }
     }
 
+    fun refresh() {
+        launch {
+            mediaRepository.invalidateCaches()
+            loadSections()
+        }
+    }
+
     fun getImageUrl(itemId: String): String =
         playbackRepository.getImageUrl(itemId, maxWidth = 400)
 

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailScreen.kt
@@ -90,7 +90,6 @@ fun PlaylistDetailScreen(
     val contentPad = adaptiveInfo.contentPadding(isTv)
 
     val navOffsetPx = com.raulshma.jellyplay.core.ui.components.LocalFloatingNavOffset.current
-    var isRefreshing by remember { mutableStateOf(false) }
 
     // TV focus-on-launch: focus the first track once data arrives so D-pad input lands on content,
     // not the navigation drawer.
@@ -112,11 +111,9 @@ fun PlaylistDetailScreen(
         },
     ) { _ ->
         PullToRefreshBox(
-            isRefreshing = isRefreshing,
+            isRefreshing = viewModel.isLoading && viewModel.items.isNotEmpty(),
             onRefresh = {
-                isRefreshing = true
-                viewModel.load(playlistId)
-                isRefreshing = false
+                viewModel.refreshPlaylist(playlistId)
             },
             modifier = Modifier.fillMaxSize(),
         ) {

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailViewModel.kt
@@ -55,6 +55,13 @@ class PlaylistDetailViewModel @Inject constructor(
         }
     }
 
+    fun refreshPlaylist(playlistId: String) {
+        launch {
+            mediaRepository.invalidateDetailCache(playlistId)
+            load(playlistId, playlistName.takeIf { it.isNotEmpty() })
+        }
+    }
+
     fun addToQueue(item: PlaylistItem) {
         val queueItem = item.toAudioQueueItem()
         audioPlaybackManager.addToQueue(queueItem)

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistsScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistsScreen.kt
@@ -88,8 +88,6 @@ fun PlaylistsScreen(
         tag = "playlists_init",
     )
 
-    var isRefreshing by remember { mutableStateOf(false) }
-
     LaunchedEffect(viewModel.error) {
         // Errors are surfaced via the dialogs/state; we keep state-based clearing
     }
@@ -106,11 +104,9 @@ fun PlaylistsScreen(
     ) { _ ->
         Box(modifier = Modifier.fillMaxSize()) {
             PullToRefreshBox(
-                isRefreshing = isRefreshing,
+                isRefreshing = viewModel.isLoading && viewModel.playlists.isNotEmpty(),
                 onRefresh = {
-                    isRefreshing = true
                     viewModel.load()
-                    isRefreshing = false
                 },
                 modifier = Modifier.fillMaxSize(),
             ) {

--- a/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterViewModel.kt
+++ b/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterViewModel.kt
@@ -47,6 +47,10 @@ class NewsletterViewModel @Inject constructor(
                 )
             }
 
+            if (isPullToRefresh) {
+                mediaRepository.invalidateCaches()
+            }
+
             val sinceDate = LocalDate.now()
                 .minusDays(7)
                 .atStartOfDay()

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlaybackProgressReporter.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlaybackProgressReporter.kt
@@ -116,7 +116,7 @@ internal class PlaybackProgressReporter(
                 delay(10_000)
                 if (getIncognitoModeEnabled()) continue
                 val engine = getMediaEngine() ?: continue
-                val itemId = getCurrentItemId() ?: break
+                val itemId = getCurrentItemId() ?: continue
                 val positionTicks = engine.currentPositionMs * 10_000
                 val isPaused = !engine.isPlaying.value
                 if (isPaused && positionTicks == lastPausedPositionTicks) continue

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
@@ -984,9 +984,10 @@ fun VideoPlayerScreen(
                     seasonNumber = nextEpisode.seasonNumber,
                     episodeNumber = nextEpisode.episodeNumber,
                     thumbnailUrl = nextEpisodeImageUrl,
-                    countdownSeconds = 10,
+                    countdownSeconds = uiState.autoPlayCountdownSec,
+                    autoplayEnabled = uiState.videoAutoplayNext,
                     onPlayNext = { viewModel.playNextEpisode() },
-                    onCancel = {},
+                    onCancel = { viewModel.cancelAutoplay() },
                     isPlaying = isPlaying,
                     focusRequester = tvNextEpisodeFocusRequester,
                     modifier = Modifier

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerUiState.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerUiState.kt
@@ -161,6 +161,9 @@ data class VideoPlayerUiState(
     val keepScreenOnDuringVideo: Boolean = true,
     val cinemaIntroState: CinemaIntroUiState? = null,
     val isMuted: Boolean = false,
+    val videoAutoplayNext: Boolean = false,
+    val autoPlayCountdownSec: Int = 10,
+    val autoplayCancelled: Boolean = false,
 ) {
 
     fun behaviorForType(type: MediaSegmentType): SegmentBehavior =
@@ -278,6 +281,7 @@ data class VideoPlayerUiState(
 
     val shouldShowUpNext: Boolean
         get() {
+            if (autoplayCancelled) return false
             if (isInSyncPlaySession) return false
             if (nextEpisode == null) return false
             if (seriesId == null) return false

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -193,6 +193,7 @@ class VideoPlayerViewModel @Inject constructor(
     private val currentPlaySessionId: String
         get() = playerSessionManager.sessionState.value.playSessionId ?: playSessionId
     private var autoplayNext: Boolean = false
+    private var autoplayCancelled: Boolean = false
     private var cachedPreferences: com.raulshma.jellyplay.core.model.UserPreferences = com.raulshma.jellyplay.core.model.UserPreferences()
 
     /**
@@ -500,6 +501,13 @@ class VideoPlayerViewModel @Inject constructor(
                 if (_uiState.value.passOutProtectionHours != prefs.videoPassOutProtectionHours) {
                     _uiState.update { it.copy(passOutProtectionHours = prefs.videoPassOutProtectionHours) }
                 }
+                if (_uiState.value.videoAutoplayNext != prefs.videoAutoplayNext) {
+                    _uiState.update { it.copy(videoAutoplayNext = prefs.videoAutoplayNext) }
+                    autoplayNext = prefs.videoAutoplayNext
+                }
+                if (_uiState.value.autoPlayCountdownSec != prefs.autoPlayCountdownSec) {
+                    _uiState.update { it.copy(autoPlayCountdownSec = prefs.autoPlayCountdownSec) }
+                }
                 if (oldPrefs.volumeBoostEnabled != prefs.volumeBoostEnabled ||
                     oldPrefs.volumeBoostGain != prefs.volumeBoostGain ||
                     oldPrefs.equalizerSettings != prefs.equalizerSettings ||
@@ -653,6 +661,9 @@ class VideoPlayerViewModel @Inject constructor(
                                 _uiState.update { s ->
                                     if (s.isBuffering == buffering) s else s.copy(isBuffering = buffering)
                                 }
+                                if (state == com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.ENDED) {
+                                    handlePlaybackEnded()
+                                }
                             } }
                             launch { engine.currentCues.collect { cues ->
                                 val filteredCues = cues.filter { it.isNotBlank() }
@@ -753,6 +764,8 @@ class VideoPlayerViewModel @Inject constructor(
         allowCinemaMode: Boolean,
     ) {
         released = false
+        autoplayCancelled = false
+        _uiState.update { it.copy(autoplayCancelled = false) }
         lastSeekPositionMs = null
         lastSeekTimestamp = 0L
         trackSelectionHelper.setPendingStreams(subtitleStreamIndex, audioStreamIndex)
@@ -883,6 +896,8 @@ class VideoPlayerViewModel @Inject constructor(
                 streamingQuality = prefs.streamingQuality,
                 adaptiveBitrateEnabled = prefs.adaptiveBitrateEnabled,
                 playbackMode = prefs.playbackMode,
+                videoAutoplayNext = prefs.videoAutoplayNext,
+                autoPlayCountdownSec = prefs.autoPlayCountdownSec,
             ) }
             autoplayNext = prefs.videoAutoplayNext
 
@@ -1464,6 +1479,24 @@ class VideoPlayerViewModel @Inject constructor(
             }
 
             initialize(next.id, null, 0L)
+        }
+    }
+
+    fun cancelAutoplay() {
+        autoplayCancelled = true
+        _uiState.update { it.copy(autoplayCancelled = true) }
+    }
+
+    private fun handlePlaybackEnded() {
+        val next = _uiState.value.nextEpisode
+        if (next != null && autoplayNext && !autoplayCancelled) {
+            playNextEpisode()
+        } else {
+            if (cinemaIntroContext != null) {
+                advanceCinemaIntro()
+            } else {
+                _closePlayer.trySend(Unit)
+            }
         }
     }
 

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/NextEpisodeOverlay.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/NextEpisodeOverlay.kt
@@ -72,6 +72,7 @@ fun NextEpisodeOverlay(
     episodeNumber: Int?,
     thumbnailUrl: String?,
     countdownSeconds: Int = 10,
+    autoplayEnabled: Boolean = true,
     onPlayNext: () -> Unit,
     onCancel: () -> Unit,
     isPlaying: Boolean,
@@ -96,8 +97,8 @@ fun NextEpisodeOverlay(
         }
     }
 
-    LaunchedEffect(isVisible, countdown, dismissed, isPlaying) {
-        if (isVisible && !dismissed && isPlaying) {
+    LaunchedEffect(isVisible, countdown, dismissed, isPlaying, autoplayEnabled) {
+        if (isVisible && !dismissed && isPlaying && autoplayEnabled) {
             if (countdown > 0) {
                 kotlinx.coroutines.delay(1000)
                 countdown--
@@ -243,7 +244,7 @@ fun NextEpisodeOverlay(
                         )
                     }
 
-                    if (show && countdown > 0) {
+                    if (show && autoplayEnabled && countdown > 0) {
                         Spacer(modifier = Modifier.height(12.dp))
                         Row(
                             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
…h handling

- Add cache invalidation on pull-to-refresh across home, library, music, and newsletter screens
- Improve AudioProgressReporter to avoid duplicate paused progress reports and properly pass item/session/position to reportStopped
- Add video player autoplay cancellation support with configurable countdown
- Move technical info action from detail buttons to dropdown and TV options menus
- Simplify refresh state management by using ViewModel isLoading state instead of local UI state
- Add AudioProgressReporterTest with comprehensive coverage for progress reporting behavior