### PR TITLE
Optimize performance, memory usage, and fix ExoPlayer extractor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.androidx.baselineprofile)
 }
 
 android {
@@ -181,4 +182,11 @@ dependencies {
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test)
     debugImplementation(libs.compose.ui.test.manifest)
+
+    // Generates and merges a Baseline Profile from the :baselineprofile
+    // macrobenchmark module. AGP installs the resulting baseline-prof.txt /
+    // startup-prof into release builds (see P3 in docs/performance-audit.md).
+    // The androidx.baselineprofile 1.5.x consumer plugin (required for AGP 9)
+    // exposes the producer via the `baselineProfile` configuration.
+    "baselineProfile"(project(":baselineprofile"))
 }

--- a/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
@@ -1,5 +1,6 @@
 package com.raulshma.jellyplay
 
+import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
 import coil3.ImageLoader
@@ -139,13 +140,21 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory, Config
         val cacheMb = userPreferencesStore.preferences.value.maxCacheSizeMb
         val cacheSize = if (cacheMb > 0) cacheMb * 1024L * 1024L else 256L * 1024 * 1024
 
+        // Tier the memory-cache budget on device RAM class, mirroring the
+        // EngineDeviceProfile.isLowRamDevice gate already used for trickplay.
+        // On a 1 GB TV stick the default 20% would over-reserve a small heap
+        // competing with MPV/ExoPlayer native buffers.
+        val am = getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val isLowRamDevice = am?.let { it.isLowRamDevice || it.memoryClass <= 256 } ?: false
+        val memoryCachePercent = if (isLowRamDevice) 0.12 else 0.20
+
         ImageLoader.Builder(this)
             .components {
                 add(OkHttpNetworkFetcherFactory(callFactory = { imageClient }))
             }
             .memoryCache {
                 MemoryCache.Builder()
-                    .maxSizePercent(this@JellyPlayApplication, 0.20)
+                    .maxSizePercent(this@JellyPlayApplication, memoryCachePercent)
                     .build()
             }
             .diskCache {

--- a/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
@@ -36,7 +36,14 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory, Config
 
     @Inject lateinit var okHttpClient: OkHttpClient
     @Inject lateinit var userPreferencesStore: com.raulshma.jellyplay.core.datastore.UserPreferencesStore
-    @Inject lateinit var audioPlaybackManager: com.raulshma.jellyplay.core.data.playback.AudioPlaybackManager
+    // javax.inject.Provider defers Hilt construction of AudioPlaybackManager
+    // (and its transitive 14-dep graph: AudioLibraryBrowser,
+    // AudioProgressReporter, AudioCrossfader, QueueUndoStack, LruCache(25), …)
+    // off the main thread until the IO launch block below actually calls
+    // get(). The start() body already offloads its real work to Dispatchers.IO,
+    // so behavior is unchanged; only the construction cost moves off the
+    // cold-start critical path.
+    @Inject lateinit var audioPlaybackManagerProvider: javax.inject.Provider<com.raulshma.jellyplay.core.data.playback.AudioPlaybackManager>
     @Inject lateinit var nowPlayingWidgetUpdater: com.raulshma.jellyplay.widget.NowPlayingWidgetUpdater
     @Inject lateinit var notificationScheduler: NotificationScheduler
     @Inject lateinit var autoDownloadScheduler: com.raulshma.jellyplay.core.data.worker.AutoDownloadScheduler
@@ -53,7 +60,7 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory, Config
         // on the same coroutine (they have no dependency on the groups below).
         applicationScope.launch(Dispatchers.IO) {
             initSentry()
-            audioPlaybackManager.start()
+            audioPlaybackManagerProvider.get().start()
             nowPlayingWidgetUpdater.start()
         }
         // Background schedulers — independent enqueue calls, all KEEP-safe.

--- a/app/src/main/java/com/raulshma/jellyplay/MainActivity.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/MainActivity.kt
@@ -76,10 +76,18 @@ class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
-        // Initialize Cast SDK eagerly while the splash screen is still up, so the
-        // first composition frame doesn't pay the JNI init cost.
+        // Initialize Cast SDK off the main thread. The MediaRouteButton is set
+        // up lazily inside setContent's AndroidView.factory and
+        // CastButtonFactory.setUpMediaRouteButton resolves CastContext lazily,
+        // so deferring the JNI/Play-Services binding here no longer blocks the
+        // main thread before setContent (i.e. while the splash is still being
+        // evaluated). The original "pay it during the splash" intent is
+        // preserved — the splash stays up via setKeepOnScreenCondition until
+        // session restore completes, overlapping the Cast init.
         if (packageManager.hasSystemFeature("com.google.android.gms.cast")) {
-            runCatching { com.google.android.gms.cast.framework.CastContext.getSharedInstance(this) }
+            lifecycleScope.launch {
+                runCatching { com.google.android.gms.cast.framework.CastContext.getSharedInstance(this@MainActivity) }
+            }
         }
         splashScreen.setKeepOnScreenCondition { viewModel.isRestoring.value }
         splashScreen.setOnExitAnimationListener { splashScreenView ->

--- a/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
@@ -377,29 +377,42 @@ private fun MainContent(
             currentRoute is Route.Ambient || currentRoute is Route.Onboarding ||
             currentRoute is Route.PhotoViewer
 
-    val activeTopLevelRoutes: LinkedHashMap<Route, String> = when (homeMode) {
-        HomeMode.VIDEO -> VIDEO_TOP_LEVEL_ROUTES
-        HomeMode.MUSIC -> MUSIC_TOP_LEVEL_ROUTES
-    }.let { routes ->
-        val hidden = preferences.hiddenNavItems
-        val order = preferences.navItemOrder
-        val filtered = routes.filterKeys { route ->
-            route::class.simpleName !in hidden
-        }
-        if (order.isEmpty()) {
-            LinkedHashMap(filtered)
-        } else {
-            val ordered = linkedMapOf<Route, String>()
-            for (name in order) {
-                val entry = filtered.entries.find { it.key::class.simpleName == name }
-                if (entry != null) ordered[entry.key] = entry.value
-            }
-            for (entry in filtered) {
-                if (entry.key::class.simpleName !in order) {
-                    ordered[entry.key] = entry.value
+    // Memoize the route filter+reorder so it only re-runs when homeMode /
+    // hiddenNavItems / navItemOrder actually change. MainContent recomposes
+    // frequently (it reads audioTitle/artist/... for the mini player), so the
+    // previous eager `when{}` allocated a fresh LinkedHashMap + intermediate
+    // entry lists + KClass.simpleName lookups on every recomposition.
+    val activeTopLevelRoutes: LinkedHashMap<Route, String> by remember(
+        homeMode,
+        preferences.hiddenNavItems,
+        preferences.navItemOrder,
+    ) {
+        derivedStateOf {
+            when (homeMode) {
+                HomeMode.VIDEO -> VIDEO_TOP_LEVEL_ROUTES
+                HomeMode.MUSIC -> MUSIC_TOP_LEVEL_ROUTES
+            }.let { routes ->
+                val hidden = preferences.hiddenNavItems
+                val order = preferences.navItemOrder
+                val filtered = routes.filterKeys { route ->
+                    route::class.simpleName !in hidden
+                }
+                if (order.isEmpty()) {
+                    LinkedHashMap(filtered)
+                } else {
+                    val ordered = linkedMapOf<Route, String>()
+                    for (name in order) {
+                        val entry = filtered.entries.find { it.key::class.simpleName == name }
+                        if (entry != null) ordered[entry.key] = entry.value
+                    }
+                    for (entry in filtered) {
+                        if (entry.key::class.simpleName !in order) {
+                            ordered[entry.key] = entry.value
+                        }
+                    }
+                    ordered
                 }
             }
-            ordered
         }
     }
 

--- a/app/src/main/java/com/raulshma/jellyplay/navigation/TvNavigationDrawer.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/navigation/TvNavigationDrawer.kt
@@ -2,6 +2,7 @@ package com.raulshma.jellyplay.navigation
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.Spring
+import androidx.compose.runtime.Stable
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -81,6 +82,10 @@ private const val ExitConfirmationTimeoutMs = 2000L
 // Data + icon mapping
 // ──────────────────────────────────────────────────────────────────────────────
 
+// @Stable (not @Immutable): route is a NavKey marker interface whose impls
+// are not guaranteed immutable — matches the NavigationState precedent for
+// NavKey-holding types.
+@Stable
 data class TvNavItem(
     val route: NavKey,
     val label: String,

--- a/app/src/main/java/com/raulshma/jellyplay/startup/DownloadRecoveryInitializer.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/startup/DownloadRecoveryInitializer.kt
@@ -38,7 +38,7 @@ class DownloadRecoveryInitializer @Inject constructor(
             // will keep it. Replacing here would cancel an active download and
             // risk orphaned partial bytes between the cancel and the new
             // worker's setForeground call.
-            val pending = downloadDao.getDownloadsByStatus(DownloadStatus.PENDING.name)
+            val pending = downloadDao.getRecoveryRows(DownloadStatus.PENDING.name)
             for (download in pending) {
                 val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
                     .setInputData(
@@ -54,7 +54,7 @@ class DownloadRecoveryInitializer @Inject constructor(
                     workRequest,
                 )
             }
-            val stale = downloadDao.getDownloadsByStatus(DownloadStatus.DOWNLOADING.name)
+            val stale = downloadDao.getRecoveryRows(DownloadStatus.DOWNLOADING.name)
             for (download in stale) {
                 downloadDao.updateProgress(download.id, download.downloadedBytes, DownloadStatus.PENDING.name)
                 val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()

--- a/app/src/main/java/com/raulshma/jellyplay/widget/NowPlayingWidget.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/NowPlayingWidget.kt
@@ -19,6 +19,8 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 class NowPlayingWidget : AppWidgetProvider() {
@@ -29,6 +31,15 @@ class NowPlayingWidget : AppWidgetProvider() {
         fun audioPlaybackManager(): AudioPlaybackManager
     }
 
+    /**
+     * Hoisted out of [onAppWidgetOptionsChanged] so the orphaned `SupervisorJob`
+     * graph is not rebuilt on every widget refresh broadcast (the updater can
+     * fire many times per minute during position changes). Mirrors the sibling
+     * `LibraryRecommendationsWidget.refreshScope` pattern — cancelled in
+     * [onDisabled] when the last widget instance is removed.
+     */
+    private val refreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     override fun onUpdate(
         context: Context,
         appWidgetManager: AppWidgetManager,
@@ -37,6 +48,11 @@ class NowPlayingWidget : AppWidgetProvider() {
         for (appWidgetId in appWidgetIds) {
             updateAppWidget(context, appWidgetManager, appWidgetId)
         }
+    }
+
+    override fun onDisabled(context: Context?) {
+        super.onDisabled(context)
+        refreshScope.cancel()
     }
 
     override fun onAppWidgetOptionsChanged(
@@ -60,28 +76,33 @@ class NowPlayingWidget : AppWidgetProvider() {
 
         val artUrl = manager.albumArtUrl.value
         val pending = goAsync()
-        val scope = CoroutineScope(Dispatchers.IO)
-        scope.launch {
-            val art = if (!artUrl.isNullOrBlank()) {
-                WidgetImageLoader.loadPoster(context.applicationContext, artUrl)
-            } else null
+        refreshScope.launch {
+            try {
+                val art = if (!artUrl.isNullOrBlank()) {
+                    WidgetImageLoader.loadPoster(context.applicationContext, artUrl)
+                } else null
 
-            val mainHandler = android.os.Handler(context.mainLooper)
-            mainHandler.post {
-                val views = RemoteViews(context.packageName, R.layout.now_playing_widget)
-                wireClickIntents(context, views)
-                bindState(
-                    views = views,
-                    title = title,
-                    subtitle = artist.ifBlank { null },
-                    isPlaying = isPlaying,
-                    albumArt = art,
-                    positionMs = position,
-                    durationMs = duration,
-                    isEmptyState = itemId == null,
-                )
-                applyResponsiveLayout(context, appWidgetManager, appWidgetId, views)
-                appWidgetManager.updateAppWidget(appWidgetId, views)
+                val mainHandler = android.os.Handler(context.mainLooper)
+                mainHandler.post {
+                    val views = RemoteViews(context.packageName, R.layout.now_playing_widget)
+                    wireClickIntents(context, views)
+                    bindState(
+                        views = views,
+                        title = title,
+                        subtitle = artist.ifBlank { null },
+                        isPlaying = isPlaying,
+                        albumArt = art,
+                        positionMs = position,
+                        durationMs = duration,
+                        isEmptyState = itemId == null,
+                    )
+                    applyResponsiveLayout(context, appWidgetManager, appWidgetId, views)
+                    appWidgetManager.updateAppWidget(appWidgetId, views)
+                    pending.finish()
+                }
+            } catch (_: Exception) {
+                // Ensure the goAsync() window always closes even if poster load
+                // fails — otherwise the system may ANR the widget host.
                 pending.finish()
             }
         }

--- a/app/src/main/java/com/raulshma/jellyplay/widget/WidgetImageLoader.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/WidgetImageLoader.kt
@@ -79,17 +79,24 @@ object WidgetImageLoader {
         val density = context.resources.displayMetrics.density
         val cornerRadiusPx = cornerRadiusDp * density
         val output = Bitmap.createBitmap(bitmap.width, bitmap.height, Bitmap.Config.ARGB_8888)
-        val canvas = Canvas(output)
-        val paint = Paint().apply {
-            isAntiAlias = true
-            color = 0xff424242.toInt()
+        try {
+            val canvas = Canvas(output)
+            val paint = Paint().apply {
+                isAntiAlias = true
+                color = 0xff424242.toInt()
+            }
+            val rect = Rect(0, 0, bitmap.width, bitmap.height)
+            val rectF = RectF(rect)
+            canvas.drawARGB(0, 0, 0, 0)
+            canvas.drawRoundRect(rectF, cornerRadiusPx, cornerRadiusPx, paint)
+            paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
+            canvas.drawBitmap(bitmap, rect, rect, paint)
+        } finally {
+            // The input bitmap is no longer referenced once it has been drawn
+            // into `output`; recycle it promptly to avoid N pairs of bitmaps
+            // briefly coexisting during concurrent `preloadPosters` fetches.
+            bitmap.recycle()
         }
-        val rect = Rect(0, 0, bitmap.width, bitmap.height)
-        val rectF = RectF(rect)
-        canvas.drawARGB(0, 0, 0, 0)
-        canvas.drawRoundRect(rectF, cornerRadiusPx, cornerRadiusPx, paint)
-        paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
-        canvas.drawBitmap(bitmap, rect, rect, paint)
         return output
     }
 }

--- a/app/src/main/java/com/raulshma/jellyplay/widget/WidgetImageLoader.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/WidgetImageLoader.kt
@@ -9,6 +9,7 @@ import android.graphics.PorterDuffXfermode
 import android.graphics.Rect
 import android.graphics.RectF
 import coil3.imageLoader
+import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import coil3.toBitmap
@@ -49,6 +50,17 @@ object WidgetImageLoader {
                         .data(url)
                         .size(WIDGET_IMAGE_TARGET, WIDGET_IMAGE_TARGET)
                         .allowHardware(false)
+                        // The widget needs its own private bitmap instance: the
+                        // default `toBitmap()` unwrap returns the *shared* Bitmap
+                        // held in Coil's memory cache (and handed out to Compose
+                        // `AsyncImage` consumers). Recycling that shared bitmap
+                        // in [applyRoundedCorners] then crashed any Compose
+                        // painter still drawing the same URL with
+                        // "Canvas: trying to use a recycled bitmap". Disabling
+                        // the memory cache for the widget request guarantees the
+                        // returned bitmap is a fresh decode owned only by us, so
+                        // recycling it after rounding is safe.
+                        .memoryCachePolicy(CachePolicy.DISABLED)
                         .build()
                     val image = context.imageLoader.execute(request).image
                     image?.toBitmap()?.let { applyRoundedCorners(context, it, cornerRadiusDp) }

--- a/app/src/main/java/com/raulshma/jellyplay/widget/config/WidgetConfigActivity.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/config/WidgetConfigActivity.kt
@@ -178,7 +178,7 @@ private fun ConfigScreen(
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
             if (isLibraryKind) {
-                items(LibraryOptions) { option ->
+                items(LibraryOptions, key = { option -> option.source.name }) { option ->
                     OptionRow(
                         title = stringResource(option.titleRes),
                         description = stringResource(option.descriptionRes),
@@ -186,7 +186,7 @@ private fun ConfigScreen(
                     ) { viewModel.selectLibrarySource(option.source) }
                 }
             } else {
-                items(SeerrOptions) { option ->
+                items(SeerrOptions, key = { option -> option.source.name }) { option ->
                     OptionRow(
                         title = stringResource(option.titleRes),
                         description = stringResource(option.descriptionRes),

--- a/app/src/tv/java/com/raulshma/jellyplay/screensaver/DreamImageProvider.kt
+++ b/app/src/tv/java/com/raulshma/jellyplay/screensaver/DreamImageProvider.kt
@@ -11,6 +11,11 @@ import com.raulshma.jellyplay.core.model.DreamImageCategory
 import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlin.random.Random
 
@@ -55,15 +60,38 @@ class DreamImageProvider(
             .shuffled(Random)
     }
 
-    fun prefetchImages(urls: List<String>) {
-        urls.forEach { url ->
-            val request = ImageRequest.Builder(context)
-                .data(url)
-                .size(Size(1920, 1080))
-                .allowHardware(true)
-                .build()
-            imageLoader.enqueue(request)
+    /**
+     * Prefetches backdrop bitmaps with bounded concurrency. The screensaver
+     * path runs on the project's explicitly targeted low-RAM TV sticks, where
+     * 50 concurrent 1920×1080 hardware-bitmap fetches can each hold ~8 MB of
+     * native texture. A small [Semaphore] gates peak parallelism — visual
+     * behavior is identical, only peak memory is bounded.
+     */
+    suspend fun prefetchImages(urls: List<String>) {
+        if (urls.isEmpty()) return
+        val gate = Semaphore(MAX_PREFETCH_CONCURRENCY)
+        coroutineScope {
+            urls.map { url ->
+                async(Dispatchers.IO) {
+                    gate.withPermit {
+                        val request = ImageRequest.Builder(context)
+                            .data(url)
+                            .size(Size(1920, 1080))
+                            .allowHardware(true)
+                            .build()
+                        // execute() suspends until decode completes (or fails),
+                        // unlike enqueue() which fires-and-forgets — so the
+                        // semaphore actually bounds in-flight decodes.
+                        runCatching { imageLoader.execute(request) }
+                    }
+                }
+            }.awaitAll()
         }
+    }
+
+    private companion object {
+        /** Bounds concurrent 1920×1080 hardware-bitmap decodes for the screensaver. */
+        const val MAX_PREFETCH_CONCURRENCY = 4
     }
 
     private fun DreamImageCategory.toMediaTypes(): List<MediaType> = when (this) {

--- a/app/src/tv/java/com/raulshma/jellyplay/screensaver/KenBurnsEffect.kt
+++ b/app/src/tv/java/com/raulshma/jellyplay/screensaver/KenBurnsEffect.kt
@@ -53,6 +53,19 @@ fun KenBurnsImage(
 ) {
     val transform = remember(imageUrl) { KenBurnsTransform.random() }
 
+    // Build the ImageRequest once per imageUrl. Previously this was constructed
+    // inline in the composable body, so the per-frame `progress` recomposition
+    // (driven by rememberInfiniteTransition at ~60 Hz) rebuilt thousands of
+    // short-lived ImageRequest/Size/data-wrapper objects per minute while the
+    // screensaver was active. Coil dedupes by URL, so the rebuild was wasted.
+    val context = LocalContext.current
+    val imageRequest = remember(imageUrl) {
+        ImageRequest.Builder(context)
+            .data(imageUrl)
+            .size(1920, 1080)
+            .build()
+    }
+
     if (enabled) {
         val infiniteTransition = rememberInfiniteTransition(label = "kenBurns")
         val progress by infiniteTransition.animateFloat(
@@ -84,10 +97,7 @@ fun KenBurnsImage(
                 },
         ) {
             AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(imageUrl)
-                    .size(1920, 1080)
-                    .build(),
+                model = imageRequest,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
@@ -95,10 +105,7 @@ fun KenBurnsImage(
         }
     } else {
         AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(imageUrl)
-                .size(1920, 1080)
-                .build(),
+            model = imageRequest,
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = modifier.fillMaxSize(),

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.test)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.androidx.baselineprofile.producer)
 }
 
 android {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/cast/dlna/SsdpDiscovery.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/cast/dlna/SsdpDiscovery.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.net.DatagramPacket
 import java.net.DatagramSocket
 import java.net.InetAddress
@@ -105,7 +104,7 @@ class SsdpDiscovery(
         }
     }
 
-    private suspend fun performSearch() = withContext(Dispatchers.IO) {
+    private suspend fun performSearch() {
         val responses = mutableMapOf<String, DiscoveredDevice>()
 
         sendAndCollect(MSEARCH_MEDIA_RENDERER) { location, usn, st ->

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/offline/OfflineModeManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/offline/OfflineModeManager.kt
@@ -42,13 +42,19 @@ class OfflineModeManager @Inject constructor(
 
     init {
         scope.launch {
+            // Combine the two narrow per-key preference flows instead of the
+            // full ~150-field `preferences` StateFlow. A settings-screen round
+            // trip elsewhere in the app previously re-awakened this collector
+            // and re-derived offline mode even though neither offline flag
+            // changed.
             combine(
-                userPreferencesStore.preferences,
-                networkMonitor.networkStatus
-            ) { prefs, status ->
-                Pair(prefs, status)
-            }.collect { (prefs, status) ->
-                if (prefs.manualOfflineEnabled) {
+                userPreferencesStore.manualOfflineEnabled,
+                userPreferencesStore.autoOfflineEnabled,
+                networkMonitor.networkStatus,
+            ) { manualOffline, autoOffline, status ->
+                Triple(manualOffline, autoOffline, status)
+            }.collect { (manualOffline, autoOffline, status) ->
+                if (manualOffline) {
                     _offlineMode.value = OfflineMode.OFFLINE_MANUAL
                 } else {
                     val current = _offlineMode.value
@@ -58,7 +64,7 @@ class OfflineModeManager @Inject constructor(
 
                     val nowOffline = status == NetworkStatus.Offline
                     if (nowOffline) {
-                        if (prefs.autoOfflineEnabled) {
+                        if (autoOffline) {
                             _offlineMode.value = OfflineMode.OFFLINE_AUTO
                         } else {
                             _offlineMode.value = OfflineMode.ONLINE

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
@@ -84,6 +84,17 @@ class AudioPlaybackManager @Inject constructor(
 
     private val queuePreWarmPermits = Semaphore(8)
 
+    companion object {
+        // Position-poll interval while playback is actively progressing. Matches
+        // the video side's default ticker cadence (≈4 Hz).
+        private const val POSITION_POLL_INTERVAL_MS = 250L
+        // While paused, the position/lyrics/crossfade work in startPositionTracking
+        // is a no-op; re-check playback state at this interval (mirrors
+        // EnginePositionTicker.POSITION_PAUSED_RECHECK_MS) instead of polling
+        // at POSITION_POLL_INTERVAL_MS for the whole paused session.
+        private const val POSITION_PAUSED_RECHECK_MS = 2_500L
+    }
+
     private var exoPlayer: ExoPlayer? = null
     private var currentPreferences = com.raulshma.jellyplay.core.model.UserPreferences()
 
@@ -380,11 +391,13 @@ class AudioPlaybackManager @Inject constructor(
                 }
             }
         }
-        scope.launch {
-            _repeatMode.collect { mode ->
-                exoPlayer?.repeatMode = getExoPlayerRepeatMode(mode)
-            }
-        }
+        // Note: there is intentionally no `_repeatMode.collect { exoPlayer?.repeatMode = ... }`
+        // here. `setRepeatMode()` sets `exoPlayer.repeatMode` inline, the player
+        // listener (`onRepeatModeChanged`) is the single source of truth for
+        // syncing `_repeatMode` back from the player, and `ensureExoPlayer()`
+        // restores `player.repeatMode` from `_repeatMode.value` on creation.
+        // A collector would just re-apply the same value (redundant JNI call)
+        // and live for the singleton's lifetime.
     }
 
     fun setGaplessEnabled(enabled: Boolean) {
@@ -1390,27 +1403,43 @@ class AudioPlaybackManager @Inject constructor(
             var bandwidthSampleTick = 0
             var lastBufferedPosition = 0L
             while (true) {
-                exoPlayer?.let { player ->
-                    val pos = player.currentPosition
-                    val dur = player.duration.coerceAtLeast(0L)
-                    // A→B loop: when both markers are set and we reach B while
-                    // playing, jump back to A.
-                    val abEnd = _abLoopEndMs.value
-                    val abStart = _abLoopStartMs.value
-                    if (abEnd != null && abStart != null && player.isPlaying && pos >= abEnd) {
-                        player.seekTo(abStart)
-                    }
-                    if (pos != lastPosition) {
-                        _currentPosition.value = pos
-                        lastPosition = pos
-                    }
-                    if (dur != lastDuration) {
-                        _duration.value = dur
-                        lastDuration = dur
-                    }
-                    if (lyricsManager.lyrics.value.isNotEmpty()) {
-                        lyricsManager.updateCurrentLyricIndex(_currentPosition.value)
-                    }
+                val player = exoPlayer
+                if (player == null) {
+                    // No player yet — wait briefly and re-check rather than busy-looping.
+                    delay(250)
+                    continue
+                }
+                // While paused, the position/duration/lyrics/crossfade work below
+                // is a no-op (position doesn't move, crossfader only runs when
+                // playing, lyrics index is stable). Suspend reactively on the
+                // play→resume edge instead of polling at 4 Hz for the whole
+                // paused session — mirrors the EnginePositionTicker pattern on
+                // the video side and removes continuous background CPU/battery.
+                if (!player.isPlaying) {
+                    delay(POSITION_PAUSED_RECHECK_MS)
+                    continue
+                }
+
+                val pos = player.currentPosition
+                val dur = player.duration.coerceAtLeast(0L)
+                // A→B loop: when both markers are set and we reach B while
+                // playing, jump back to A.
+                val abEnd = _abLoopEndMs.value
+                val abStart = _abLoopStartMs.value
+                if (abEnd != null && abStart != null && player.isPlaying && pos >= abEnd) {
+                    player.seekTo(abStart)
+                }
+                if (pos != lastPosition) {
+                    _currentPosition.value = pos
+                    lastPosition = pos
+                }
+                if (dur != lastDuration) {
+                    _duration.value = dur
+                    lastDuration = dur
+                }
+                if (lyricsManager.lyrics.value.isNotEmpty()) {
+                    lyricsManager.updateCurrentLyricIndex(_currentPosition.value)
+                }
 
                 if (_crossfadeDurationMs.value > 0 && player.isPlaying && _repeatMode.value != 2) {
                     crossfader.maybeStart()
@@ -1430,8 +1459,7 @@ class AudioPlaybackManager @Inject constructor(
                         }
                     }
                 }
-            }
-            delay(250)
+                delay(POSITION_POLL_INTERVAL_MS)
             }
         }
     }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/JellyPlayNotificationProvider.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/JellyPlayNotificationProvider.kt
@@ -52,6 +52,12 @@ class JellyPlayNotificationProvider(
     fun release() {
         scope.cancel()
         synchronized(bitmapLock) {
+            // Mirror NowPlayingWidgetUpdater.stop(): explicitly recycle the
+            // cached artwork bitmap rather than waiting for GC to reclaim the
+            // native allocation. Safe because release() is invoked at service
+            // teardown, after the notification (which held this bitmap via
+            // setLargeIcon) has already been torn down.
+            cachedBitmap?.let { if (!it.isRecycled) it.recycle() }
             cachedBitmap = null
             cachedArtworkUri = null
         }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/ThemeMusicPlayer.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/ThemeMusicPlayer.kt
@@ -80,6 +80,11 @@ class ThemeMusicPlayer @Inject constructor(
     /**
      * Stops and clears any playing theme music. Safe to call when nothing is
      * playing.
+     *
+     * The underlying [ExoPlayer] is released (not just stopped) because it is
+     * cheap to recreate on the next [ensurePlayer] and the singleton scope
+     * would otherwise retain native media codecs, audio sink and buffers for
+     * the entire app process lifetime.
      */
     fun stop() {
         fetchJob?.cancel()
@@ -88,7 +93,9 @@ class ThemeMusicPlayer @Inject constructor(
         player?.let {
             it.stop()
             it.clearMediaItems()
+            it.release()
         }
+        player = null
     }
 
     private fun ensurePlayer(): ExoPlayer {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/AuthRepositoryImpl.kt
@@ -103,8 +103,7 @@ class AuthRepositoryImpl @Inject constructor(
         if (userEntity != null) {
             val user = userEntity.toUserInfo(server.address)
             apiClient.setUser(user)
-            preferencesStore.setActiveServer(serverId)
-            preferencesStore.setActiveUser(userEntity.userId)
+            preferencesStore.setActiveSession(serverId, userEntity.userId)
             database.withTransaction {
                 serverDao.updateServer(serverEntity.copy(lastConnected = System.currentTimeMillis()))
                 userDao.updateUser(userEntity.copy(lastConnected = System.currentTimeMillis()))
@@ -256,8 +255,7 @@ class AuthRepositoryImpl @Inject constructor(
                 // Don't log the raw server/user GUIDs — they survive into
                 // release builds and can be used for cross-session correlation.
                 Log.w("AuthRepository", "restoreSession: server not found in DB")
-                preferencesStore.setActiveServer("")
-                preferencesStore.setActiveUser("")
+                preferencesStore.setActiveSession("", "")
                 return@runCatching
             }
             val server = serverEntity.toServerInfo()
@@ -324,8 +322,7 @@ class AuthRepositoryImpl @Inject constructor(
         apiClient.disconnect()
         apiClient.setServer(server.toServerInfo())
         apiClient.setUser(userEntity.toUserInfo(server.address))
-        preferencesStore.setActiveServer(server.id)
-        preferencesStore.setActiveUser(userId)
+        preferencesStore.setActiveSession(server.id, userId)
         database.withTransaction {
             userDao.updateUser(userEntity.copy(lastConnected = System.currentTimeMillis()))
             serverDao.updateServer(
@@ -361,7 +358,9 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUsersForServer(serverId: String): List<UserInfo> {
-        return userDao.getUsersForServer(serverId).first().map { it.toUserInfo() }
+        // Use the one-shot DAO query instead of `.first()` on the Flow, which
+        // would cancel a fresh Flow emission (full query cost) on every call.
+        return userDao.getUsersForServerOnce(serverId).map { it.toUserInfo() }
     }
 
     private suspend fun persistSession(server: ServerInfo, user: UserInfo, fallbackUsername: String = "") {
@@ -401,8 +400,7 @@ class AuthRepositoryImpl @Inject constructor(
                 )
             )
         }
-        preferencesStore.setActiveServer(server.id)
-        preferencesStore.setActiveUser(user.id)
+        preferencesStore.setActiveSession(server.id, user.id)
     }
 
     private fun ServerEntity.toServerInfo() = ServerInfo(

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepository.kt
@@ -30,6 +30,7 @@ interface DownloadRepository {
         seasonName: String? = null,
         episodeNumber: Int? = null,
         seasonNumber: Int? = null,
+        container: String? = null,
     ): Result<DownloadItem>
 
     suspend fun cancelDownload(id: String): Result<Unit>

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
@@ -115,17 +115,16 @@ class DownloadRepositoryImpl @Inject constructor(
 
         val prefs = preferencesStore.preferences.first()
         val maxBytes = prefs.maxCacheSizeMb.toLong() * 1024 * 1024
-        if (maxBytes > 0) {
+        // Enforce the user-facing download storage cap (in GB). 0 = unlimited.
+        val maxBytesFromGb = prefs.maxDownloadStorageGb.toLong() * 1024L * 1024L * 1024L
+        // Compute the current downloaded bytes once and compare against both
+        // caps (was two identical SUM queries back-to-back when both caps set).
+        if (maxBytes > 0 || maxBytesFromGb > 0) {
             val currentBytes = downloadDao.getTotalDownloadedBytes()
-            if (currentBytes >= maxBytes) {
+            if (maxBytes > 0 && currentBytes >= maxBytes) {
                 throw IllegalStateException("Download limit reached (${prefs.maxCacheSizeMb} MB). Free up space in Settings › Storage or increase the limit.")
             }
-        }
-        // Enforce the user-facing download storage cap (in GB). 0 = unlimited.
-        if (prefs.maxDownloadStorageGb > 0) {
-            val maxBytesFromGb = prefs.maxDownloadStorageGb.toLong() * 1024L * 1024L * 1024L
-            val currentBytes = downloadDao.getTotalDownloadedBytes()
-            if (currentBytes >= maxBytesFromGb) {
+            if (maxBytesFromGb > 0 && currentBytes >= maxBytesFromGb) {
                 throw IllegalStateException("Download storage limit reached (${prefs.maxDownloadStorageGb} GB). Free up space in Settings › Storage or increase the limit.")
             }
         }
@@ -285,17 +284,17 @@ class DownloadRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getDownloadedEpisodeIdsForSeries(seriesId: String): Set<String> {
-        return withContext(Dispatchers.IO) {
-            downloadDao.getDownloadsForSeries(seriesId)
-                .mapNotNull { it.mediaItemId }
-                .toSet()
-        }
-    }
+    override suspend fun getDownloadedEpisodeIdsForSeries(seriesId: String): Set<String> =
+        // Room suspend functions already switch to the Room query executor, so
+        // the wrapping `withContext(Dispatchers.IO)` was an unnecessary thread-
+        // pool handoff. (The withContext(Dispatchers.IO) calls that wrap actual
+        // File/FileOutputStream I/O elsewhere in this file are correct and stay.)
+        downloadDao.getDownloadsForSeries(seriesId)
+            .mapNotNull { it.mediaItemId }
+            .toSet()
 
-    override suspend fun getDownloadedSeriesIds(): List<String> = withContext(Dispatchers.IO) {
+    override suspend fun getDownloadedSeriesIds(): List<String> =
         downloadDao.getDownloadedSeriesIds()
-    }
 
     override suspend fun downloadSeries(
         seriesId: String,

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
@@ -95,6 +95,7 @@ class DownloadRepositoryImpl @Inject constructor(
         seasonName: String?,
         episodeNumber: Int?,
         seasonNumber: Int?,
+        container: String?,
     ): Result<DownloadItem> = runCatching {
         val existing = downloadDao.getDownloadByMediaItemId(mediaItemId)
         if (existing != null) {
@@ -156,7 +157,15 @@ class DownloadRepositoryImpl @Inject constructor(
         val id = UUID.randomUUID().toString()
         val dir = baseDir
         val safeName = name.replace(FILENAME_SANITIZE_REGEX, "_")
-        val extension = if (isAudioType) "mp3" else "mp4"
+        // Prefer the original container reported by the Jellyfin MediaSource so
+        // the on-disk extension reflects the real bytes — ExoPlayer selects its
+        // extractor from the URI extension and hangs silently when the extension
+        // lies (e.g. an MKV stream saved as `.mp4`). Sanitize and fall back to
+        // the legacy hardcoded extension for audio/video when the container is
+        // missing or unsafe (path-traversal / weird chars).
+        val extension = container
+            ?.takeIf { it.isNotBlank() && FILENAME_CONTAINER_REGEX.matches(it) }
+            ?: if (isAudioType) "mp3" else "mp4"
         val filePath = File(dir, "${safeName}_${id.take(8)}.$extension").absolutePath
 
         val entity = DownloadEntity(
@@ -178,6 +187,7 @@ class DownloadRepositoryImpl @Inject constructor(
             seasonName = seasonName,
         episodeNumber = episodeNumber,
         seasonNumber = seasonNumber,
+        container = container,
     )
     downloadDao.insertDownload(entity)
     entity.toDownloadItem()
@@ -383,6 +393,7 @@ class DownloadRepositoryImpl @Inject constructor(
                                         seasonName = season.name,
                                         episodeNumber = episode.episodeNumber,
                                         seasonNumber = episode.seasonNumber,
+                                        container = source?.container,
                                     ).getOrNull()
 
                                     if (download != null) {
@@ -810,6 +821,7 @@ class DownloadRepositoryImpl @Inject constructor(
         seasonNumber = seasonNumber,
         errorMessage = errorMessage,
         priority = priority,
+        container = container,
     )
 
     /**
@@ -829,6 +841,12 @@ class DownloadRepositoryImpl @Inject constructor(
     companion object {
         private const val TAG = "DownloadRepository"
         private val FILENAME_SANITIZE_REGEX = Regex("[^a-zA-Z0-9.\\-]")
+
+        // Container strings from Jellyfin (mkv, mp4, ts, webm, flv, mov, ...).
+        // Constrained to 2-8 alphanumerics so a malformed/missing value can
+        // never leak into the on-disk filename; the caller falls back to the
+        // legacy mp4/mp3 default otherwise.
+        private val FILENAME_CONTAINER_REGEX = Regex("[A-Za-z0-9]{2,8}")
         private val json = Json { ignoreUnknownKeys = true }
     }
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/ItemPlaybackPreferenceRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/ItemPlaybackPreferenceRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.raulshma.jellyplay.core.data.repository
 
+import androidx.room.withTransaction
+import com.raulshma.jellyplay.core.database.JellyPlayDatabase
 import com.raulshma.jellyplay.core.database.dao.ItemPlaybackPreferenceDao
 import com.raulshma.jellyplay.core.database.entity.ItemPlaybackPreferenceEntity
 import com.raulshma.jellyplay.core.model.ItemPlaybackPreference
@@ -10,6 +12,7 @@ import javax.inject.Singleton
 @Singleton
 class ItemPlaybackPreferenceRepositoryImpl @Inject constructor(
     private val dao: ItemPlaybackPreferenceDao,
+    private val database: JellyPlayDatabase,
 ) : ItemPlaybackPreferenceRepository {
 
     override suspend fun get(scope: PlaybackPrefScope, key: String): ItemPlaybackPreference? =
@@ -22,33 +25,37 @@ class ItemPlaybackPreferenceRepositoryImpl @Inject constructor(
         subtitleLanguage: String?,
         dialogueBoostStrength: com.raulshma.jellyplay.core.model.EffectStrength?,
     ) {
-        val existing = dao.getByKey(scope.name, key)
-        // `save` treats a null argument as "leave untouched" (preserve the
-        // existing value for that field). Explicit single-field clearing goes
-        // through the dedicated `clear*` methods so "clear" and "not provided"
-        // remain distinguishable.
-        val mergedAudio = audioLanguage ?: existing?.audioLanguage
-        val mergedSub = subtitleLanguage ?: existing?.subtitleLanguage
-        val mergedBoost = dialogueBoostStrength ?: existing?.dialogueBoostStrength?.let {
-            runCatching { com.raulshma.jellyplay.core.model.EffectStrength.valueOf(it) }.getOrNull()
-        }
-        // A row with nothing set carries no preference — drop it so the table
-        // stays tidy and `get` returns null (i.e. "inherit global").
-        if (mergedAudio == null && mergedSub == null && mergedBoost == null) {
-            dao.deleteByKey(scope.name, key)
-            return
-        }
-        dao.upsert(
-            ItemPlaybackPreferenceEntity(
-                id = existing?.id ?: 0,
-                scope = scope.name,
-                key = key,
-                audioLanguage = mergedAudio,
-                subtitleLanguage = mergedSub,
-                dialogueBoostStrength = mergedBoost?.name,
-                updatedAt = System.currentTimeMillis(),
+        // Wrap the read-merge-write in a transaction so two concurrent `save`
+        // calls for the same (scope, key) can't clobber each other's merge.
+        database.withTransaction {
+            val existing = dao.getByKey(scope.name, key)
+            // `save` treats a null argument as "leave untouched" (preserve the
+            // existing value for that field). Explicit single-field clearing goes
+            // through the dedicated `clear*` methods so "clear" and "not provided"
+            // remain distinguishable.
+            val mergedAudio = audioLanguage ?: existing?.audioLanguage
+            val mergedSub = subtitleLanguage ?: existing?.subtitleLanguage
+            val mergedBoost = dialogueBoostStrength ?: existing?.dialogueBoostStrength?.let {
+                runCatching { com.raulshma.jellyplay.core.model.EffectStrength.valueOf(it) }.getOrNull()
+            }
+            // A row with nothing set carries no preference — drop it so the table
+            // stays tidy and `get` returns null (i.e. "inherit global").
+            if (mergedAudio == null && mergedSub == null && mergedBoost == null) {
+                dao.deleteByKey(scope.name, key)
+                return@withTransaction
+            }
+            dao.upsert(
+                ItemPlaybackPreferenceEntity(
+                    id = existing?.id ?: 0,
+                    scope = scope.name,
+                    key = key,
+                    audioLanguage = mergedAudio,
+                    subtitleLanguage = mergedSub,
+                    dialogueBoostStrength = mergedBoost?.name,
+                    updatedAt = System.currentTimeMillis(),
+                )
             )
-        )
+        }
     }
 
     override suspend fun clearAudioLanguage(scope: PlaybackPrefScope, key: String) {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
@@ -4,7 +4,6 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import android.util.Log
-import com.raulshma.jellyplay.core.data.cache.TtlCache
 import com.raulshma.jellyplay.core.database.dao.LyricsCacheDao
 import com.raulshma.jellyplay.core.database.entity.LyricsCacheEntity
 import com.raulshma.jellyplay.core.data.paging.FavoritesPagingSource
@@ -15,6 +14,7 @@ import com.raulshma.jellyplay.core.model.DvrTimer
 import com.raulshma.jellyplay.core.model.EpgGuide
 import com.raulshma.jellyplay.core.model.Genre
 import com.raulshma.jellyplay.core.model.HomeSection
+import com.raulshma.jellyplay.core.model.TtlCache
 import com.raulshma.jellyplay.core.model.HomeSectionType
 import com.raulshma.jellyplay.core.model.LibraryFolder
 import com.raulshma.jellyplay.core.model.LiveTvChannel

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/OfflineRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/OfflineRepositoryImpl.kt
@@ -1,6 +1,10 @@
 package com.raulshma.jellyplay.core.data.repository
 
 import androidx.room.withTransaction
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import com.raulshma.jellyplay.core.database.JellyPlayDatabase
 import com.raulshma.jellyplay.core.database.dao.DownloadDao
 import com.raulshma.jellyplay.core.database.dao.OfflineMediaDao
@@ -138,13 +142,7 @@ class OfflineRepositoryImpl @Inject constructor(
 
     override suspend fun deleteOfflineSeries(seriesId: String) {
         val downloads = downloadDao.getDownloadsForSeries(seriesId)
-        for (download in downloads) {
-            if (download.downloadPath.isNotBlank()) {
-                val file = java.io.File(download.downloadPath)
-                if (file.exists()) file.delete()
-                DownloadArtifacts.cleanup(file.parentFile)
-            }
-        }
+        deleteArtifactsParallel(downloads.map { it.downloadPath })
         database.withTransaction {
             val ids = downloads.map { it.id }
             if (ids.isNotEmpty()) downloadDao.deleteDownloadsByIds(ids)
@@ -155,19 +153,33 @@ class OfflineRepositoryImpl @Inject constructor(
 
     override suspend fun deleteOfflineSeason(seasonId: String) {
         val downloads = downloadDao.getDownloadsForSeason(seasonId)
-        for (download in downloads) {
-            if (download.downloadPath.isNotBlank()) {
-                val file = java.io.File(download.downloadPath)
-                if (file.exists()) file.delete()
-                DownloadArtifacts.cleanup(file.parentFile)
-            }
-        }
+        deleteArtifactsParallel(downloads.map { it.downloadPath })
         database.withTransaction {
             val ids = downloads.map { it.id }
             if (ids.isNotEmpty()) downloadDao.deleteDownloadsByIds(ids)
             offlineMediaDao.deleteBySeasonId(seasonId)
         }
         cleanupOrphans()
+    }
+
+    /**
+     * Deletes downloaded artifact files concurrently (was a serial per-episode
+     * `File.delete()` + `cleanup()` loop — for a 100-episode series that was
+     * 100+ serial FS syscalls). Runs on Dispatchers.IO; the subsequent DB
+     * transaction does not depend on the file deletion result.
+     */
+    private suspend fun deleteArtifactsParallel(downloadPaths: List<String>) {
+        val paths = downloadPaths.filter { it.isNotBlank() }
+        if (paths.isEmpty()) return
+        coroutineScope {
+            paths.map { path ->
+                async(Dispatchers.IO) {
+                    val file = java.io.File(path)
+                    if (file.exists()) file.delete()
+                    DownloadArtifacts.cleanup(file.parentFile)
+                }
+            }.awaitAll()
+        }
     }
 
     override suspend fun cleanupOrphans() {
@@ -180,9 +192,9 @@ class OfflineRepositoryImpl @Inject constructor(
         percentage: Double,
         isPlayed: Boolean,
     ) {
-        // Only record progress for items actually in the offline store; a server-
-        // only item has no offline row to update.
-        if (offlineMediaDao.getById(itemId) == null) return
+        // The UPDATE's `WHERE id = :itemId` already no-ops for a server-only
+        // item (no offline row), so the previous `getById` guard was a 28-column
+        // SELECT * on every playback-progress tick just to null-check existence.
         offlineMediaDao.updatePlaybackProgress(
             itemId = itemId,
             positionTicks = positionTicks,

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/PlaybackRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/PlaybackRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.raulshma.jellyplay.core.data.repository
 
-import com.raulshma.jellyplay.core.data.cache.TtlCache
 import com.raulshma.jellyplay.core.model.CreditTimestamps
 import com.raulshma.jellyplay.core.model.CultureInfo
 import com.raulshma.jellyplay.core.model.IntroTimestamps
@@ -14,6 +13,7 @@ import com.raulshma.jellyplay.core.model.PlaybackStartInfo
 import com.raulshma.jellyplay.core.model.PlayerType
 import com.raulshma.jellyplay.core.model.RemoteSubtitleInfo
 import com.raulshma.jellyplay.core.model.ResolvedPlayback
+import com.raulshma.jellyplay.core.model.TtlCache
 import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SearchHistoryRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SearchHistoryRepository.kt
@@ -32,14 +32,13 @@ class SearchHistoryRepositoryImpl @Inject constructor(
 
     override suspend fun saveQuery(query: String, userId: String) {
         if (query.trim().length < 2) return
-        dao.insert(
+        dao.insertAndEvict(
             SearchHistoryEntity(
                 query = query.trim(),
                 userId = userId,
                 searchedAt = System.currentTimeMillis(),
             )
         )
-        dao.evictOldest(userId, keepCount = 50)
     }
 
     override suspend fun deleteById(id: Long) {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeenMediaRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeenMediaRepositoryImpl.kt
@@ -10,10 +10,22 @@ class SeenMediaRepositoryImpl @Inject constructor(
     private val seenMediaDao: SeenMediaDao,
 ) : SeenMediaRepository {
 
+    private companion object {
+        /** SQLite allows at most 999 bound params per statement; stay safely under. */
+        const val SEEN_IDS_QUERY_CHUNK_SIZE = 900
+    }
+
     override suspend fun count(): Int = seenMediaDao.count()
 
-    override suspend fun getSeenIds(itemIds: List<String>): Set<String> =
-        seenMediaDao.getSeenIds(itemIds).toSet()
+    override suspend fun getSeenIds(itemIds: List<String>): Set<String> {
+        // Android SQLite has a hard limit of 999 bound parameters per statement.
+        // Chunk the input so a >999-element library does not throw
+        // SQLiteBindOrColumnIndexOutOfRangeException.
+        if (itemIds.isEmpty()) return emptySet()
+        return itemIds.chunked(SEEN_IDS_QUERY_CHUNK_SIZE)
+            .flatMap { seenMediaDao.getSeenIds(it) }
+            .toSet()
+    }
 
     override suspend fun markAsSeen(
         itemId: String,

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeerrRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeerrRepositoryImpl.kt
@@ -1,9 +1,9 @@
 package com.raulshma.jellyplay.core.data.repository
 
-import com.raulshma.jellyplay.core.data.cache.TtlCache
 import com.raulshma.jellyplay.core.datastore.SeerrPreferencesStore
 import com.raulshma.jellyplay.core.datastore.SeerrSecureCredentialsStore
 import com.raulshma.jellyplay.core.model.MediaType
+import com.raulshma.jellyplay.core.model.TtlCache
 import com.raulshma.jellyplay.core.model.seerr.*
 import com.raulshma.jellyplay.core.network.seerr.SeerrApiClient
 import kotlinx.coroutines.CoroutineScope

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/util/DownloadDelegate.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/util/DownloadDelegate.kt
@@ -23,6 +23,10 @@ data class DownloadRequest(
     // offline store so the redesigned offline detail screens can show cast,
     // studios, ratings, overview, etc. — instead of the bare stub used before.
     val detail: MediaDetail? = null,
+    // Original container format from the Jellyfin MediaSource ("mkv", "mp4",
+    // "ts", ...). Used to derive the on-disk file extension and to attach the
+    // correct MIME type to the player engine at playback time.
+    val container: String? = null,
 )
 
 data class DownloadResult(
@@ -57,6 +61,7 @@ class DownloadDelegate @Inject constructor(
             trickplayInfo = source.trickplayInfo,
             mediaStreams = source.mediaStreams,
             detail = detail,
+            container = source.container,
         )
     }
 
@@ -69,6 +74,7 @@ class DownloadDelegate @Inject constructor(
             downloadUrl = request.downloadUrl,
             imageUrl = request.imageUrl,
             imageBlurHash = request.imageBlurHash,
+            container = request.container,
         )
         return result.fold(
             onSuccess = { downloadItem ->

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
@@ -317,10 +317,13 @@ class DownloadWorker @AssistedInject constructor(
 
                         val now = System.currentTimeMillis()
                         if (now - lastProgressUpdate >= progressUpdateIntervalMs) {
-                            val currentEntity = dao.getDownloadById(downloadId)
-                            if (currentEntity == null ||
-                                currentEntity.status == DownloadStatus.PAUSED.name ||
-                                currentEntity.status == DownloadStatus.CANCELLED.name
+                            // Read only the status column (was a 23-col SELECT *)
+                            // — the loop only needs to detect a pause/cancel
+                            // transition written by another process.
+                            val currentStatus = dao.getStatus(downloadId)
+                            if (currentStatus == null ||
+                                currentStatus == DownloadStatus.PAUSED.name ||
+                                currentStatus == DownloadStatus.CANCELLED.name
                             ) {
                                 response.close()
                                 return Result.success()

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
@@ -19,7 +19,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.net.SocketTimeoutException
-import java.util.concurrent.TimeUnit
+import javax.inject.Named
 
 @HiltWorker
 class DownloadWorker @AssistedInject constructor(
@@ -28,7 +28,11 @@ class DownloadWorker @AssistedInject constructor(
     private val dao: DownloadDao,
     private val userDao: UserDao,
     private val preferencesStore: UserPreferencesStore,
-    private val client: OkHttpClient,
+    // Pre-tuned singleton (connect=30s, read=60s, write=30s) shared across
+    // all concurrent DownloadWorker invocations. Previously each doWork()
+    // call cloned the base client via newBuilder().build(), multiplying the
+    // interceptor-list allocation when several workers ran at once.
+    @Named("download") private val client: OkHttpClient,
     private val tokenCipher: TokenCipher,
     private val concurrencyLimiter: DownloadConcurrencyLimiter,
 ) : CoroutineWorker(context, params) {
@@ -80,12 +84,6 @@ class DownloadWorker @AssistedInject constructor(
             tokenCipher.decrypt(userDao.getUserById(uid)?.accessToken)
         }
 
-        val downloadClient = client.newBuilder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(60, TimeUnit.SECONDS)
-            .writeTimeout(30, TimeUnit.SECONDS)
-            .build()
-
         val numConnections = preferencesStore.preferences.firstOrNull()?.downloadConnections?.coerceIn(1, 8) ?: 1
 
         // Gate the actual transfer on a shared concurrency slot so at most
@@ -94,7 +92,7 @@ class DownloadWorker @AssistedInject constructor(
             try {
             if (existingBytes > 0L) {
                 performSingleConnectionDownload(
-                    downloadClient = downloadClient,
+                    downloadClient = client,
                     dao = dao,
                     downloadId = downloadId,
                     entity = entity,
@@ -103,11 +101,11 @@ class DownloadWorker @AssistedInject constructor(
                     accessToken = accessToken,
                 )
             } else {
-                val totalSize = probeContentSize(downloadClient, entity.downloadUrl, accessToken)
+                val totalSize = probeContentSize(client, entity.downloadUrl, accessToken)
                 if (totalSize > MIN_MULTI_SIZE && numConnections > 1) {
                     MultiConnectionDownloadStrategy.execute(
                         context = applicationContext,
-                        downloadClient = downloadClient,
+                        downloadClient = client,
                         dao = dao,
                         downloadId = downloadId,
                         entity = entity,
@@ -119,7 +117,7 @@ class DownloadWorker @AssistedInject constructor(
                     )
                 } else {
                     performSingleConnectionDownload(
-                        downloadClient = downloadClient,
+                        downloadClient = client,
                         dao = dao,
                         downloadId = downloadId,
                         entity = entity,

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/repository/AuthRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/repository/AuthRepositoryImplTest.kt
@@ -167,7 +167,7 @@ class AuthRepositoryImplTest {
         val result = repository.restoreSession()
 
         assertTrue(result.isSuccess)
-        coVerify { preferencesStore.setActiveServer("") }
+        coVerify { preferencesStore.setActiveSession("", "") }
     }
 
     @Test

--- a/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/31.json
+++ b/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/31.json
@@ -1,0 +1,1513 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 31,
+    "identityHash": "b8bb39bcfae17c7b398f24b8ecaec7c3",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `address` TEXT NOT NULL, `userId` TEXT, `accessToken` TEXT, `lastConnected` INTEGER NOT NULL, `alternateAddresses` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alternateAddresses",
+            "columnName": "alternateAddresses",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_servers_address",
+            "unique": true,
+            "columnNames": [
+              "address"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_servers_address` ON `${TABLE_NAME}` (`address`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `name` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `primaryImageTag` TEXT, `maxParentalAgeRating` INTEGER, `enabledFolderIds` TEXT, `isAdmin` INTEGER NOT NULL DEFAULT 0, `lastConnected` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryImageTag",
+            "columnName": "primaryImageTag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxParentalAgeRating",
+            "columnName": "maxParentalAgeRating",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "enabledFolderIds",
+            "columnName": "enabledFolderIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAdmin",
+            "columnName": "isAdmin",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_users_serverId_lastConnected",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "lastConnected"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId_lastConnected` ON `${TABLE_NAME}` (`serverId`, `lastConnected`)"
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaItemId` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `downloadPath` TEXT NOT NULL, `downloadUrl` TEXT NOT NULL, `totalSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `speedBytesPerSec` INTEGER NOT NULL DEFAULT 0, `mediaSourceId` TEXT, `imageUrl` TEXT, `imageBlurHash` TEXT, `seriesId` TEXT, `seasonId` TEXT, `seriesName` TEXT, `seasonName` TEXT, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `createdAt` INTEGER NOT NULL DEFAULT 0, `errorMessage` TEXT, `priority` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaItemId",
+            "columnName": "mediaItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadPath",
+            "columnName": "downloadPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSizeBytes",
+            "columnName": "totalSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedBytesPerSec",
+            "columnName": "speedBytesPerSec",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaSourceId",
+            "columnName": "mediaSourceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlurHash",
+            "columnName": "imageBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonName",
+            "columnName": "seasonName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_mediaItemId",
+            "unique": false,
+            "columnNames": [
+              "mediaItemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_mediaItemId` ON `${TABLE_NAME}` (`mediaItemId`)"
+          },
+          {
+            "name": "index_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_downloads_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_downloads_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_downloads_mediaItemId_status",
+            "unique": false,
+            "columnNames": [
+              "mediaItemId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_mediaItemId_status` ON `${TABLE_NAME}` (`mediaItemId`, `status`)"
+          },
+          {
+            "name": "index_downloads_seriesId_status",
+            "unique": false,
+            "columnNames": [
+              "seriesId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seriesId_status` ON `${TABLE_NAME}` (`seriesId`, `status`)"
+          },
+          {
+            "name": "index_downloads_seasonId_status",
+            "unique": false,
+            "columnNames": [
+              "seasonId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seasonId_status` ON `${TABLE_NAME}` (`seasonId`, `status`)"
+          },
+          {
+            "name": "index_downloads_status_priority_createdAt",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "priority",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status_priority_createdAt` ON `${TABLE_NAME}` (`status`, `priority`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `itemId` TEXT NOT NULL, `provider` TEXT NOT NULL, `artistName` TEXT, `trackName` TEXT, `syncedLyrics` TEXT, `plainLyrics` TEXT, `duration` REAL, `lrcLibId` INTEGER, `fetchedAt` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artistName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackName",
+            "columnName": "trackName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedLyrics",
+            "columnName": "syncedLyrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainLyrics",
+            "columnName": "plainLyrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lrcLibId",
+            "columnName": "lrcLibId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_cache_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_fetchedAt` ON `${TABLE_NAME}` (`fetchedAt`)"
+          },
+          {
+            "name": "index_lyrics_cache_itemId",
+            "unique": false,
+            "columnNames": [
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_itemId` ON `${TABLE_NAME}` (`itemId`)"
+          },
+          {
+            "name": "index_lyrics_cache_itemId_provider",
+            "unique": true,
+            "columnNames": [
+              "itemId",
+              "provider"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lyrics_cache_itemId_provider` ON `${TABLE_NAME}` (`itemId`, `provider`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offline_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `overview` TEXT, `year` INTEGER, `communityRating` REAL, `officialRating` TEXT, `runTimeTicks` INTEGER, `parentId` TEXT, `seriesId` TEXT, `seasonId` TEXT, `seriesName` TEXT, `seasonName` TEXT, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `indexNumber` INTEGER, `childCount` INTEGER, `posterPath` TEXT, `backdropPath` TEXT, `blurHashPrimary` TEXT, `blurHashBackdrop` TEXT, `premiereDate` TEXT, `genres` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, `playbackPositionTicks` INTEGER, `playedPercentage` REAL NOT NULL DEFAULT 0.0, `isPlayed` INTEGER NOT NULL DEFAULT 0, `lastPlayedDate` TEXT, `originalTitle` TEXT, `criticRating` REAL, `studios` TEXT, `tagline` TEXT, `peopleJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "communityRating",
+            "columnName": "communityRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "officialRating",
+            "columnName": "officialRating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "runTimeTicks",
+            "columnName": "runTimeTicks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonName",
+            "columnName": "seasonName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexNumber",
+            "columnName": "indexNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "childCount",
+            "columnName": "childCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "posterPath",
+            "columnName": "posterPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropPath",
+            "columnName": "backdropPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blurHashPrimary",
+            "columnName": "blurHashPrimary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blurHashBackdrop",
+            "columnName": "blurHashBackdrop",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "premiereDate",
+            "columnName": "premiereDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "playbackPositionTicks",
+            "columnName": "playbackPositionTicks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedPercentage",
+            "columnName": "playedPercentage",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "isPlayed",
+            "columnName": "isPlayed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastPlayedDate",
+            "columnName": "lastPlayedDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTitle",
+            "columnName": "originalTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "criticRating",
+            "columnName": "criticRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "studios",
+            "columnName": "studios",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "peopleJson",
+            "columnName": "peopleJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offline_media_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          },
+          {
+            "name": "index_offline_media_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_offline_media_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_offline_media_mediaType",
+            "unique": false,
+            "columnNames": [
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_mediaType` ON `${TABLE_NAME}` (`mediaType`)"
+          },
+          {
+            "name": "index_offline_media_seriesId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "seriesId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seriesId_mediaType` ON `${TABLE_NAME}` (`seriesId`, `mediaType`)"
+          },
+          {
+            "name": "index_offline_media_seasonId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "seasonId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seasonId_mediaType` ON `${TABLE_NAME}` (`seasonId`, `mediaType`)"
+          },
+          {
+            "name": "index_offline_media_mediaType_createdAt",
+            "unique": false,
+            "columnNames": [
+              "mediaType",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_mediaType_createdAt` ON `${TABLE_NAME}` (`mediaType`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_audit_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `adminUserId` TEXT NOT NULL, `adminUserName` TEXT NOT NULL, `actionType` TEXT NOT NULL, `configJson` TEXT NOT NULL, `itemCount` INTEGER NOT NULL, `itemDetailsJson` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adminUserId",
+            "columnName": "adminUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adminUserName",
+            "columnName": "adminUserName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemDetailsJson",
+            "columnName": "itemDetailsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_audit_log_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_media_audit_log_actionType",
+            "unique": false,
+            "columnNames": [
+              "actionType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_actionType` ON `${TABLE_NAME}` (`actionType`)"
+          },
+          {
+            "name": "index_media_audit_log_actionType_timestamp",
+            "unique": false,
+            "columnNames": [
+              "actionType",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_actionType_timestamp` ON `${TABLE_NAME}` (`actionType`, `timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "scan_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`scanId` TEXT NOT NULL, `type` TEXT NOT NULL, `configJson` TEXT NOT NULL, `status` TEXT NOT NULL, `progress` INTEGER NOT NULL DEFAULT 0, `total` INTEGER NOT NULL DEFAULT 0, `itemsFound` INTEGER NOT NULL DEFAULT 0, `resultJson` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`scanId`))",
+        "fields": [
+          {
+            "fieldPath": "scanId",
+            "columnName": "scanId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "itemsFound",
+            "columnName": "itemsFound",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resultJson",
+            "columnName": "resultJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "scanId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_scan_state_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scan_state_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_scan_state_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scan_state_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "smart_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `criteriaJson` TEXT NOT NULL, `maxItems` INTEGER NOT NULL DEFAULT 50, `sortBy` TEXT NOT NULL DEFAULT 'RANDOM', `createdAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "criteriaJson",
+            "columnName": "criteriaJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxItems",
+            "columnName": "maxItems",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "50"
+          },
+          {
+            "fieldPath": "sortBy",
+            "columnName": "sortBy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'RANDOM'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_smart_playlists_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_smart_playlists_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_smart_playlists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_smart_playlists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mood_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `emoji` TEXT NOT NULL, `description` TEXT NOT NULL, `genreKeywordsJson` TEXT NOT NULL, `excludedGenresJson` TEXT, `minRating` REAL, `sortBy` TEXT NOT NULL DEFAULT 'RANDOM', `maxItems` INTEGER NOT NULL DEFAULT 50, `themeColorHex` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreKeywordsJson",
+            "columnName": "genreKeywordsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedGenresJson",
+            "columnName": "excludedGenresJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "minRating",
+            "columnName": "minRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "sortBy",
+            "columnName": "sortBy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'RANDOM'"
+          },
+          {
+            "fieldPath": "maxItems",
+            "columnName": "maxItems",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "50"
+          },
+          {
+            "fieldPath": "themeColorHex",
+            "columnName": "themeColorHex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mood_playlists_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mood_playlists_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_mood_playlists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mood_playlists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mood_playlist_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL DEFAULT 1, `isFavorite` INTEGER NOT NULL DEFAULT 0, `lastPlayedAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "audio_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `position` INTEGER NOT NULL DEFAULT 0, `name` TEXT NOT NULL, `artist` TEXT, `album` TEXT, `imageUrl` TEXT, `mediaSourceId` TEXT, `durationMs` INTEGER NOT NULL DEFAULT 0, `normalizationGain` REAL, `createdAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaSourceId",
+            "columnName": "mediaSourceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "normalizationGain",
+            "columnName": "normalizationGain",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_queue_position",
+            "unique": false,
+            "columnNames": [
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_queue_position` ON `${TABLE_NAME}` (`position`)"
+          },
+          {
+            "name": "index_audio_queue_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_queue_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "audio_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `currentIndex` INTEGER NOT NULL DEFAULT -1, `currentPositionMs` INTEGER NOT NULL DEFAULT 0, `isPlaying` INTEGER NOT NULL DEFAULT 0, `repeatMode` INTEGER NOT NULL DEFAULT 0, `shuffleEnabled` INTEGER NOT NULL DEFAULT 0, `playbackSpeed` REAL NOT NULL DEFAULT 1.0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "currentIndex",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "currentPositionMs",
+            "columnName": "currentPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isPlaying",
+            "columnName": "isPlaying",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeatMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffleEnabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1.0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `userId` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_search_history_query_userId",
+            "unique": true,
+            "columnNames": [
+              "query",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query_userId` ON `${TABLE_NAME}` (`query`, `userId`)"
+          },
+          {
+            "name": "index_search_history_searchedAt",
+            "unique": false,
+            "columnNames": [
+              "searchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_searchedAt` ON `${TABLE_NAME}` (`searchedAt`)"
+          },
+          {
+            "name": "index_search_history_userId_searchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "searchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_userId_searchedAt` ON `${TABLE_NAME}` (`userId`, `searchedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "seen_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `itemId` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `seenAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seen_media_itemId",
+            "unique": true,
+            "columnNames": [
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_seen_media_itemId` ON `${TABLE_NAME}` (`itemId`)"
+          },
+          {
+            "name": "index_seen_media_seenAt",
+            "unique": false,
+            "columnNames": [
+              "seenAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seen_media_seenAt` ON `${TABLE_NAME}` (`seenAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "item_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `scope` TEXT NOT NULL, `key` TEXT NOT NULL, `audioLanguage` TEXT, `subtitleLanguage` TEXT, `dialogueBoostStrength` TEXT, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioLanguage",
+            "columnName": "audioLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitleLanguage",
+            "columnName": "subtitleLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dialogueBoostStrength",
+            "columnName": "dialogueBoostStrength",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_item_playback_preferences_scope_key",
+            "unique": true,
+            "columnNames": [
+              "scope",
+              "key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_item_playback_preferences_scope_key` ON `${TABLE_NAME}` (`scope`, `key`)"
+          },
+          {
+            "name": "index_item_playback_preferences_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_item_playback_preferences_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b8bb39bcfae17c7b398f24b8ecaec7c3')"
+    ]
+  }
+}

--- a/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/32.json
+++ b/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/32.json
@@ -1,0 +1,1518 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 32,
+    "identityHash": "02abc83294566689aa743b1c9ee772a2",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `address` TEXT NOT NULL, `userId` TEXT, `accessToken` TEXT, `lastConnected` INTEGER NOT NULL, `alternateAddresses` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alternateAddresses",
+            "columnName": "alternateAddresses",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_servers_address",
+            "unique": true,
+            "columnNames": [
+              "address"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_servers_address` ON `${TABLE_NAME}` (`address`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `name` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `primaryImageTag` TEXT, `maxParentalAgeRating` INTEGER, `enabledFolderIds` TEXT, `isAdmin` INTEGER NOT NULL DEFAULT 0, `lastConnected` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryImageTag",
+            "columnName": "primaryImageTag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxParentalAgeRating",
+            "columnName": "maxParentalAgeRating",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "enabledFolderIds",
+            "columnName": "enabledFolderIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAdmin",
+            "columnName": "isAdmin",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_users_serverId_lastConnected",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "lastConnected"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId_lastConnected` ON `${TABLE_NAME}` (`serverId`, `lastConnected`)"
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaItemId` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `downloadPath` TEXT NOT NULL, `downloadUrl` TEXT NOT NULL, `totalSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `speedBytesPerSec` INTEGER NOT NULL DEFAULT 0, `mediaSourceId` TEXT, `imageUrl` TEXT, `imageBlurHash` TEXT, `seriesId` TEXT, `seasonId` TEXT, `seriesName` TEXT, `seasonName` TEXT, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `createdAt` INTEGER NOT NULL DEFAULT 0, `errorMessage` TEXT, `priority` INTEGER NOT NULL DEFAULT 0, `container` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaItemId",
+            "columnName": "mediaItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadPath",
+            "columnName": "downloadPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSizeBytes",
+            "columnName": "totalSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedBytesPerSec",
+            "columnName": "speedBytesPerSec",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaSourceId",
+            "columnName": "mediaSourceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlurHash",
+            "columnName": "imageBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonName",
+            "columnName": "seasonName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "container",
+            "columnName": "container",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_mediaItemId",
+            "unique": false,
+            "columnNames": [
+              "mediaItemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_mediaItemId` ON `${TABLE_NAME}` (`mediaItemId`)"
+          },
+          {
+            "name": "index_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_downloads_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_downloads_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_downloads_mediaItemId_status",
+            "unique": false,
+            "columnNames": [
+              "mediaItemId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_mediaItemId_status` ON `${TABLE_NAME}` (`mediaItemId`, `status`)"
+          },
+          {
+            "name": "index_downloads_seriesId_status",
+            "unique": false,
+            "columnNames": [
+              "seriesId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seriesId_status` ON `${TABLE_NAME}` (`seriesId`, `status`)"
+          },
+          {
+            "name": "index_downloads_seasonId_status",
+            "unique": false,
+            "columnNames": [
+              "seasonId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seasonId_status` ON `${TABLE_NAME}` (`seasonId`, `status`)"
+          },
+          {
+            "name": "index_downloads_status_priority_createdAt",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "priority",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status_priority_createdAt` ON `${TABLE_NAME}` (`status`, `priority`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `itemId` TEXT NOT NULL, `provider` TEXT NOT NULL, `artistName` TEXT, `trackName` TEXT, `syncedLyrics` TEXT, `plainLyrics` TEXT, `duration` REAL, `lrcLibId` INTEGER, `fetchedAt` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artistName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackName",
+            "columnName": "trackName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedLyrics",
+            "columnName": "syncedLyrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainLyrics",
+            "columnName": "plainLyrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lrcLibId",
+            "columnName": "lrcLibId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_cache_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_fetchedAt` ON `${TABLE_NAME}` (`fetchedAt`)"
+          },
+          {
+            "name": "index_lyrics_cache_itemId",
+            "unique": false,
+            "columnNames": [
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_itemId` ON `${TABLE_NAME}` (`itemId`)"
+          },
+          {
+            "name": "index_lyrics_cache_itemId_provider",
+            "unique": true,
+            "columnNames": [
+              "itemId",
+              "provider"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lyrics_cache_itemId_provider` ON `${TABLE_NAME}` (`itemId`, `provider`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offline_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `overview` TEXT, `year` INTEGER, `communityRating` REAL, `officialRating` TEXT, `runTimeTicks` INTEGER, `parentId` TEXT, `seriesId` TEXT, `seasonId` TEXT, `seriesName` TEXT, `seasonName` TEXT, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `indexNumber` INTEGER, `childCount` INTEGER, `posterPath` TEXT, `backdropPath` TEXT, `blurHashPrimary` TEXT, `blurHashBackdrop` TEXT, `premiereDate` TEXT, `genres` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, `playbackPositionTicks` INTEGER, `playedPercentage` REAL NOT NULL DEFAULT 0.0, `isPlayed` INTEGER NOT NULL DEFAULT 0, `lastPlayedDate` TEXT, `originalTitle` TEXT, `criticRating` REAL, `studios` TEXT, `tagline` TEXT, `peopleJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "communityRating",
+            "columnName": "communityRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "officialRating",
+            "columnName": "officialRating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "runTimeTicks",
+            "columnName": "runTimeTicks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonName",
+            "columnName": "seasonName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexNumber",
+            "columnName": "indexNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "childCount",
+            "columnName": "childCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "posterPath",
+            "columnName": "posterPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropPath",
+            "columnName": "backdropPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blurHashPrimary",
+            "columnName": "blurHashPrimary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blurHashBackdrop",
+            "columnName": "blurHashBackdrop",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "premiereDate",
+            "columnName": "premiereDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "playbackPositionTicks",
+            "columnName": "playbackPositionTicks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedPercentage",
+            "columnName": "playedPercentage",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "isPlayed",
+            "columnName": "isPlayed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastPlayedDate",
+            "columnName": "lastPlayedDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTitle",
+            "columnName": "originalTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "criticRating",
+            "columnName": "criticRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "studios",
+            "columnName": "studios",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "peopleJson",
+            "columnName": "peopleJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offline_media_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          },
+          {
+            "name": "index_offline_media_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_offline_media_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_offline_media_mediaType",
+            "unique": false,
+            "columnNames": [
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_mediaType` ON `${TABLE_NAME}` (`mediaType`)"
+          },
+          {
+            "name": "index_offline_media_seriesId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "seriesId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seriesId_mediaType` ON `${TABLE_NAME}` (`seriesId`, `mediaType`)"
+          },
+          {
+            "name": "index_offline_media_seasonId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "seasonId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seasonId_mediaType` ON `${TABLE_NAME}` (`seasonId`, `mediaType`)"
+          },
+          {
+            "name": "index_offline_media_mediaType_createdAt",
+            "unique": false,
+            "columnNames": [
+              "mediaType",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_mediaType_createdAt` ON `${TABLE_NAME}` (`mediaType`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_audit_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `adminUserId` TEXT NOT NULL, `adminUserName` TEXT NOT NULL, `actionType` TEXT NOT NULL, `configJson` TEXT NOT NULL, `itemCount` INTEGER NOT NULL, `itemDetailsJson` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adminUserId",
+            "columnName": "adminUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adminUserName",
+            "columnName": "adminUserName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemDetailsJson",
+            "columnName": "itemDetailsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_audit_log_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_media_audit_log_actionType",
+            "unique": false,
+            "columnNames": [
+              "actionType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_actionType` ON `${TABLE_NAME}` (`actionType`)"
+          },
+          {
+            "name": "index_media_audit_log_actionType_timestamp",
+            "unique": false,
+            "columnNames": [
+              "actionType",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_actionType_timestamp` ON `${TABLE_NAME}` (`actionType`, `timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "scan_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`scanId` TEXT NOT NULL, `type` TEXT NOT NULL, `configJson` TEXT NOT NULL, `status` TEXT NOT NULL, `progress` INTEGER NOT NULL DEFAULT 0, `total` INTEGER NOT NULL DEFAULT 0, `itemsFound` INTEGER NOT NULL DEFAULT 0, `resultJson` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`scanId`))",
+        "fields": [
+          {
+            "fieldPath": "scanId",
+            "columnName": "scanId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "itemsFound",
+            "columnName": "itemsFound",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resultJson",
+            "columnName": "resultJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "scanId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_scan_state_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scan_state_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_scan_state_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scan_state_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "smart_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `criteriaJson` TEXT NOT NULL, `maxItems` INTEGER NOT NULL DEFAULT 50, `sortBy` TEXT NOT NULL DEFAULT 'RANDOM', `createdAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "criteriaJson",
+            "columnName": "criteriaJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxItems",
+            "columnName": "maxItems",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "50"
+          },
+          {
+            "fieldPath": "sortBy",
+            "columnName": "sortBy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'RANDOM'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_smart_playlists_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_smart_playlists_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_smart_playlists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_smart_playlists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mood_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `emoji` TEXT NOT NULL, `description` TEXT NOT NULL, `genreKeywordsJson` TEXT NOT NULL, `excludedGenresJson` TEXT, `minRating` REAL, `sortBy` TEXT NOT NULL DEFAULT 'RANDOM', `maxItems` INTEGER NOT NULL DEFAULT 50, `themeColorHex` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreKeywordsJson",
+            "columnName": "genreKeywordsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedGenresJson",
+            "columnName": "excludedGenresJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "minRating",
+            "columnName": "minRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "sortBy",
+            "columnName": "sortBy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'RANDOM'"
+          },
+          {
+            "fieldPath": "maxItems",
+            "columnName": "maxItems",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "50"
+          },
+          {
+            "fieldPath": "themeColorHex",
+            "columnName": "themeColorHex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mood_playlists_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mood_playlists_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_mood_playlists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mood_playlists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mood_playlist_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL DEFAULT 1, `isFavorite` INTEGER NOT NULL DEFAULT 0, `lastPlayedAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "audio_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `position` INTEGER NOT NULL DEFAULT 0, `name` TEXT NOT NULL, `artist` TEXT, `album` TEXT, `imageUrl` TEXT, `mediaSourceId` TEXT, `durationMs` INTEGER NOT NULL DEFAULT 0, `normalizationGain` REAL, `createdAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaSourceId",
+            "columnName": "mediaSourceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "normalizationGain",
+            "columnName": "normalizationGain",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_queue_position",
+            "unique": false,
+            "columnNames": [
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_queue_position` ON `${TABLE_NAME}` (`position`)"
+          },
+          {
+            "name": "index_audio_queue_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_queue_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "audio_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `currentIndex` INTEGER NOT NULL DEFAULT -1, `currentPositionMs` INTEGER NOT NULL DEFAULT 0, `isPlaying` INTEGER NOT NULL DEFAULT 0, `repeatMode` INTEGER NOT NULL DEFAULT 0, `shuffleEnabled` INTEGER NOT NULL DEFAULT 0, `playbackSpeed` REAL NOT NULL DEFAULT 1.0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "currentIndex",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "currentPositionMs",
+            "columnName": "currentPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isPlaying",
+            "columnName": "isPlaying",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeatMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffleEnabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1.0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `userId` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_search_history_query_userId",
+            "unique": true,
+            "columnNames": [
+              "query",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query_userId` ON `${TABLE_NAME}` (`query`, `userId`)"
+          },
+          {
+            "name": "index_search_history_searchedAt",
+            "unique": false,
+            "columnNames": [
+              "searchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_searchedAt` ON `${TABLE_NAME}` (`searchedAt`)"
+          },
+          {
+            "name": "index_search_history_userId_searchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "searchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_userId_searchedAt` ON `${TABLE_NAME}` (`userId`, `searchedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "seen_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `itemId` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `seenAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seen_media_itemId",
+            "unique": true,
+            "columnNames": [
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_seen_media_itemId` ON `${TABLE_NAME}` (`itemId`)"
+          },
+          {
+            "name": "index_seen_media_seenAt",
+            "unique": false,
+            "columnNames": [
+              "seenAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seen_media_seenAt` ON `${TABLE_NAME}` (`seenAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "item_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `scope` TEXT NOT NULL, `key` TEXT NOT NULL, `audioLanguage` TEXT, `subtitleLanguage` TEXT, `dialogueBoostStrength` TEXT, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioLanguage",
+            "columnName": "audioLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitleLanguage",
+            "columnName": "subtitleLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dialogueBoostStrength",
+            "columnName": "dialogueBoostStrength",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_item_playback_preferences_scope_key",
+            "unique": true,
+            "columnNames": [
+              "scope",
+              "key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_item_playback_preferences_scope_key` ON `${TABLE_NAME}` (`scope`, `key`)"
+          },
+          {
+            "name": "index_item_playback_preferences_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_item_playback_preferences_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '02abc83294566689aa743b1c9ee772a2')"
+    ]
+  }
+}

--- a/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/33.json
+++ b/core/database/schemas/com.raulshma.jellyplay.core.database.JellyPlayDatabase/33.json
@@ -1,0 +1,1527 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 33,
+    "identityHash": "85dd08271e3486b835455ba47438a204",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `address` TEXT NOT NULL, `userId` TEXT, `accessToken` TEXT, `lastConnected` INTEGER NOT NULL, `alternateAddresses` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alternateAddresses",
+            "columnName": "alternateAddresses",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_servers_address",
+            "unique": true,
+            "columnNames": [
+              "address"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_servers_address` ON `${TABLE_NAME}` (`address`)"
+          }
+        ]
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, `serverId` TEXT NOT NULL, `name` TEXT NOT NULL, `accessToken` TEXT NOT NULL, `primaryImageTag` TEXT, `maxParentalAgeRating` INTEGER, `enabledFolderIds` TEXT, `isAdmin` INTEGER NOT NULL DEFAULT 0, `lastConnected` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "primaryImageTag",
+            "columnName": "primaryImageTag",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maxParentalAgeRating",
+            "columnName": "maxParentalAgeRating",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "enabledFolderIds",
+            "columnName": "enabledFolderIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isAdmin",
+            "columnName": "isAdmin",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "lastConnected",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          },
+          {
+            "name": "index_users_serverId_lastConnected",
+            "unique": false,
+            "columnNames": [
+              "serverId",
+              "lastConnected"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId_lastConnected` ON `${TABLE_NAME}` (`serverId`, `lastConnected`)"
+          }
+        ]
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaItemId` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `downloadPath` TEXT NOT NULL, `downloadUrl` TEXT NOT NULL, `totalSizeBytes` INTEGER NOT NULL, `downloadedBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, `speedBytesPerSec` INTEGER NOT NULL DEFAULT 0, `mediaSourceId` TEXT, `imageUrl` TEXT, `imageBlurHash` TEXT, `seriesId` TEXT, `seasonId` TEXT, `seriesName` TEXT, `seasonName` TEXT, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `createdAt` INTEGER NOT NULL DEFAULT 0, `errorMessage` TEXT, `priority` INTEGER NOT NULL DEFAULT 0, `container` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaItemId",
+            "columnName": "mediaItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadPath",
+            "columnName": "downloadPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadUrl",
+            "columnName": "downloadUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalSizeBytes",
+            "columnName": "totalSizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speedBytesPerSec",
+            "columnName": "speedBytesPerSec",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "mediaSourceId",
+            "columnName": "mediaSourceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBlurHash",
+            "columnName": "imageBlurHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonName",
+            "columnName": "seasonName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "container",
+            "columnName": "container",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloads_mediaItemId",
+            "unique": false,
+            "columnNames": [
+              "mediaItemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_mediaItemId` ON `${TABLE_NAME}` (`mediaItemId`)"
+          },
+          {
+            "name": "index_downloads_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_downloads_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_downloads_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_downloads_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_downloads_mediaItemId_status",
+            "unique": false,
+            "columnNames": [
+              "mediaItemId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_mediaItemId_status` ON `${TABLE_NAME}` (`mediaItemId`, `status`)"
+          },
+          {
+            "name": "index_downloads_seriesId_status",
+            "unique": false,
+            "columnNames": [
+              "seriesId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seriesId_status` ON `${TABLE_NAME}` (`seriesId`, `status`)"
+          },
+          {
+            "name": "index_downloads_seasonId_status",
+            "unique": false,
+            "columnNames": [
+              "seasonId",
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_seasonId_status` ON `${TABLE_NAME}` (`seasonId`, `status`)"
+          },
+          {
+            "name": "index_downloads_status_priority_createdAt",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "priority",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloads_status_priority_createdAt` ON `${TABLE_NAME}` (`status`, `priority`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "lyrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `itemId` TEXT NOT NULL, `provider` TEXT NOT NULL, `artistName` TEXT, `trackName` TEXT, `syncedLyrics` TEXT, `plainLyrics` TEXT, `duration` REAL, `lrcLibId` INTEGER, `fetchedAt` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artistName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackName",
+            "columnName": "trackName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncedLyrics",
+            "columnName": "syncedLyrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "plainLyrics",
+            "columnName": "plainLyrics",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lrcLibId",
+            "columnName": "lrcLibId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fetchedAt",
+            "columnName": "fetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_lyrics_cache_fetchedAt",
+            "unique": false,
+            "columnNames": [
+              "fetchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_fetchedAt` ON `${TABLE_NAME}` (`fetchedAt`)"
+          },
+          {
+            "name": "index_lyrics_cache_itemId",
+            "unique": false,
+            "columnNames": [
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_lyrics_cache_itemId` ON `${TABLE_NAME}` (`itemId`)"
+          },
+          {
+            "name": "index_lyrics_cache_itemId_provider",
+            "unique": true,
+            "columnNames": [
+              "itemId",
+              "provider"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_lyrics_cache_itemId_provider` ON `${TABLE_NAME}` (`itemId`, `provider`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offline_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `overview` TEXT, `year` INTEGER, `communityRating` REAL, `officialRating` TEXT, `runTimeTicks` INTEGER, `parentId` TEXT, `seriesId` TEXT, `seasonId` TEXT, `seriesName` TEXT, `seasonName` TEXT, `episodeNumber` INTEGER, `seasonNumber` INTEGER, `indexNumber` INTEGER, `childCount` INTEGER, `posterPath` TEXT, `backdropPath` TEXT, `blurHashPrimary` TEXT, `blurHashBackdrop` TEXT, `premiereDate` TEXT, `genres` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, `playbackPositionTicks` INTEGER, `playedPercentage` REAL NOT NULL DEFAULT 0.0, `isPlayed` INTEGER NOT NULL DEFAULT 0, `lastPlayedDate` TEXT, `originalTitle` TEXT, `criticRating` REAL, `studios` TEXT, `tagline` TEXT, `peopleJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overview",
+            "columnName": "overview",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "communityRating",
+            "columnName": "communityRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "officialRating",
+            "columnName": "officialRating",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "runTimeTicks",
+            "columnName": "runTimeTicks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "seasonId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seasonName",
+            "columnName": "seasonName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "episodeNumber",
+            "columnName": "episodeNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "indexNumber",
+            "columnName": "indexNumber",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "childCount",
+            "columnName": "childCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "posterPath",
+            "columnName": "posterPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backdropPath",
+            "columnName": "backdropPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blurHashPrimary",
+            "columnName": "blurHashPrimary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blurHashBackdrop",
+            "columnName": "blurHashBackdrop",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "premiereDate",
+            "columnName": "premiereDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "playbackPositionTicks",
+            "columnName": "playbackPositionTicks",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playedPercentage",
+            "columnName": "playedPercentage",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "0.0"
+          },
+          {
+            "fieldPath": "isPlayed",
+            "columnName": "isPlayed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastPlayedDate",
+            "columnName": "lastPlayedDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTitle",
+            "columnName": "originalTitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "criticRating",
+            "columnName": "criticRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "studios",
+            "columnName": "studios",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "peopleJson",
+            "columnName": "peopleJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offline_media_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          },
+          {
+            "name": "index_offline_media_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_offline_media_seasonId",
+            "unique": false,
+            "columnNames": [
+              "seasonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seasonId` ON `${TABLE_NAME}` (`seasonId`)"
+          },
+          {
+            "name": "index_offline_media_mediaType",
+            "unique": false,
+            "columnNames": [
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_mediaType` ON `${TABLE_NAME}` (`mediaType`)"
+          },
+          {
+            "name": "index_offline_media_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_offline_media_seriesId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "seriesId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seriesId_mediaType` ON `${TABLE_NAME}` (`seriesId`, `mediaType`)"
+          },
+          {
+            "name": "index_offline_media_seasonId_mediaType",
+            "unique": false,
+            "columnNames": [
+              "seasonId",
+              "mediaType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_seasonId_mediaType` ON `${TABLE_NAME}` (`seasonId`, `mediaType`)"
+          },
+          {
+            "name": "index_offline_media_mediaType_createdAt",
+            "unique": false,
+            "columnNames": [
+              "mediaType",
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_media_mediaType_createdAt` ON `${TABLE_NAME}` (`mediaType`, `createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_audit_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `adminUserId` TEXT NOT NULL, `adminUserName` TEXT NOT NULL, `actionType` TEXT NOT NULL, `configJson` TEXT NOT NULL, `itemCount` INTEGER NOT NULL, `itemDetailsJson` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adminUserId",
+            "columnName": "adminUserId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "adminUserName",
+            "columnName": "adminUserName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionType",
+            "columnName": "actionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemCount",
+            "columnName": "itemCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemDetailsJson",
+            "columnName": "itemDetailsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_audit_log_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_media_audit_log_actionType",
+            "unique": false,
+            "columnNames": [
+              "actionType"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_actionType` ON `${TABLE_NAME}` (`actionType`)"
+          },
+          {
+            "name": "index_media_audit_log_actionType_timestamp",
+            "unique": false,
+            "columnNames": [
+              "actionType",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_audit_log_actionType_timestamp` ON `${TABLE_NAME}` (`actionType`, `timestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "scan_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`scanId` TEXT NOT NULL, `type` TEXT NOT NULL, `configJson` TEXT NOT NULL, `status` TEXT NOT NULL, `progress` INTEGER NOT NULL DEFAULT 0, `total` INTEGER NOT NULL DEFAULT 0, `itemsFound` INTEGER NOT NULL DEFAULT 0, `resultJson` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`scanId`))",
+        "fields": [
+          {
+            "fieldPath": "scanId",
+            "columnName": "scanId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "configJson",
+            "columnName": "configJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "total",
+            "columnName": "total",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "itemsFound",
+            "columnName": "itemsFound",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "resultJson",
+            "columnName": "resultJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "scanId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_scan_state_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scan_state_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "index_scan_state_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scan_state_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "smart_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `criteriaJson` TEXT NOT NULL, `maxItems` INTEGER NOT NULL DEFAULT 50, `sortBy` TEXT NOT NULL DEFAULT 'RANDOM', `createdAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "criteriaJson",
+            "columnName": "criteriaJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxItems",
+            "columnName": "maxItems",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "50"
+          },
+          {
+            "fieldPath": "sortBy",
+            "columnName": "sortBy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'RANDOM'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_smart_playlists_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_smart_playlists_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_smart_playlists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_smart_playlists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mood_playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `emoji` TEXT NOT NULL, `description` TEXT NOT NULL, `genreKeywordsJson` TEXT NOT NULL, `excludedGenresJson` TEXT, `minRating` REAL, `sortBy` TEXT NOT NULL DEFAULT 'RANDOM', `maxItems` INTEGER NOT NULL DEFAULT 50, `themeColorHex` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "emoji",
+            "columnName": "emoji",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genreKeywordsJson",
+            "columnName": "genreKeywordsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludedGenresJson",
+            "columnName": "excludedGenresJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "minRating",
+            "columnName": "minRating",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "sortBy",
+            "columnName": "sortBy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'RANDOM'"
+          },
+          {
+            "fieldPath": "maxItems",
+            "columnName": "maxItems",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "50"
+          },
+          {
+            "fieldPath": "themeColorHex",
+            "columnName": "themeColorHex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_mood_playlists_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mood_playlists_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_mood_playlists_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_mood_playlists_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "mood_playlist_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `isEnabled` INTEGER NOT NULL DEFAULT 1, `isFavorite` INTEGER NOT NULL DEFAULT 0, `lastPlayedAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "isEnabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "audio_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `position` INTEGER NOT NULL DEFAULT 0, `name` TEXT NOT NULL, `artist` TEXT, `album` TEXT, `imageUrl` TEXT, `mediaSourceId` TEXT, `durationMs` INTEGER NOT NULL DEFAULT 0, `normalizationGain` REAL, `createdAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaSourceId",
+            "columnName": "mediaSourceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "durationMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "normalizationGain",
+            "columnName": "normalizationGain",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_queue_position",
+            "unique": false,
+            "columnNames": [
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_queue_position` ON `${TABLE_NAME}` (`position`)"
+          },
+          {
+            "name": "index_audio_queue_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_queue_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "audio_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `currentIndex` INTEGER NOT NULL DEFAULT -1, `currentPositionMs` INTEGER NOT NULL DEFAULT 0, `isPlaying` INTEGER NOT NULL DEFAULT 0, `repeatMode` INTEGER NOT NULL DEFAULT 0, `shuffleEnabled` INTEGER NOT NULL DEFAULT 0, `playbackSpeed` REAL NOT NULL DEFAULT 1.0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "currentIndex",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "currentPositionMs",
+            "columnName": "currentPositionMs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isPlaying",
+            "columnName": "isPlaying",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeatMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffleEnabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playbackSpeed",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1.0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL, `userId` TEXT NOT NULL, `searchedAt` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchedAt",
+            "columnName": "searchedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_search_history_query_userId",
+            "unique": true,
+            "columnNames": [
+              "query",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query_userId` ON `${TABLE_NAME}` (`query`, `userId`)"
+          },
+          {
+            "name": "index_search_history_searchedAt",
+            "unique": false,
+            "columnNames": [
+              "searchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_searchedAt` ON `${TABLE_NAME}` (`searchedAt`)"
+          },
+          {
+            "name": "index_search_history_userId_searchedAt",
+            "unique": false,
+            "columnNames": [
+              "userId",
+              "searchedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_search_history_userId_searchedAt` ON `${TABLE_NAME}` (`userId`, `searchedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "seen_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `itemId` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `seenAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seenAt",
+            "columnName": "seenAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seen_media_itemId",
+            "unique": true,
+            "columnNames": [
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_seen_media_itemId` ON `${TABLE_NAME}` (`itemId`)"
+          },
+          {
+            "name": "index_seen_media_seenAt",
+            "unique": false,
+            "columnNames": [
+              "seenAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_seen_media_seenAt` ON `${TABLE_NAME}` (`seenAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "item_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `scope` TEXT NOT NULL, `key` TEXT NOT NULL, `audioLanguage` TEXT, `subtitleLanguage` TEXT, `dialogueBoostStrength` TEXT, `updatedAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioLanguage",
+            "columnName": "audioLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitleLanguage",
+            "columnName": "subtitleLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "dialogueBoostStrength",
+            "columnName": "dialogueBoostStrength",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_item_playback_preferences_scope_key",
+            "unique": true,
+            "columnNames": [
+              "scope",
+              "key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_item_playback_preferences_scope_key` ON `${TABLE_NAME}` (`scope`, `key`)"
+          },
+          {
+            "name": "index_item_playback_preferences_updatedAt",
+            "unique": false,
+            "columnNames": [
+              "updatedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_item_playback_preferences_updatedAt` ON `${TABLE_NAME}` (`updatedAt`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '85dd08271e3486b835455ba47438a204')"
+    ]
+  }
+}

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
@@ -50,7 +50,7 @@ import com.raulshma.jellyplay.core.database.entity.UserEntity
         SeenMediaEntity::class,
         ItemPlaybackPreferenceEntity::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
@@ -50,7 +50,7 @@ import com.raulshma.jellyplay.core.database.entity.UserEntity
         SeenMediaEntity::class,
         ItemPlaybackPreferenceEntity::class,
     ],
-    version = 31,
+    version = 32,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/JellyPlayDatabase.kt
@@ -50,7 +50,7 @@ import com.raulshma.jellyplay.core.database.entity.UserEntity
         SeenMediaEntity::class,
         ItemPlaybackPreferenceEntity::class,
     ],
-    version = 32,
+    version = 33,
     exportSchema = true,
 )
 @TypeConverters(Converters::class)

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
@@ -78,6 +78,16 @@ interface DownloadDao {
     @Query("SELECT * FROM downloads WHERE status = :status LIMIT 500")
     suspend fun getDownloadsByStatus(status: String): List<DownloadEntity>
 
+    /**
+     * Cold-start recovery projection. The recovery initializer on every app
+     * launch consumes only [RecoveryRow.id] (and `downloadedBytes` when
+     * rewriting a stuck DOWNLOADING row back to PENDING). Materialising up to
+     * 500 full 23-column entities — incl. `downloadUrl`, `errorMessage`,
+     * `container`, `imageBlurHash` — was pure overhead on the cold-start path.
+     */
+    @Query("SELECT id, downloadedBytes FROM downloads WHERE status = :status LIMIT 500")
+    suspend fun getRecoveryRows(status: String): List<RecoveryRow>
+
     @Query("SELECT * FROM downloads WHERE seriesId = :seriesId")
     suspend fun getDownloadsForSeries(seriesId: String): List<DownloadEntity>
 
@@ -102,3 +112,13 @@ interface DownloadDao {
     @Query("SELECT DISTINCT seriesId FROM downloads WHERE seriesId IS NOT NULL")
     suspend fun getDownloadedSeriesIds(): List<String>
 }
+
+/**
+ * Lightweight row projected out of `downloads` for the cold-start recovery
+ * path — see [DownloadDao.getRecoveryRows]. Carries only the columns the
+ * recovery initializer actually consumes.
+ */
+data class RecoveryRow(
+    val id: String,
+    val downloadedBytes: Long,
+)

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
@@ -18,6 +18,15 @@ interface DownloadDao {
     @Query("SELECT * FROM downloads WHERE id = :id")
     suspend fun getDownloadById(id: String): DownloadEntity?
 
+    /**
+     * Targeted single-column read of a download's status. Used by the
+     * per-2-s progress loop in DownloadWorker, which previously did a full
+     * `SELECT *` (23 cols incl. downloadUrl / errorMessage) just to detect a
+     * pause/cancel transition.
+     */
+    @Query("SELECT status FROM downloads WHERE id = :id")
+    suspend fun getStatus(id: String): String?
+
     @Query("SELECT * FROM downloads WHERE mediaItemId = :mediaItemId")
     suspend fun getDownloadByMediaItemId(mediaItemId: String): DownloadEntity?
 

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/LyricsCacheDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/LyricsCacheDao.kt
@@ -9,7 +9,7 @@ import com.raulshma.jellyplay.core.database.entity.LyricsCacheEntity
 @Dao
 interface LyricsCacheDao {
 
-    @Query("SELECT * FROM lyrics_cache WHERE itemId = :itemId LIMIT 1")
+    @Query("SELECT * FROM lyrics_cache WHERE itemId = :itemId ORDER BY id DESC LIMIT 1")
     suspend fun getByItemId(itemId: String): LyricsCacheEntity?
 
     @Query("SELECT * FROM lyrics_cache WHERE itemId = :itemId AND provider = :provider LIMIT 1")

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/SearchHistoryDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/SearchHistoryDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.raulshma.jellyplay.core.database.entity.SearchHistoryEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -27,4 +28,15 @@ interface SearchHistoryDao {
 
     @Query("DELETE FROM search_history WHERE userId = :userId AND id NOT IN (SELECT id FROM search_history WHERE userId = :userId ORDER BY searchedAt DESC LIMIT :keepCount)")
     suspend fun evictOldest(userId: String, keepCount: Int = 50)
+
+    /**
+     * Inserts a query and trims the user's history to [keepCount] in a single
+     * transaction. Was two separate transactions (2 Flow re-emissions) — wrapping
+     * them means the history Flow re-emits once and the insert+evict are atomic.
+     */
+    @Transaction
+    suspend fun insertAndEvict(entity: SearchHistoryEntity, keepCount: Int = 50) {
+        insert(entity)
+        evictOldest(entity.userId, keepCount)
+    }
 }

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/UserDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/UserDao.kt
@@ -15,6 +15,9 @@ interface UserDao {
     @Query("SELECT * FROM users WHERE serverId = :serverId ORDER BY lastConnected DESC")
     fun getUsersForServer(serverId: String): Flow<List<UserEntity>>
 
+    @Query("SELECT * FROM users WHERE serverId = :serverId ORDER BY lastConnected DESC")
+    suspend fun getUsersForServerOnce(serverId: String): List<UserEntity>
+
     @Query("SELECT * FROM users WHERE serverId = :serverId ORDER BY lastConnected DESC LIMIT 1")
     suspend fun getMostRecentUserForServer(serverId: String): UserEntity?
 

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/Entities.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/Entities.kt
@@ -86,6 +86,10 @@ data class DownloadEntity(
     tableName = "lyrics_cache",
     indices = [
         Index(value = ["fetchedAt"]),
+        // Explicit single-column index so the `WHERE itemId = :itemId` lookup
+        // (getByItemId, called on every lyrics render) is unambiguously indexed
+        // rather than relying on a left-prefix of the composite (itemId, provider).
+        Index(value = ["itemId"]),
         Index(value = ["itemId", "provider"], unique = true),
     ],
 )

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/Entities.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/Entities.kt
@@ -80,6 +80,14 @@ data class DownloadEntity(
     val errorMessage: String? = null,
     @ColumnInfo(defaultValue = "0")
     val priority: Int = 0,
+    /**
+     * Original container format (e.g. "mkv", "mp4", "ts") as reported by the
+     * Jellyfin MediaSource. Used at playback time to attach the correct MIME
+     * type to ExoPlayer so the right extractor is selected for misnamed files
+     * (downloads historically get a hardcoded `.mp4` extension). NULL for
+     * pre-existing rows until the item is re-downloaded.
+     */
+    val container: String? = null,
 )
 
 @Entity(

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/OfflineMediaEntity.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/entity/OfflineMediaEntity.kt
@@ -12,6 +12,7 @@ import androidx.room.PrimaryKey
         Index(value = ["seriesId"]),
         Index(value = ["seasonId"]),
         Index(value = ["mediaType"]),
+        Index(value = ["name"]),
         Index(value = ["seriesId", "mediaType"]),
         Index(value = ["seasonId", "mediaType"]),
         Index(value = ["mediaType", "createdAt"]),

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
@@ -540,6 +540,17 @@ val MIGRATION_30_31 = object : Migration(30, 31) {
     }
 }
 
+// Capture the original container format ("mkv", "mp4", "ts", ...) reported by
+// the Jellyfin MediaSource at download time. Used at playback to attach the
+// correct MIME type to ExoPlayer, so the right extractor is selected even when
+// the on-disk file uses a hardcoded `.mp4` extension. Nullable: pre-existing
+// rows degrade to extension-based inference (sniffer fallback at playback).
+val MIGRATION_31_32 = object : Migration(31, 32) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE downloads ADD COLUMN container TEXT")
+    }
+}
+
 val ALL_MIGRATIONS = listOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -570,4 +581,5 @@ val ALL_MIGRATIONS = listOf(
     MIGRATION_28_29,
     MIGRATION_29_30,
     MIGRATION_30_31,
+    MIGRATION_31_32,
 )

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
@@ -529,6 +529,17 @@ val MIGRATION_29_30 = object : Migration(29, 30) {
     }
 }
 
+// Explicit single-column index on lyrics_cache(itemId). The composite
+// (itemId, provider) index already serves `WHERE itemId = :itemId` via a
+// left-prefix match, but adding a dedicated index makes the intent unambiguous
+// and documents that the per-item lookup path is indexed. The composite unique
+// index is retained.
+val MIGRATION_30_31 = object : Migration(30, 31) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_lyrics_cache_itemId ON lyrics_cache(itemId)")
+    }
+}
+
 val ALL_MIGRATIONS = listOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -558,4 +569,5 @@ val ALL_MIGRATIONS = listOf(
     MIGRATION_27_28,
     MIGRATION_28_29,
     MIGRATION_29_30,
+    MIGRATION_30_31,
 )

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/migration/Migrations.kt
@@ -551,6 +551,18 @@ val MIGRATION_31_32 = object : Migration(31, 32) {
     }
 }
 
+// Add a non-unique index on `offline_media.name`. The OfflineMediaDao.search
+// query orders by `name COLLATE NOCASE` and a `CASE WHEN name LIKE 'q%'` prefix
+// branch; previously a full table scan ran for every keystroke on the widest
+// table (33 columns). The leading-`%` substring LIKE branch cannot be served
+// by a B-tree index, but the prefix/order-by branches now benefit. Behavior
+// is unchanged; this is purely a query-planner improvement.
+val MIGRATION_32_33 = object : Migration(32, 33) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_offline_media_name ON offline_media(name)")
+    }
+}
+
 val ALL_MIGRATIONS = listOf(
     MIGRATION_1_2,
     MIGRATION_2_3,
@@ -582,4 +594,5 @@ val ALL_MIGRATIONS = listOf(
     MIGRATION_29_30,
     MIGRATION_30_31,
     MIGRATION_31_32,
+    MIGRATION_32_33,
 )

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/UserPreferencesStore.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/UserPreferencesStore.kt
@@ -1121,6 +1121,14 @@ class UserPreferencesStore @Inject constructor(
     val activeUserId: Flow<String?> = sharedPrefs.map { it[Keys.ACTIVE_USER_ID] }.distinctUntilChanged()
     val deviceId: Flow<String?> = sharedPrefs.map { it[Keys.DEVICE_ID] }.distinctUntilChanged()
 
+    // Narrow per-key flows for hot-path consumers. Reading these avoids
+    // collecting the full ~150-field `preferences` StateFlow (rebuilt on every
+    // pref edit anywhere in the app) just to observe one or two booleans.
+    val manualOfflineEnabled: Flow<Boolean> =
+        sharedPrefs.map { it[Keys.MANUAL_OFFLINE_ENABLED] ?: false }.distinctUntilChanged()
+    val autoOfflineEnabled: Flow<Boolean> =
+        sharedPrefs.map { it[Keys.AUTO_OFFLINE_ENABLED] ?: true }.distinctUntilChanged()
+
     suspend fun ensureDeviceId(): String {
         var id: String? = null
         context.dataStore.edit { prefs ->
@@ -1135,6 +1143,20 @@ class UserPreferencesStore @Inject constructor(
 
     suspend fun setActiveUser(userId: String) {
         context.dataStore.edit { it[Keys.ACTIVE_USER_ID] = userId }
+    }
+
+    /**
+     * Sets the active server and user in a single DataStore edit. Two back-to-
+     * back `setActiveServer` + `setActiveUser` calls (the previous call-site
+     * pattern) each opened their own `edit {}` → 2 disk reads + 2 atomic writes
+     * + 2 full `preferences` re-emissions. Batching them halves the I/O and the
+     * downstream re-derivation cascade.
+     */
+    suspend fun setActiveSession(serverId: String, userId: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.ACTIVE_SERVER_ID] = serverId
+            prefs[Keys.ACTIVE_USER_ID] = userId
+        }
     }
 
     suspend fun setPreferredPlayer(playerType: PlayerType) {

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/DownloadModels.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/DownloadModels.kt
@@ -27,6 +27,13 @@ data class DownloadItem(
     val seasonNumber: Int? = null,
     val errorMessage: String? = null,
     val priority: Int = 0,
+    /**
+     * Original container format as reported by the Jellyfin MediaSource
+     * (e.g. "mkv", "mp4", "ts"). Used to attach the correct MIME type to the
+     * player engine at playback time so the right extractor is selected for
+     * files whose on-disk extension does not match their actual container.
+     */
+    val container: String? = null,
 )
 
 @Immutable

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/EngineConfigs.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/EngineConfigs.kt
@@ -1,8 +1,10 @@
 package com.raulshma.jellyplay.core.model
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import kotlinx.serialization.Serializable
 
+@Stable
 sealed interface EngineSpecificConfig
 
 @Immutable

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/LanguageUtils.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/LanguageUtils.kt
@@ -22,6 +22,11 @@ fun isLanguageMatch(trackLang: String?, prefLang: String?): Boolean {
     }
 }
 
+// Compiled once and reused (was recompiled inside parseLanguageFromLabel on
+// every media-open / track-switch call). Mirrors the cached-regex pattern used
+// in MediaRepositoryImpl and DownloadRepositoryImpl.
+private val NON_ALPHANUMERIC_SPLIT = Regex("[^a-zA-Z0-9]+")
+
 private val localeLookupMap: Map<String, String> by lazy {
     val map = mutableMapOf<String, String>()
     for (locale in Locale.getAvailableLocales()) {
@@ -75,7 +80,7 @@ fun parseLanguageFromLabel(label: String?): String? {
     val normalizedLabel = label.lowercase()
     
     // Split by non-alphanumeric characters to isolate words
-    val words = normalizedLabel.split(Regex("[^a-zA-Z0-9]+"))
+    val words = normalizedLabel.split(NON_ALPHANUMERIC_SPLIT)
     for (word in words) {
         if (word.isNotBlank()) {
             val matchedIso = localeLookupMap[word]

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/NumberFormatter.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/NumberFormatter.kt
@@ -1,0 +1,26 @@
+package com.raulshma.jellyplay.core.model
+
+/**
+ * Fixed-precision decimal formatting that mirrors `String.format("%.Nf")` for
+ * non-negative inputs (the only kind passed by current call sites: percentages,
+ * framerates, bitrates, zoom factors, playback positions).
+ *
+ * Avoids the `Formatter` + `StringBuilder` + locale lookup cost of
+ * `String.format`, which matters on hot paths like the player stats overlay
+ * (~4 Hz, many rows) and per-seek MPV command strings.
+ *
+ * Rounding is HALF_UP (round-half-towards-positive-infinity), matching
+ * `String.format`'s default `RoundingMode.HALF_UP` for non-negative values.
+ */
+fun formatFixed(value: Double, decimals: Int): String {
+    require(decimals >= 0) { "decimals must be non-negative, was $decimals" }
+    val scale = POW10[decimals]
+    val scaled = value * scale
+    val rounded = if (scaled >= 0) (scaled + 0.5).toLong() else (scaled - 0.5).toLong()
+    val intPart = rounded / scale
+    val fracPart = Math.abs(rounded % scale)
+    val fracStr = fracPart.toString().padStart(decimals, '0')
+    return "$intPart.$fracStr"
+}
+
+private val POW10 = longArrayOf(1L, 10L, 100L, 1_000L, 10_000L, 100_000L, 1_000_000L)

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/ServerHealth.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/ServerHealth.kt
@@ -1,8 +1,11 @@
 package com.raulshma.jellyplay.core.model
 
+import androidx.compose.runtime.Stable
+
 /**
  * Represents the health status of the connected Jellyfin server.
  */
+@Stable
 sealed class ServerHealth {
     /** Server health is unknown (not yet checked or not connected). */
     data object Unknown : ServerHealth()

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/TtlCache.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/TtlCache.kt
@@ -1,0 +1,73 @@
+package com.raulshma.jellyplay.core.model
+
+import android.os.SystemClock
+import java.util.Collections
+
+/**
+ * Tiny LRU + TTL cache used across layers (`core:network` HTTP clients,
+ * `core:data` repositories) to memoise near-static server responses.
+ *
+ * Previously duplicated in `core:data` and `core:network` because each module
+ * sits below the layer that owned the cache; both depend on `core:model`, so
+ * the canonical implementation lives here and the duplicates were removed.
+ *
+ * Thread-safe via a [Collections.synchronizedMap] wrapper. The `get`-check-`put`
+ * sequence is *not* atomic across threads — concurrent callers may both observe
+ * a miss and re-fetch. For idempotent network reads this is acceptable (the
+ * last writer wins); do not rely on it for compute-expensive single-flight.
+ *
+ * @param maxSize LRU eviction threshold (entry-access-order, not insertion).
+ * @param ttlMs   time-to-live in milliseconds; entries older than this are
+ *                treated as misses on read and evicted lazily.
+ * @param clock   monotonic time source; defaults to [SystemClock.elapsedRealtime]
+ *                so production behaviour is unchanged. Injectable for unit tests
+ *                (the JVM tests in `core:model` cannot call `SystemClock` without
+ *                Robolectric).
+ */
+class TtlCache<V>(
+    private val maxSize: Int = DEFAULT_MAX_SIZE,
+    private val ttlMs: Long = DEFAULT_TTL_MS,
+    private val clock: () -> Long = SystemClock::elapsedRealtime,
+) {
+
+    private data class Entry<V>(val value: V, val fetchedAt: Long)
+
+    private val map: MutableMap<String, Entry<V>> =
+        Collections.synchronizedMap(
+            object : LinkedHashMap<String, Entry<V>>(16, 0.75f, true) {
+                override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Entry<V>>?): Boolean =
+                    size > maxSize
+            }
+        )
+
+    fun get(key: String): V? {
+        val entry = map[key] ?: return null
+        if (clock() - entry.fetchedAt >= ttlMs) {
+            map.remove(key)
+            return null
+        }
+        return entry.value
+    }
+
+    fun put(key: String, value: V) {
+        map[key] = Entry(value, clock())
+    }
+
+    fun remove(key: String) {
+        map.remove(key)
+    }
+
+    fun clear() {
+        map.clear()
+    }
+
+    fun evictExpired() {
+        val now = clock()
+        map.entries.removeIf { now - it.value.fetchedAt >= ttlMs }
+    }
+
+    companion object {
+        const val DEFAULT_MAX_SIZE = 30
+        const val DEFAULT_TTL_MS = 2 * 60 * 1000L
+    }
+}

--- a/core/model/src/test/java/com/raulshma/jellyplay/core/model/TtlCacheTest.kt
+++ b/core/model/src/test/java/com/raulshma/jellyplay/core/model/TtlCacheTest.kt
@@ -1,28 +1,54 @@
-package com.raulshma.jellyplay.core.data.cache
+package com.raulshma.jellyplay.core.model
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
+/**
+ * Pure-JVM tests — `TtlCache` accepts an injectable clock so it does not depend
+ * on `android.os.SystemClock` at test time (the `core:model` module has no
+ * Robolectric dependency).
+ */
 class TtlCacheTest {
+
+    private var fakeNowMs = 0L
+
+    private fun newCache(maxSize: Int = 10, ttlMs: Long = 60_000L) =
+        TtlCache<String>(maxSize = maxSize, ttlMs = ttlMs, clock = { fakeNowMs })
 
     @Test
     fun get_emptyCache_returnsNull() {
-        val cache = TtlCache<String>(maxSize = 10, ttlMs = 60_000L)
+        val cache = newCache()
         assertNull(cache.get("key"))
     }
 
     @Test
     fun put_thenGet_returnsValue() {
-        val cache = TtlCache<String>(maxSize = 10, ttlMs = 60_000L)
+        val cache = newCache()
         cache.put("key", "value")
         assertEquals("value", cache.get("key"))
     }
 
     @Test
+    fun get_afterTtl_returnsNull() {
+        val cache = newCache(ttlMs = 1_000L)
+        cache.put("key", "value")
+        fakeNowMs += 1_000L
+        assertNull(cache.get("key"))
+    }
+
+    @Test
+    fun get_beforeTtl_returnsValue() {
+        val cache = newCache(ttlMs = 1_000L)
+        cache.put("key", "value")
+        fakeNowMs += 999L
+        assertEquals("value", cache.get("key"))
+    }
+
+    @Test
     fun remove_existingKey_removesEntry() {
-        val cache = TtlCache<String>(maxSize = 10, ttlMs = 60_000L)
+        val cache = newCache()
         cache.put("key", "value")
         cache.remove("key")
         assertNull(cache.get("key"))
@@ -30,13 +56,13 @@ class TtlCacheTest {
 
     @Test
     fun remove_nonExistingKey_noOp() {
-        val cache = TtlCache<String>(maxSize = 10, ttlMs = 60_000L)
+        val cache = newCache()
         cache.remove("nonexistent")
     }
 
     @Test
     fun clear_removesAllEntries() {
-        val cache = TtlCache<String>(maxSize = 10, ttlMs = 60_000L)
+        val cache = newCache()
         cache.put("key1", "value1")
         cache.put("key2", "value2")
         cache.clear()
@@ -46,7 +72,7 @@ class TtlCacheTest {
 
     @Test
     fun put_overwritesExistingKey() {
-        val cache = TtlCache<String>(maxSize = 10, ttlMs = 60_000L)
+        val cache = newCache()
         cache.put("key", "value1")
         cache.put("key", "value2")
         assertEquals("value2", cache.get("key"))
@@ -54,7 +80,7 @@ class TtlCacheTest {
 
     @Test
     fun put_exceedsMaxSize_evictsEldest() {
-        val cache = TtlCache<String>(maxSize = 3, ttlMs = 60_000L)
+        val cache = newCache(maxSize = 3)
         cache.put("key1", "value1")
         cache.put("key2", "value2")
         cache.put("key3", "value3")
@@ -67,7 +93,7 @@ class TtlCacheTest {
 
     @Test
     fun get_accessedKey_preventsEviction() {
-        val cache = TtlCache<String>(maxSize = 3, ttlMs = 60_000L)
+        val cache = newCache(maxSize = 3)
         cache.put("key1", "value1")
         cache.put("key2", "value2")
         cache.put("key3", "value3")
@@ -79,8 +105,9 @@ class TtlCacheTest {
 
     @Test
     fun evictExpired_removesStaleEntries() {
-        val cache = TtlCache<String>(maxSize = 10, ttlMs = 0L)
+        val cache = newCache(ttlMs = 1_000L)
         cache.put("key", "value")
+        fakeNowMs += 1_000L
         cache.evictExpired()
         assertNull(cache.get("key"))
     }

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/AdminApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/AdminApiClientImpl.kt
@@ -8,6 +8,7 @@ import com.raulshma.jellyplay.core.model.ScheduledTaskInfo
 import com.raulshma.jellyplay.core.model.SessionInfo
 import com.raulshma.jellyplay.core.model.SystemInfo
 import com.raulshma.jellyplay.core.model.TaskTriggerInfo
+import com.raulshma.jellyplay.core.model.TtlCache
 import org.jellyfin.sdk.model.api.DayOfWeek
 import org.jellyfin.sdk.model.api.TaskTriggerInfoType
 import org.jellyfin.sdk.model.serializer.toUUID
@@ -20,9 +21,18 @@ class AdminApiClientImpl @Inject constructor(
     private val engine: JellyfinApiEngine,
 ) : AdminApiClient {
 
+    // loadDashboard() runs on every admin screen entry and on periodic refresh,
+    // re-issuing getSystemInfo + getItemCounts in parallel each time. Both are
+    // near-static (server version / library counts) but the repository layer
+    // does not memoise them here (unlike MediaRepositoryImpl). A short TTL
+    // removes the redundant calls without observable staleness.
+    private val systemInfoCache = TtlCache<SystemInfo>(maxSize = 4, ttlMs = SYSTEM_INFO_TTL_MS)
+    private val itemCountsCache = TtlCache<ItemCounts>(maxSize = 4, ttlMs = ITEM_COUNTS_TTL_MS)
+
     override suspend fun getSystemInfo(): Result<SystemInfo> = engine.apiResultWithRetry {
+        systemInfoCache.get(KEY_SYSTEM_INFO)?.let { return@apiResultWithRetry it }
         val dto = engine.requireApi().systemApi.getSystemInfo().content
-        SystemInfo(
+        val info = SystemInfo(
             serverName = dto.serverName ?: "",
             version = dto.version ?: "",
             productName = dto.productName ?: "",
@@ -43,11 +53,14 @@ class AdminApiClientImpl @Inject constructor(
             logPath = dto.logPath ?: "",
             internalMetadataPath = dto.internalMetadataPath ?: "",
         )
+        systemInfoCache.put(KEY_SYSTEM_INFO, info)
+        info
     }
 
     override suspend fun getItemCounts(): Result<ItemCounts> = engine.apiResultWithRetry {
+        itemCountsCache.get(KEY_ITEM_COUNTS)?.let { return@apiResultWithRetry it }
         val dto = engine.requireApi().libraryApi.getItemCounts().content
-        ItemCounts(
+        val counts = ItemCounts(
             movieCount = dto.movieCount.toLong(),
             seriesCount = dto.seriesCount.toLong(),
             episodeCount = dto.episodeCount.toLong(),
@@ -60,6 +73,8 @@ class AdminApiClientImpl @Inject constructor(
                     dto.songCount.toLong() + dto.musicVideoCount.toLong() +
                     dto.bookCount.toLong(),
         )
+        itemCountsCache.put(KEY_ITEM_COUNTS, counts)
+        counts
     }
 
     override suspend fun restartServer(): Result<Unit> = engine.apiResultWithRetry {
@@ -227,5 +242,15 @@ class AdminApiClientImpl @Inject constructor(
                 arguments = arguments ?: emptyMap(),
             )
         )
+    }
+
+    private companion object {
+        const val KEY_SYSTEM_INFO = "systemInfo"
+        const val KEY_ITEM_COUNTS = "itemCounts"
+        // 2 minutes — long enough to dedupe the parallel calls fired by
+        // loadDashboard() and the independent About-screen getSystemInfo(),
+        // short enough to reflect server version/count changes promptly.
+        const val SYSTEM_INFO_TTL_MS = 2 * 60 * 1000L
+        const val ITEM_COUNTS_TTL_MS = 2 * 60 * 1000L
     }
 }

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/MediaInfoApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/MediaInfoApiClientImpl.kt
@@ -12,6 +12,7 @@ import com.raulshma.jellyplay.core.model.PlaybackReportingActivity
 import com.raulshma.jellyplay.core.model.PlaybackReportingDetail
 import com.raulshma.jellyplay.core.model.PlaybackReportingStatus
 import com.raulshma.jellyplay.core.model.StaleMediaItem
+import com.raulshma.jellyplay.core.model.TtlCache
 import com.raulshma.jellyplay.core.model.WatchedMediaItem
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -36,13 +37,24 @@ class MediaInfoApiClientImpl @Inject constructor(
     private val engine: JellyfinApiEngine,
 ) : MediaInfoApiClient {
 
+    // The server name is effectively session-static but lives below the
+    // repository layer (which already caches library folders), so every
+    // newsletter render previously bypassed the in-memory cache. Short TTL
+    // keeps it fresh across server renames without per-render network calls.
+    private val serverNameCache = TtlCache<String>(maxSize = 4, ttlMs = 30 * 60 * 1000L)
+
+    private suspend fun getCachedServerName(): String {
+        serverNameCache.get(KEY_SERVER_NAME)?.let { return it }
+        return try {
+            val name = engine.requireApi().systemApi.getSystemInfo().content.serverName ?: ""
+            serverNameCache.put(KEY_SERVER_NAME, name)
+            name
+        } catch (_: Exception) { "" }
+    }
+
     override suspend fun getNewsletterData(sinceDate: String, limit: Int): Result<NewsletterData> = engine.apiResultWithRetry {
         coroutineScope {
-            val serverName = async {
-                try {
-                    engine.requireApi().systemApi.getSystemInfo().content.serverName ?: ""
-                } catch (_: Exception) { "" }
-            }
+            val serverName = async { getCachedServerName() }
             val recentlyAdded = async {
                 try {
                     val folders = engine.requireApi().libraryApi.getMediaFolders().content?.items ?: emptyList()
@@ -660,5 +672,9 @@ class MediaInfoApiClientImpl @Inject constructor(
                 )
             }
         }
+    }
+
+    private companion object {
+        const val KEY_SERVER_NAME = "serverName"
     }
 }

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/cache/TtlCache.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/cache/TtlCache.kt
@@ -1,8 +1,17 @@
-package com.raulshma.jellyplay.core.data.cache
+package com.raulshma.jellyplay.core.network.cache
 
 import android.os.SystemClock
 import java.util.Collections
 
+/**
+ * Tiny LRU + TTL cache used inside [core:network] clients (e.g.
+ * `MediaInfoApiClientImpl`, `AdminApiClientImpl`) to memoise near-static
+ * server responses that sit below the repository-layer caches in `core:data`.
+ *
+ * `core:network` cannot depend on `core:data` (the dependency direction is
+ * inverted), so this is a focused duplicate of the `core:data` `TtlCache`
+ * rather than a shared abstraction. Keep the two implementations in sync.
+ */
 class TtlCache<V>(
     private val maxSize: Int = DEFAULT_MAX_SIZE,
     private val ttlMs: Long = DEFAULT_TTL_MS,
@@ -31,17 +40,8 @@ class TtlCache<V>(
         map[key] = Entry(value, elapsed())
     }
 
-    fun remove(key: String) {
-        map.remove(key)
-    }
-
     fun clear() {
         map.clear()
-    }
-
-    fun evictExpired() {
-        val now = elapsed()
-        map.entries.removeIf { now - it.value.fetchedAt >= ttlMs }
     }
 
     private fun elapsed(): Long = SystemClock.elapsedRealtime()

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
@@ -107,6 +107,13 @@ abstract class NetworkModule {
     ): TmdbApiClient
 
     companion object {
+        // Hoisted so the pattern compiles once at class load rather than on each
+        // OkHttp client construction (low impact since the provider is @Singleton,
+        // but removes an unnecessary per-cold-start Regex allocation).
+        val TOKEN_PARAM_PATTERN = Regex(
+            "(?i)(\\?|&)(api_key|apikey|token|x-emby-token|accesstoken)=[^&\\s]+",
+        )
+
         @Provides
         @Singleton
         fun provideConnectivityManager(
@@ -150,9 +157,7 @@ abstract class NetworkModule {
             // The logger replaces the query string of any URL line containing a
             // token-bearing param with "[redacted]" so verbose network logging
             // can never leak credentials to logcat.
-            val tokenParamPattern = Regex(
-                "(?i)(\\?|&)(api_key|apikey|token|x-emby-token|accesstoken)=[^&\\s]+",
-            )
+            val tokenParamPattern = TOKEN_PARAM_PATTERN
             val loggingInterceptor = HttpLoggingInterceptor { message ->
                 val safe = if (tokenParamPattern.containsMatchIn(message)) {
                     tokenParamPattern.replace(message) { mr ->

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
@@ -247,5 +247,26 @@ abstract class NetworkModule {
                 .readTimeout(streamingReadSec, TimeUnit.SECONDS)
                 .build()
         }
+
+        /**
+         * Derived client for download paths. Mirrors the per-run `newBuilder()`
+         * previously invoked inside `DownloadWorker.doWork()` — same connect /
+         * read / write timeouts, but hoisted to a single shared singleton so
+         * concurrent `DownloadWorker` invocations (the limiter allows up to
+         * `maxConcurrentDownloads`) no longer each pay a `build()` cost and
+         * clone the interceptor list. The base `OkHttpClient` shares its
+         * `ConnectionPool` and `Dispatcher` via `newBuilder()`, so behavior is
+         * identical to the prior per-worker client.
+         */
+        @Provides
+        @Singleton
+        @Named("download")
+        fun provideDownloadOkHttpClient(
+            okHttpClient: OkHttpClient,
+        ): OkHttpClient = okHttpClient.newBuilder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
     }
 }

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/SeerrApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/SeerrApiClientImpl.kt
@@ -4,6 +4,7 @@ import com.raulshma.jellyplay.core.model.seerr.*
 import com.raulshma.jellyplay.core.network.api.ApiException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -201,13 +202,12 @@ class SeerrApiClientImpl @Inject constructor(
     override suspend fun search(
         baseUrl: String, credentials: SeerrCredentials, query: String, page: Int,
     ): Result<SeerrSearchResponse> {
-        val url = buildUrl(baseUrl, "/search")
-            .let { base ->
-                Request.Builder().url(base).build().url.newBuilder()
-                    .addQueryParameter("query", query)
-                    .addQueryParameter("page", page.toString())
-                    .build()
-            }
+        // Build the HttpUrl directly rather than constructing a throwaway
+        // Request merely to borrow its url. Same final URL, less garbage.
+        val url = buildUrl(baseUrl, "/search").toHttpUrl().newBuilder()
+            .addQueryParameter("query", query)
+            .addQueryParameter("page", page.toString())
+            .build()
         val request = Request.Builder().url(url).withAuth(credentials).get().build()
         return parseAndMap(executeRequest(request))
     }

--- a/core/notification/src/main/java/com/raulshma/jellyplay/core/notification/worker/NewMediaCheckWorker.kt
+++ b/core/notification/src/main/java/com/raulshma/jellyplay/core/notification/worker/NewMediaCheckWorker.kt
@@ -18,8 +18,12 @@ import com.raulshma.jellyplay.core.notification.dispatcher.NotificationDispatche
 import com.raulshma.jellyplay.core.notification.scheduler.NotificationScheduler
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.util.Calendar
@@ -78,47 +82,24 @@ class NewMediaCheckWorker @AssistedInject constructor(
         if (enabledFolders.isEmpty()) return
 
         val isFirstScan = seenMediaRepository.count() == 0
-        val newItemsByLibrary = mutableMapOf<LibraryFolder, List<com.raulshma.jellyplay.core.model.MediaItem>>()
 
-        for (folder in enabledFolders) {
-            if (isStopped) break
-            delay(200)
+        // Per-folder fetches are independent (each folder's seen-id set is keyed
+        // by that folder's items), so they can run concurrently. A small gate
+        // keeps peak server load bounded — replaces the prior naive 200 ms
+        // per-folder `delay` that serialized every fetch behind N network RTTs.
+        val fetchGate = Semaphore(MAX_CONCURRENT_FOLDER_FETCHES)
 
-            val latestResult = mediaRepository.getLatestMedia(
-                parentId = folder.id,
-                limit = prefs.maxPerCheck,
-            )
-            val latest = latestResult.getOrDefault(emptyList())
-            if (latest.isEmpty()) continue
+        val newItemsByLibrary = coroutineScope {
+            enabledFolders.map { folder ->
+                async {
+                    if (isStopped) return@async null
 
-            val config = prefs.libraryConfigs[folder.id]
-            val filtered = if (config != null && config.mediaTypes.isNotEmpty()) {
-                latest.filter { it.mediaType.name in config.mediaTypes }
-            } else {
-                latest
-            }
-            if (filtered.isEmpty()) continue
-
-            val itemIds = filtered.map { it.id }
-            val seenIds = seenMediaRepository.getSeenIds(itemIds)
-            val newItems = filtered.filter { it.id !in seenIds }
-
-            if (newItems.isNotEmpty()) {
-                seenMediaRepository.markAsSeen(
-                    newItems.map { item ->
-                        SeenMediaRecord(
-                            itemId = item.id,
-                            libraryId = folder.id,
-                            mediaType = item.mediaType.name,
-                            seenAtEpochMs = System.currentTimeMillis(),
-                        )
+                    fetchGate.withPermit {
+                        fetchFolderNewItems(folder, prefs, isFirstScan)
                     }
-                )
-                if (!isFirstScan) {
-                    newItemsByLibrary[folder] = newItems
                 }
-            }
-        }
+            }.awaitAll()
+        }.filterNotNull().toMap()
 
         val thirtyDaysAgo = System.currentTimeMillis() - THIRTY_DAYS_MS
         seenMediaRepository.pruneOlderThan(thirtyDaysAgo)
@@ -126,6 +107,59 @@ class NewMediaCheckWorker @AssistedInject constructor(
         if (newItemsByLibrary.isNotEmpty()) {
             dispatcher.dispatch(newItemsByLibrary, prefs)
         }
+    }
+
+    /**
+     * Fetches the latest media for a single library folder and records any
+     * never-seen-before items. Returns the folder → new-items pair (or null if
+     * nothing new was found, the worker was cancelled, or this is the first
+     * scan where notifications would be noise).
+     *
+     * Each folder's seen-id lookups are keyed only by items returned for that
+     * same folder, so concurrent invocations across distinct folders do not
+     * race on shared state.
+     */
+    private suspend fun fetchFolderNewItems(
+        folder: LibraryFolder,
+        prefs: NotificationPreferences,
+        isFirstScan: Boolean,
+    ): Pair<LibraryFolder, List<com.raulshma.jellyplay.core.model.MediaItem>>? {
+        if (isStopped) return null
+
+        val latestResult = mediaRepository.getLatestMedia(
+            parentId = folder.id,
+            limit = prefs.maxPerCheck,
+        )
+        val latest = latestResult.getOrDefault(emptyList())
+        if (latest.isEmpty()) return null
+
+        val config = prefs.libraryConfigs[folder.id]
+        val filtered = if (config != null && config.mediaTypes.isNotEmpty()) {
+            latest.filter { it.mediaType.name in config.mediaTypes }
+        } else {
+            latest
+        }
+        if (filtered.isEmpty()) return null
+
+        val itemIds = filtered.map { it.id }
+        val seenIds = seenMediaRepository.getSeenIds(itemIds)
+        val newItems = filtered.filter { it.id !in seenIds }
+
+        if (newItems.isEmpty()) return null
+
+        seenMediaRepository.markAsSeen(
+            newItems.map { item ->
+                SeenMediaRecord(
+                    itemId = item.id,
+                    libraryId = folder.id,
+                    mediaType = item.mediaType.name,
+                    seenAtEpochMs = System.currentTimeMillis(),
+                )
+            }
+        )
+        // On the first scan everything is "new" — suppress notifications to
+        // avoid spamming the user with the entire library catalog.
+        return if (isFirstScan) null else folder to newItems
     }
 
     private fun isInQuietHours(prefs: NotificationPreferences): Boolean =
@@ -144,6 +178,9 @@ class NewMediaCheckWorker @AssistedInject constructor(
     companion object {
         const val WORK_TAG = "notification"
         private const val THIRTY_DAYS_MS = 30L * 24 * 60 * 60 * 1000
+        /** Bounds concurrent per-folder network fetches so a server with many
+         *  enabled libraries is not hit with N simultaneous requests. */
+        private const val MAX_CONCURRENT_FOLDER_FETCHES = 4
 
         /**
          * Pure helper that decides whether [currentMinutes] falls inside a quiet-hours window

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/AccentColorPicker.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/AccentColorPicker.kt
@@ -97,7 +97,7 @@ fun AccentColorPicker(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
-            items(count = swatches.size, contentType = { "swatch" }) { i ->
+            items(count = swatches.size, key = { swatches[it].name }, contentType = { "swatch" }) { i ->
                 val swatch = swatches[i]
                 val isSelected = (selectedSwatch.lowercase() == swatch.name.lowercase()) ||
                     (selectedSwatch == "dynamic" && swatch == AccentColorSwatch.DYNAMIC)
@@ -298,7 +298,7 @@ fun ColorStylePicker(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
-            items(count = styles.size, contentType = { "style" }) { i ->
+            items(count = styles.size, key = { styles[it].name }, contentType = { "style" }) { i ->
                 val style = styles[i]
                 val isSelected = style == selectedStyle
 
@@ -407,7 +407,7 @@ fun SynthwaveAccentPicker(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
-            items(count = accents.size, contentType = { "accent" }) { i ->
+            items(count = accents.size, key = { accents[it].first }, contentType = { "accent" }) { i ->
                 val (accentName, color) = accents[i]
                 val isSelected = selectedAccent.lowercase() == accentName.lowercase()
 
@@ -518,7 +518,7 @@ fun SoothingAccentPicker(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier.fillMaxWidth()
         ) {
-            items(count = accents.size, contentType = { "accent" }) { i ->
+            items(count = accents.size, key = { accents[it].first }, contentType = { "accent" }) { i ->
                 val (accentName, color) = accents[i]
                 val isSelected = selectedAccent.lowercase() == accentName.lowercase()
 

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/DateFormatHelper.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/DateFormatHelper.kt
@@ -7,16 +7,40 @@ import java.util.Locale
 
 private const val ISO_DATE_PATTERN = "yyyy-MM-dd"
 
+/**
+ * Cache of per-thread [SimpleDateFormat] instances, keyed by pattern+locale.
+ *
+ * `SimpleDateFormat` construction parses the pattern and builds a
+ * `DateFormatSymbols` graph — one of the more expensive `java.text`
+ * allocations — and `formatDate`/`formatDateIso` are called from list-item
+ * composables and viewmodels. Caching avoids rebuilding that graph per call.
+ *
+ * `SimpleDateFormat` is **not** thread-safe, so a [ThreadLocal] is required
+ * (rather than a single shared instance). Each thread that calls these helpers
+ * pays the construction cost exactly once per distinct pattern+locale; later
+ * calls reuse the cached instance.
+ */
+private val dateFormatCache = ThreadLocal<MutableMap<String, SimpleDateFormat>>()
+
+private fun obtainFormatter(pattern: String, locale: Locale): SimpleDateFormat {
+    val cache = dateFormatCache.get() ?: mutableMapOf<String, SimpleDateFormat>().also { dateFormatCache.set(it) }
+    val key = "$pattern@${locale.toLanguageTag()}"
+    return cache.getOrPut(key) { SimpleDateFormat(pattern, locale) }
+}
+
 fun getDateFormat(preference: DateFormatPreference): SimpleDateFormat = when (preference) {
     DateFormatPreference.SYSTEM -> {
         val locale = Locale.getDefault()
-        SimpleDateFormat(android.text.format.DateFormat.getBestDateTimePattern(locale, "MM/dd/yyyy"), locale)
+        obtainFormatter(
+            android.text.format.DateFormat.getBestDateTimePattern(locale, "MM/dd/yyyy"),
+            locale,
+        )
     }
-    DateFormatPreference.US -> SimpleDateFormat("MM/dd/yyyy", Locale.US)
-    DateFormatPreference.ISO -> SimpleDateFormat(ISO_DATE_PATTERN, Locale.US)
-    DateFormatPreference.EU -> SimpleDateFormat("dd/MM/yyyy", Locale.UK)
-    DateFormatPreference.LONG -> SimpleDateFormat("MMMM d, yyyy", Locale.getDefault())
-    DateFormatPreference.SHORT -> SimpleDateFormat("M/d/yy", Locale.US)
+    DateFormatPreference.US -> obtainFormatter("MM/dd/yyyy", Locale.US)
+    DateFormatPreference.ISO -> obtainFormatter(ISO_DATE_PATTERN, Locale.US)
+    DateFormatPreference.EU -> obtainFormatter("dd/MM/yyyy", Locale.UK)
+    DateFormatPreference.LONG -> obtainFormatter("MMMM d, yyyy", Locale.getDefault())
+    DateFormatPreference.SHORT -> obtainFormatter("M/d/yy", Locale.US)
 }
 
 fun formatDate(
@@ -27,6 +51,5 @@ fun formatDate(
     return formatter.format(Date(timestamp))
 }
 
-fun formatDateIso(timestamp: Long): String {
-    return SimpleDateFormat(ISO_DATE_PATTERN, Locale.US).format(Date(timestamp))
-}
+fun formatDateIso(timestamp: Long): String =
+    obtainFormatter(ISO_DATE_PATTERN, Locale.US).format(Date(timestamp))

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/DurationFormatter.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/DurationFormatter.kt
@@ -42,10 +42,13 @@ fun formatDurationMs(ms: Long): String {
     val hours = totalSeconds / 3600
     val minutes = (totalSeconds % 3600) / 60
     val seconds = totalSeconds % 60
+    // String templates avoid the Formatter + StringBuilder + boxed-varargs
+    // allocation that String.format makes per call — this runs per-frame
+    // during trickplay scrubbing.
     return if (hours > 0) {
-        String.format("%d:%02d:%02d", hours, minutes, seconds)
+        "$hours:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
     } else {
-        String.format("%d:%02d", minutes, seconds)
+        "$minutes:${seconds.toString().padStart(2, '0')}"
     }
 }
 

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/InlineTrailerPlayer.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/InlineTrailerPlayer.kt
@@ -340,6 +340,10 @@ fun InlineTrailerPlayer(
                 (webView.parent as? ViewGroup)?.removeView(webView)
                 webView.stopLoading()
                 webView.loadUrl("about:blank")
+                // Destroy the native renderer/V8/GPU textures. Detaching + loadUrl("about:blank")
+                // alone leaves the Chromium renderer process alive; destroy() is required to
+                // reclaim it.
+                webView.destroy()
             }
         }
     }

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/MediaCardComponents.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/MediaCardComponents.kt
@@ -383,6 +383,10 @@ fun PosterCard(
                         modifier = imageModifier,
                         contentScale = ContentScale.Crop,
                         crossfade = false,
+                        // Poster cards fill a dynamic column width at a 2:3 aspect ratio.
+                        // ~360×540 px covers ~2× density for typical grid card sizes
+                        // (≤180 dp wide) without the over-decode of the 512×512 default.
+                        size = CoilSize(360, 540),
                     )
                 }
 

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SeerrMediaCard.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SeerrMediaCard.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil3.size.Size as CoilSize
 import com.raulshma.jellyplay.core.designsystem.theme.AlphaEasing
 import com.raulshma.jellyplay.core.designsystem.theme.FancyTransitionEasing
 import com.raulshma.jellyplay.core.designsystem.theme.RatingColors
@@ -297,6 +298,9 @@ fun SeerrMediaCard(
                         modifier = imageModifier,
                         contentScale = ContentScale.Crop,
                         crossfade = false,
+                        // Poster card (2:3, fillMaxWidth). ~360×540 covers ~2× density
+                        // for typical grid card widths without the 512×512 over-decode.
+                        size = CoilSize(360, 540),
                     )
                 } else {
                     Box(

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/image/BlurHashImage.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/image/BlurHashImage.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -40,7 +39,6 @@ internal fun BlurHashImage(
     decodeWidth: Int = 32,
     decodeHeight: Int = 32,
 ) {
-    val density = LocalDensity.current
     val bitmapState = produceState<ImageBitmap?>(null, blurHash, decodeWidth, decodeHeight) {
         val cached = BlurHashCache.get(blurHash)
         if (cached != null && !cached.isRecycled) {

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/components/AuditHistoryTab.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/components/AuditHistoryTab.kt
@@ -186,6 +186,7 @@ private fun AuditEntryCard(entry: AuditLogEntry) {
     }
 }
 
+@Composable
 private fun formatRelativeTime(timestamp: Long): String {
     val diff = System.currentTimeMillis() - timestamp
     return when {
@@ -193,10 +194,18 @@ private fun formatRelativeTime(timestamp: Long): String {
         diff < TimeUnit.HOURS.toMillis(1) -> "${TimeUnit.MILLISECONDS.toMinutes(diff)} minutes ago"
         diff < TimeUnit.DAYS.toMillis(1) -> "${TimeUnit.MILLISECONDS.toHours(diff)} hours ago"
         diff < TimeUnit.DAYS.toMillis(7) -> "${TimeUnit.MILLISECONDS.toDays(diff)} days ago"
-        else -> SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()).format(Date(timestamp))
+        else -> {
+            // Reuse a single SimpleDateFormat per locale instead of constructing
+            // one (pattern parse + DateFormatSymbols graph) per card per
+            // recomposition.
+            val formatter = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
+            formatter.format(Date(timestamp))
+        }
     }
 }
 
+@Composable
 private fun formatAbsoluteTime(timestamp: Long): String {
-    return SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.getDefault()).format(Date(timestamp))
+    val formatter = remember { SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.getDefault()) }
+    return formatter.format(Date(timestamp))
 }

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/logs/LogsViewModel.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/logs/LogsViewModel.kt
@@ -57,6 +57,11 @@ class LogsViewModel @Inject constructor(
     private val _liveEvents = MutableSharedFlow<ActivityLogEntry>(extraBufferCapacity = 64)
     val liveEvents: SharedFlow<ActivityLogEntry> = _liveEvents.asSharedFlow()
 
+    private companion object {
+        /** Reusable lenient Json — hoisted out of the per-WebSocket-message hot path. */
+        val JSON = Json { ignoreUnknownKeys = true }
+    }
+
     private var webSocket: WebSocket? = null
     private var pollingJob: Job? = null
     private var liveCollectJob: Job? = null
@@ -185,12 +190,11 @@ class LogsViewModel @Inject constructor(
         webSocket = okHttpClient.newWebSocket(request, object : WebSocketListener() {
             override fun onMessage(webSocket: WebSocket, text: String) {
                 try {
-                    val json = Json { ignoreUnknownKeys = true }
-                    val obj = json.parseToJsonElement(text).jsonObject
+                    val obj = JSON.parseToJsonElement(text).jsonObject
                     val messageType = obj["MessageType"]?.jsonPrimitive?.contentOrNull
                     if (messageType == "ActivityLogEntry") {
                         val dataStr = obj["MessageData"].toString()
-                        val entry = json.decodeFromString<ActivityLogEntry>(dataStr)
+                        val entry = JSON.decodeFromString<ActivityLogEntry>(dataStr)
                         _liveEvents.tryEmit(entry)
                     }
                 } catch (_: Exception) {}

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/plugins/components/CatalogTab.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/plugins/components/CatalogTab.kt
@@ -89,7 +89,7 @@ fun CatalogTab(
 
                 // Status filter chips (All / Installed / Available).
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    items(PluginStatusFilter.entries) { status ->
+                    items(PluginStatusFilter.entries, key = { it.name }) { status ->
                         FilterChip(
                             selected = statusFilter == status,
                             onClick = { onStatusFilterChange(status) },
@@ -102,7 +102,7 @@ fun CatalogTab(
 
                 // Category filter chips.
                 LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    items(PluginCategory.entries) { category ->
+                    items(PluginCategory.entries, key = { it.name }) { category ->
                         FilterChip(
                             selected = categoryFilter == category,
                             onClick = { onCategoryFilterChange(category) },

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/plugins/components/PluginCatalogCard.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/plugins/components/PluginCatalogCard.kt
@@ -38,6 +38,7 @@ import com.composables.icons.tabler.outline.Download
 import com.composables.icons.tabler.outline.Puzzle
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.PluginPackage
+import com.raulshma.jellyplay.core.ui.image.MediaImage
 import com.raulshma.jellyplay.core.ui.tv.rememberTvFocusState
 import com.raulshma.jellyplay.core.ui.tv.tvFocusIndicator
 import com.raulshma.jellyplay.feature.admin.plugins.isTrustedRepository
@@ -213,10 +214,14 @@ internal fun PluginImage(
         contentAlignment = Alignment.Center,
     ) {
         if (!imageUrl.isNullOrBlank()) {
-            coil3.compose.AsyncImage(
-                model = imageUrl,
+            // Route through the central MediaImage pipeline so the plugin image
+            // gets the same crossfade + explicit decode size as the rest of the app
+            // (avoids the bare-String AsyncImage over-decode at 40 dp).
+            MediaImage(
+                url = imageUrl,
                 contentDescription = null,
                 modifier = Modifier.fillMaxWidth(),
+                size = coil3.size.Size(80, 80),
             )
         } else {
             Box(

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/statistics/UserStatisticsScreen.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/statistics/UserStatisticsScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -64,7 +64,7 @@ fun UserStatisticsScreen(
     onUserDetail: (userId: String) -> Unit,
     viewModel: UserStatisticsViewModel = hiltViewModel(),
 ) {
-    val state by viewModel.state.collectAsState()
+    val state by viewModel.state.collectAsStateWithLifecycle()
     val adaptiveInfo = LocalAdaptiveInfo.current
 
     // TV focus-on-launch: focus the first user card once data arrives so D-pad input lands on

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/CollectionDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/CollectionDetailScreen.kt
@@ -37,6 +37,7 @@ import com.raulshma.jellyplay.core.designsystem.theme.LocalIsSynthwave
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil3.size.Size as CoilSize
 import com.raulshma.jellyplay.core.ui.adaptive.LocalAdaptiveInfo
 import com.raulshma.jellyplay.core.ui.adaptive.bottomPadding
 import com.raulshma.jellyplay.core.ui.adaptive.contentPadding
@@ -137,6 +138,9 @@ fun CollectionDetailScreen(
                                     modifier = Modifier
                                         .fillMaxSize()
                                         .graphicsLayer { alpha = 0.7f },
+                                    // Full-width backdrop banner (~200 dp tall). Decode large
+                                    // enough for tablets/TV rather than the blurry 512 default.
+                                    size = CoilSize(1280, 720),
                                 )
                             }
                         }

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/DetailViewModel.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/DetailViewModel.kt
@@ -299,7 +299,18 @@ class DetailViewModel @Inject constructor(
             mediaRepository.getEpisodes(seriesId, seasonId)
                 .onSuccess { episodeList ->
                     episodesMap[seasonId] = episodeList
-                    _uiState.update { it.copy(episodes = episodesMap.toMap()) }
+                    // Fold the fetchedSeasonIds update into the same emission as
+                    // the episodes update so each recursion level produces one
+                    // uiState copy (was two: one for episodes, one for
+                    // fetchedSeasonIds). StateFlow conflation means downstream
+                    // sees the final state either way; this halves the
+                    // intermediate allocation/emit churn.
+                    _uiState.update {
+                        it.copy(
+                            episodes = episodesMap.toMap(),
+                            fetchedSeasonIds = it.fetchedSeasonIds + seasonId,
+                        )
+                    }
 
                     if (episodeList.isEmpty()) {
                         val seasons = _uiState.value.seasons
@@ -317,7 +328,15 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     if (!_uiState.value.episodes.containsKey(seasonId)) {
                         episodesMap[seasonId] = emptyList()
-                        _uiState.update { it.copy(episodes = episodesMap.toMap()) }
+                        _uiState.update {
+                            it.copy(
+                                episodes = episodesMap.toMap(),
+                                fetchedSeasonIds = it.fetchedSeasonIds + seasonId,
+                            )
+                        }
+                    } else {
+                        // Still record the fetched season id even on a no-op failure.
+                        _uiState.update { it.copy(fetchedSeasonIds = it.fetchedSeasonIds + seasonId) }
                     }
 
                     val seasons = _uiState.value.seasons
@@ -333,7 +352,6 @@ class DetailViewModel @Inject constructor(
                         maybeComputeSmartPlayTarget()
                     }
                 }
-            _uiState.update { it.copy(fetchedSeasonIds = it.fetchedSeasonIds + seasonId) }
         }
     }
 

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailActionButtons.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailActionButtons.kt
@@ -75,7 +75,9 @@ internal fun DetailActionButtons(
     val itemProgressFraction = item.progressFraction()
     val hasProgress = itemProgressFraction != null && itemProgressFraction > 0f
     val allSeasonsFetched = seasons.isNotEmpty() && fetchedSeasonIds.size >= seasons.size
-    val allEpisodesEmpty = seasons.isNotEmpty() && episodes.values.all { it.isEmpty() }
+    val allEpisodesEmpty = remember(seasons, episodes) {
+        seasons.isNotEmpty() && episodes.values.all { it.isEmpty() }
+    }
     val isResolvingSeriesTarget = isSeries &&
         target == null &&
         !allSeasonsFetched
@@ -208,7 +210,6 @@ internal fun DetailActionButtons(
                 modifier = iconsModifier,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                val isTv = LocalTvMode.current
                 val markTvFocusState = rememberTvFocusState(focusedScale = 1.08f)
                 val favoriteTvFocusState = rememberTvFocusState(focusedScale = 1.08f)
 

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailBody.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailBody.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Brush
@@ -86,15 +85,12 @@ internal fun FadingItem(
         animationSpec = tween(300),
         label = "itemAlpha"
     )
-    val blurRadius by animateFloatAsState(
-        targetValue = if (visible) 0f else 8f,
-        animationSpec = tween(400),
-        label = "itemBlur"
-    )
+    // Render-thread blur animation dropped (was the most expensive piece of the
+    // entrance animation, applied to ~20 nested FadingItems during screen entry).
+    // Alpha-only fade preserves the entrance feel at a fraction of the cost.
     Box(
         modifier = modifier
             .graphicsLayer { this.alpha = alpha }
-            .blur(blurRadius.dp)
     ) {
         content()
     }
@@ -730,6 +726,31 @@ private fun VideosSection(
     onVideoClick: (SeerrRelatedVideo) -> Unit,
 ) {
     val bodyContentPad = LocalAdaptiveInfo.current.contentPadding(isTv = LocalTvMode.current)
+    // The video card border depends only on the active theme, not on the per-video
+    // data, so compute it once here rather than rebuilding a BorderStroke + gradient
+    // per video per recomposition.
+    val isSynthwave = LocalIsSynthwave.current
+    val isSoothing = LocalIsSoothingTheme.current
+    val videoCardBorder = when {
+        isSynthwave -> {
+            androidx.compose.foundation.BorderStroke(
+                width = 1.5.dp,
+                brush = Brush.linearGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.colorScheme.secondary
+                    )
+                )
+            )
+        }
+        isSoothing -> {
+            androidx.compose.foundation.BorderStroke(
+                width = 0.8.dp,
+                color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f)
+            )
+        }
+        else -> null
+    }
     Column {
         FadingItem {
             Text(
@@ -746,33 +767,13 @@ private fun VideosSection(
             contentPadding = PaddingValues(horizontal = bodyContentPad),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) { _, video, focusModifier ->
-                val thumbnailUrl = if (video.site?.lowercase() == "youtube") {
-                    "https://img.youtube.com/vi/${video.key}/mqdefault.jpg"
-                } else null
+                val thumbnailUrl = remember(video.site, video.key) {
+                    if (video.site?.equals("youtube", ignoreCase = true) == true) {
+                        "https://img.youtube.com/vi/${video.key}/mqdefault.jpg"
+                    } else null
+                }
 
                 val videoCardFocusState = rememberTvFocusState(focusedScale = 1.05f)
-                val isSynthwave = LocalIsSynthwave.current
-                val isSoothing = LocalIsSoothingTheme.current
-                val videoCardBorder = when {
-                    isSynthwave -> {
-                        androidx.compose.foundation.BorderStroke(
-                            width = 1.5.dp,
-                            brush = Brush.linearGradient(
-                                colors = listOf(
-                                    MaterialTheme.colorScheme.primary,
-                                    MaterialTheme.colorScheme.secondary
-                                )
-                            )
-                        )
-                    }
-                    isSoothing -> {
-                        androidx.compose.foundation.BorderStroke(
-                            width = 0.8.dp,
-                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f)
-                        )
-                    }
-                    else -> null
-                }
 
                 FadingItem {
                     Card(

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailBody.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailBody.kt
@@ -484,10 +484,17 @@ internal fun DetailContentBody(
             val showSeasons = (item.mediaType == MediaType.SERIES || item.mediaType == MediaType.EPISODE) && seasons.isNotEmpty()
             if (showSeasons) {
                 CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) {
-                    val filteredEpisodes = if (preferences.skipSpecials) {
-                        episodes.mapValues { (_, eps) -> eps.filter { it.seasonNumber != 0 } }
-                    } else {
-                        episodes
+                    // Memoize the skip-specials filter so it is not recomputed (allocating
+                    // a new Map + per-season Lists) on every recomposition of this
+                    // detail item (scroll-driven FadingItem animations, sibling
+                    // sections animating). Only re-runs when episodes or the
+                    // skipSpecials flag actually change.
+                    val filteredEpisodes = remember(episodes, preferences.skipSpecials) {
+                        if (preferences.skipSpecials) {
+                            episodes.mapValues { (_, eps) -> eps.filter { it.seasonNumber != 0 } }
+                        } else {
+                            episodes
+                        }
                     }
                     SeasonsSection(
                         seriesItem = item,

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailCast.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailCast.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import coil3.size.Size as CoilSize
 import com.raulshma.jellyplay.core.model.PersonInfo
 import com.raulshma.jellyplay.core.ui.image.MediaImage
 import com.raulshma.jellyplay.core.ui.tv.rememberTvFocusState
@@ -64,6 +65,8 @@ internal fun PersonItem(
                 .size(64.dp)
                 .clip(CircleShape),
             contentScale = ContentScale.Crop,
+            // 64.dp @ ~3× density renders at ~192 px; 128 px covers 2× density with margin.
+            size = CoilSize(128, 128),
         )
         Spacer(Modifier.height(4.dp))
         Text(

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailHeader.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailHeader.kt
@@ -99,9 +99,22 @@ internal fun MediaInfoSection(
     preferences: UserPreferences,
     horizontalPadding: androidx.compose.ui.unit.Dp = 24.dp,
 ) {
-    val videoStream = mediaStreams.firstOrNull { it.type == StreamType.VIDEO }
-    val audioStreams = mediaStreams.filter { it.type == StreamType.AUDIO }
-    val subtitleStreams = mediaStreams.filter { it.type == StreamType.SUBTITLE }
+    // Single-pass extraction of (first video, all audio, all subtitle) replaces
+    // three independent traversals per recomposition.
+    val (videoStream, audioStreams, subtitleStreams) = remember(mediaStreams) {
+        var firstVideo: MediaStream? = null
+        val audio = mutableListOf<MediaStream>()
+        val subtitle = mutableListOf<MediaStream>()
+        mediaStreams.forEach { s ->
+            when (s.type) {
+                StreamType.VIDEO -> if (firstVideo == null) firstVideo = s
+                StreamType.AUDIO -> audio += s
+                StreamType.SUBTITLE -> subtitle += s
+                else -> Unit
+            }
+        }
+        Triple(firstVideo, audio, subtitle)
+    }
 
     if (videoStream == null && audioStreams.isEmpty() && subtitleStreams.isEmpty()) return
 
@@ -138,22 +151,30 @@ internal fun MediaInfoSection(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            val qualityLabel = buildString {
-                val res = videoStream?.height?.let { h ->
-                    when {
-                        h >= 2160 -> "4K"
-                        h >= 1080 -> "HD"
-                        h >= 720 -> "HD"
-                        else -> "SD"
-                    }
-                } ?: "Auto"
-                append(res)
-                append(" ")
-                val range = videoStream?.videoDoViTitle
-                    ?: videoStream?.videoRangeType
-                    ?: videoStream?.videoRange
-                    ?: "SDR"
-                append(range.uppercase())
+            // Hoist the per-string resources out of the remembered label builders
+            // (stringResource is composable-only) and remember the labels so the
+            // buildString allocations don't repeat per recomposition.
+            val audioChannelsFormat = stringResource(R.string.detail_audio_channels_format)
+            val subtitleOff = stringResource(R.string.detail_subtitle_off)
+
+            val qualityLabel = remember(videoStream) {
+                buildString {
+                    val res = videoStream?.height?.let { h ->
+                        when {
+                            h >= 2160 -> "4K"
+                            h >= 1080 -> "HD"
+                            h >= 720 -> "HD"
+                            else -> "SD"
+                        }
+                    } ?: "Auto"
+                    append(res)
+                    append(" ")
+                    val range = videoStream?.videoDoViTitle
+                        ?: videoStream?.videoRangeType
+                        ?: videoStream?.videoRange
+                        ?: "SDR"
+                    append(range.uppercase())
+                }
             }
 
             FadingItem(modifier = Modifier.weight(1f)) {
@@ -164,24 +185,26 @@ internal fun MediaInfoSection(
                 )
             }
 
-            val audioLabel = buildString {
-                append(
-                    selectedAudio
-                        ?.language?.uppercase()?.take(3)
-                        ?: selectedAudio?.displayTitle?.take(3)?.uppercase()
-                        ?: "AUTO"
-                )
-                selectedAudio?.channels?.let { channels ->
-                    append(" - ")
+            val audioLabel = remember(selectedAudio, audioChannelsFormat) {
+                buildString {
                     append(
-                        when (channels) {
-                            1 -> "MONO"
-                            2 -> "STEREO"
-                            6 -> "5.1"
-                            8 -> "7.1"
-                            else -> stringResource(R.string.detail_audio_channels_format, channels)
-                        }
+                        selectedAudio
+                            ?.language?.uppercase()?.take(3)
+                            ?: selectedAudio?.displayTitle?.take(3)?.uppercase()
+                            ?: "AUTO"
                     )
+                    selectedAudio?.channels?.let { channels ->
+                        append(" - ")
+                        append(
+                            when (channels) {
+                                1 -> "MONO"
+                                2 -> "STEREO"
+                                6 -> "5.1"
+                                8 -> "7.1"
+                                else -> audioChannelsFormat.format(channels)
+                            }
+                        )
+                    }
                 }
             }
 
@@ -196,12 +219,14 @@ internal fun MediaInfoSection(
                 )
             }
 
-            val subtitleLabel = selectedSubtitle
-                ?.displayTitle
-                ?.takeIf { it.isNotBlank() }
-                ?.let { if (it.length > 10) it.take(10) + "…" else it }
-                ?: selectedSubtitle?.language?.uppercase()?.take(3)
-                ?: stringResource(R.string.detail_subtitle_off)
+            val subtitleLabel = remember(selectedSubtitle, subtitleOff) {
+                selectedSubtitle
+                    ?.displayTitle
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { if (it.length > 10) it.take(10) + "…" else it }
+                    ?: selectedSubtitle?.language?.uppercase()?.take(3)
+                    ?: subtitleOff
+            }
 
             FadingItem(modifier = Modifier.weight(1f)) {
                 QuickInfoPill(
@@ -217,45 +242,69 @@ internal fun MediaInfoSection(
 
         if (picker != null) {
             val activePicker = picker ?: return@Column
-            val options = when (activePicker) {
-                StreamPickerType.AUDIO -> {
-                    buildList {
-                        if (selectedAudioIndex != null) {
-                            add(StreamPickerOption(index = null, label = stringResource(R.string.detail_stream_auto), isDefault = false))
-                        }
-                        add(StreamPickerOption(index = -1, label = stringResource(R.string.detail_stream_default), isDefault = true))
-                        addAll(
-                            audioStreams.map { stream ->
-                                StreamPickerOption(
-                                    index = stream.index,
-                                    label = stream.displayTitle
-                                        ?: stream.title
-                                        ?: stream.language
-                                        ?: stringResource(R.string.detail_audio_track_format, stream.index),
-                                    isDefault = stream.isDefault,
-                                )
+            // Hoist the string lookups out of the remembered builder (stringResource
+            // is composable-only) and remember the option list so it isn't rebuilt
+            // with fresh StreamPickerOption allocations on every recompose while the
+            // picker sheet is open (audio/subtitle lists commonly 10–20 entries).
+            val autoLabel = stringResource(R.string.detail_stream_auto)
+            val defaultLabel = stringResource(R.string.detail_stream_default)
+            val offLabel = stringResource(R.string.detail_stream_subtitle_off)
+            // Fetch the raw format templates (no args → unformatted) so the
+            // remembered builder can substitute the per-stream index itself.
+            val audioTrackFormat = stringResource(R.string.detail_audio_track_format)
+            val subtitleTrackFormat = stringResource(R.string.detail_subtitle_track_format)
+            val options = remember(
+                activePicker,
+                audioStreams,
+                subtitleStreams,
+                selectedAudioIndex,
+                selectedSubtitleIndex,
+                autoLabel,
+                defaultLabel,
+                offLabel,
+                audioTrackFormat,
+                subtitleTrackFormat,
+            ) {
+                when (activePicker) {
+                    StreamPickerType.AUDIO -> {
+                        buildList {
+                            if (selectedAudioIndex != null) {
+                                add(StreamPickerOption(index = null, label = autoLabel, isDefault = false))
                             }
-                        )
+                            add(StreamPickerOption(index = -1, label = defaultLabel, isDefault = true))
+                            addAll(
+                                audioStreams.map { stream ->
+                                    StreamPickerOption(
+                                        index = stream.index,
+                                        label = stream.displayTitle
+                                            ?: stream.title
+                                            ?: stream.language
+                                            ?: audioTrackFormat.format(stream.index),
+                                        isDefault = stream.isDefault,
+                                    )
+                                }
+                            )
+                        }
                     }
-                }
-                StreamPickerType.SUBTITLE -> {
-                    buildList {
-                        if (selectedSubtitleIndex != null) {
-                            add(StreamPickerOption(index = null, label = stringResource(R.string.detail_stream_auto), isDefault = false))
-                        }
-                        add(StreamPickerOption(index = -1, label = stringResource(R.string.detail_stream_subtitle_off), isDefault = true))
-                        addAll(
-                            subtitleStreams.map { stream ->
-                                StreamPickerOption(
-                                    index = stream.index,
-                                    label = stream.displayTitle
-                                        ?: stream.title
-                                        ?: stream.language
-                                        ?: stringResource(R.string.detail_subtitle_track_format, stream.index),
-                                    isDefault = stream.isDefault,
-                                )
+                    StreamPickerType.SUBTITLE -> {
+                        buildList {
+                            if (selectedSubtitleIndex != null) {
+                                add(StreamPickerOption(index = null, label = autoLabel, isDefault = false))
                             }
-                        )
+                            add(StreamPickerOption(index = -1, label = offLabel, isDefault = true))
+                            addAll(
+                                subtitleStreams.map { stream ->
+                                    StreamPickerOption(
+                                        index = stream.index,
+                                        label = stream.displayTitle
+                                            ?: stream.title
+                                            ?: stream.language
+                                            ?: subtitleTrackFormat.format(stream.index),
+                                        isDefault = stream.isDefault,
+                                    )
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailMusic.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailMusic.kt
@@ -87,6 +87,9 @@ internal fun AlbumTrackItem(
                 blurHash = track.blurHashes.primary,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
+                // 48.dp target — decode a small thumbnail instead of full album
+                // artwork (commonly 800–1500 px²). Tracks compose eagerly.
+                size = coil3.size.Size(96, 96),
             )
         }
 

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
@@ -100,6 +100,7 @@ import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.model.UserPreferences
 import com.raulshma.jellyplay.core.model.seerr.SeerrRelatedVideo
 import com.raulshma.jellyplay.core.model.seerr.SeerrSearchItem
+import coil3.size.Size as CoilSize
 import com.raulshma.jellyplay.core.ui.adaptive.LocalAdaptiveInfo
 import com.raulshma.jellyplay.core.ui.adaptive.WindowSizeClass
 import com.raulshma.jellyplay.core.ui.adaptive.*
@@ -353,15 +354,17 @@ fun MediaDetailScreen(
             collectionItems = collectionItems,
             onPlayAlbumTrack = remember(viewModel) { { index: Int -> viewModel.playAlbum(index) } },
             relatedVideos = relatedVideos,
-            onVideoClick = { video ->
-                if (video.site?.lowercase() == "youtube" && video.key != null) {
-                    activeTrailerKey = video.key
-                } else if (video.key != null) {
-                    val url = when (video.site?.lowercase()) {
-                        "youtube" -> "https://www.youtube.com/watch?v=${video.key}"
-                        else -> null
+            onVideoClick = remember(uriHandler) {
+                { video: SeerrRelatedVideo ->
+                    if (video.site?.lowercase() == "youtube" && video.key != null) {
+                        activeTrailerKey = video.key
+                    } else if (video.key != null) {
+                        val url = when (video.site?.lowercase()) {
+                            "youtube" -> "https://www.youtube.com/watch?v=${video.key}"
+                            else -> null
+                        }
+                        url?.let { uriHandler.openUri(it) }
                     }
-                    url?.let { uriHandler.openUri(it) }
                 }
             },
             preferences = preferences,
@@ -736,6 +739,9 @@ private fun DetailContent(
                     blurHash = item?.blurHashes?.backdrop,
                     modifier = backdropModifier,
                     contentScale = ContentScale.Crop,
+                    // Full-bleed hero backdrop: decode large enough for 4K TV width
+                    // (3840 px). The default 512×512 produces visible blur on TV.
+                    size = CoilSize(1920, 1080),
                 )
             }
 

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
@@ -140,8 +140,15 @@ fun MediaDetailScreen(
     onBack: () -> Unit,
     viewModel: DetailViewModel = hiltViewModel(),
 ) {
+    // Declared before the load-item effect below so the trailer-dismiss reset
+    // can be merged into it (was previously a separate LaunchedEffect(itemId)).
+    var activeTrailerKey by remember { mutableStateOf<String?>(null) }
+
     LaunchedEffect(itemId) {
         viewModel.loadItem(itemId)
+        // Dismiss any open trailer dialog when navigating to a different item
+        // (previously a separate LaunchedEffect(itemId) block).
+        activeTrailerKey = null
     }
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -166,7 +173,7 @@ fun MediaDetailScreen(
     val userMessage = uiState.userMessage
     val cellularDownloadWarningMb = uiState.cellularDownloadWarningMb
     val seerrTvSeasons = uiState.seerrTvSeasons
-    LaunchedEffect(detail) {
+    LaunchedEffect(detail?.item?.id) {
         detail?.let {
             viewModel.loadSeerrDataIfNeeded(it)
         }
@@ -186,9 +193,6 @@ fun MediaDetailScreen(
     val outerIsLightTheme = rememberIsLightTheme()
 
     var showSeriesDownloadSheet by remember { mutableStateOf(false) }
-    var activeTrailerKey by remember { mutableStateOf<String?>(null) }
-    // Dismiss any open trailer dialog when navigating to a different item.
-    LaunchedEffect(itemId) { activeTrailerKey = null }
     val snackbarHostState = remember { SnackbarHostState() }
     val snackbarContext = LocalContext.current
 
@@ -589,15 +593,24 @@ private fun DetailContent(
         adaptiveInfo.windowSizeClass == WindowSizeClass.Expanded -> com.raulshma.jellyplay.core.ui.adaptive.AdaptiveBackdropHeight.Expanded
         else -> com.raulshma.jellyplay.core.ui.adaptive.AdaptiveBackdropHeight.Portrait
     }
-    val baseBackdropHeight = with(density) { (backdropHeight.toPx() / 1.2f).toDp() }
-    val collapsedHeight = with(density) { backdropHeight.toPx() }
-    val spacerHeightPx = with(density) { (baseBackdropHeight - 150.dp).toPx() }
-    val scrollOffset by remember {
+    // Hoist density-derived dimensions into a single remember keyed on their
+    // inputs so they don't reallocate per recompose and so the derivedStateOf
+    // blocks below capture the current value instead of one frozen at first
+    // composition (which was a latent bug on rotation / window resize / TV toggle).
+    val (baseBackdropHeight, collapsedHeight, spacerHeightPx) = remember(backdropHeight, density) {
+        with(density) {
+            val base = (backdropHeight.toPx() / 1.2f).toDp()
+            val collapsed = backdropHeight.toPx()
+            val spacer = (base - 150.dp).toPx()
+            Triple(base, collapsed, spacer)
+        }
+    }
+    val scrollOffset by remember(spacerHeightPx) {
         derivedStateOf {
             (if (listState.firstVisibleItemIndex > 0) spacerHeightPx else 0f) + listState.firstVisibleItemScrollOffset.toFloat()
         }
     }
-    val scrollFraction by remember {
+    val scrollFraction by remember(collapsedHeight) {
         derivedStateOf {
             (scrollOffset / collapsedHeight).coerceIn(0f, 1f)
         }
@@ -841,6 +854,10 @@ private fun DetailContent(
                                         url = getImageUrl(itemId),
                                         contentDescription = null,
                                         blurHash = item?.blurHashes?.primary,
+                                        // 220.dp × 3× ≈ 660 px wide; 2/3 aspect → ~990 px tall.
+                                        // Avoids under-sized decode (blur on TV) and over-sized
+                                        // decode (memory waste on phone) from the default size.
+                                        size = coil3.size.Size(660, 990),
                                         modifier = Modifier
                                             .fillMaxWidth()
                                             .aspectRatio(2f / 3f)
@@ -983,6 +1000,10 @@ private fun DetailContent(
                                             url = getImageUrl(itemId),
                                             contentDescription = null,
                                             blurHash = item?.blurHashes?.primary,
+                                            // Portrait poster (~120 dp × 3× ≈ 432 px) — decode a
+                                            // right-sized thumbnail instead of the default 512×512
+                                            // (or larger) bitmap.
+                                            size = coil3.size.Size(480, 600),
                                             modifier = Modifier
                                                 .fillMaxSize()
                                                 .clip(ShapeCache.smooth8)

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailSeasons.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailSeasons.kt
@@ -272,23 +272,29 @@ internal fun EpisodeCard(
 
     val isSynthwave = LocalIsSynthwave.current
     val isSoothing = LocalIsSoothingTheme.current
-    val borderModifier = when {
-        isSynthwave -> Modifier.border(
-            width = 1.5.dp,
-            brush = Brush.linearGradient(
-                colors = listOf(
-                    MaterialTheme.colorScheme.primary,
-                    MaterialTheme.colorScheme.secondary
-                )
-            ),
-            shape = ShapeCache.smooth16
-        )
-        isSoothing -> Modifier.border(
-            width = 0.8.dp,
-            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.35f),
-            shape = ShapeCache.smooth16
-        )
-        else -> Modifier
+    // Read theme colors here (composable scope) so the remember block below
+    // doesn't need to call composable functions.
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val secondaryColor = MaterialTheme.colorScheme.secondary
+    val outlineColor = MaterialTheme.colorScheme.outline
+    // Depends only on the active theme, not on the per-episode data — wrap in
+    // remember so the Modifier + gradient aren't rebuilt per card per recompose.
+    val borderModifier = remember(isSynthwave, isSoothing, primaryColor, secondaryColor, outlineColor) {
+        when {
+            isSynthwave -> Modifier.border(
+                width = 1.5.dp,
+                brush = Brush.linearGradient(
+                    colors = listOf(primaryColor, secondaryColor)
+                ),
+                shape = ShapeCache.smooth16
+            )
+            isSoothing -> Modifier.border(
+                width = 0.8.dp,
+                color = outlineColor.copy(alpha = 0.35f),
+                shape = ShapeCache.smooth16
+            )
+            else -> Modifier
+        }
     }
 
     Column(
@@ -327,6 +333,9 @@ internal fun EpisodeCard(
                     url = getImageUrl(episode.id),
                     contentDescription = episode.name,
                     blurHash = episode.blurHashes.primary,
+                    // Episode thumbnails render up to ~480 dp wide × 16:9. Decode a
+                    // right-sized bitmap (4–8 cards compose simultaneously).
+                    size = coil3.size.Size(640, 360),
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Crop,
                 )

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaInfoScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaInfoScreen.kt
@@ -1,6 +1,5 @@
 package com.raulshma.jellyplay.feature.details
 
-import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
@@ -133,11 +132,8 @@ private fun MediaSourceSection(
     sourceIndex: Int,
     totalSources: Int,
 ) {
-    val containerColor by animateColorAsState(
-        targetValue = MaterialTheme.colorScheme.surfaceContainerLow,
-        animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
-        label = "sourceContainerColor",
-    )
+    // Constant target — animateColorAsState was pure overhead (target never changes at runtime).
+    val containerColor = MaterialTheme.colorScheme.surfaceContainerLow
 
     Column(
         modifier = Modifier
@@ -170,9 +166,23 @@ private fun MediaSourceSection(
             add("Transcode" to if (source.supportsTranscoding) "Supported" else "No")
         })
 
-        val videoStreams = source.mediaStreams.filter { it.type == StreamType.VIDEO }
-        val audioStreams = source.mediaStreams.filter { it.type == StreamType.AUDIO }
-        val subtitleStreams = source.mediaStreams.filter { it.type == StreamType.SUBTITLE }
+        // Single-pass partition of mediaStreams replaces 3 independent filter
+        // allocations per source per recomposition.
+        val (videoStreams, audioStreams, subtitleStreams) = remember(source.mediaStreams) {
+            val video = mutableListOf<MediaStream>()
+            val audio = mutableListOf<MediaStream>()
+            val subtitle = mutableListOf<MediaStream>()
+            source.mediaStreams.forEach { s ->
+                when (s.type) {
+                    StreamType.VIDEO -> video += s
+                    StreamType.AUDIO -> audio += s
+                    StreamType.SUBTITLE -> subtitle += s
+                    // EMBEDDED_IMAGE and any future types are not displayed here.
+                    else -> Unit
+                }
+            }
+            Triple(video, audio, subtitle)
+        }
 
         if (videoStreams.isNotEmpty()) {
             StreamSection(
@@ -261,11 +271,8 @@ private fun StreamSection(
         }
 
         streams.forEachIndexed { index, stream ->
-            val streamColor by animateColorAsState(
-                targetValue = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-                animationSpec = MaterialTheme.motionScheme.defaultEffectsSpec(),
-                label = "streamContainerColor",
-            )
+            // Constant target — animateColorAsState was pure overhead (target never changes).
+            val streamColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
             Column(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeriesDownloadSheet.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeriesDownloadSheet.kt
@@ -94,10 +94,12 @@ fun SeriesDownloadSheet(
 
     val totalSelectedCount = selectedEpisodeIds.values.sumOf { it.size }
 
-    val allSelected = allSelectableIds.isNotEmpty() &&
-        allSelectableIds.all { id ->
-            selectedEpisodeIds.values.any { id in it }
-        }
+    // Flatten once into a Set instead of scanning every season set per id
+    // (was O(selectable × seasons); now O(total selected) once).
+    val allSelected = remember(allSelectableIds, selectedEpisodeIds) {
+        val selectedFlat = selectedEpisodeIds.values.flatten().toHashSet()
+        allSelectableIds.isNotEmpty() && allSelectableIds.all { it in selectedFlat }
+    }
 
     Column(
         modifier = Modifier
@@ -200,7 +202,7 @@ fun SeriesDownloadSheet(
                 .height(400.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            items(seasons, key = { it.id }) { season ->
+            items(seasons, key = { it.id }, contentType = { "season" }) { season ->
                 val isExpanded = expandedSeasonId == season.id
                 val seasonEpisodes = episodes[season.id].orEmpty()
                 val isLoadingThis = season.id in loadingSeasons

--- a/feature/downloads/src/main/java/com/raulshma/jellyplay/feature/downloads/DownloadsScreen.kt
+++ b/feature/downloads/src/main/java/com/raulshma/jellyplay/feature/downloads/DownloadsScreen.kt
@@ -128,6 +128,14 @@ fun DownloadsScreen(
                 description = "Downloaded content will appear here",
             )
         } else {
+            // Hoist the three pure formatter lambdas once above the list. They
+            // only delegate to viewModel and are identical across rows, so
+            // allocating them per-row per-recomposition (the list recomposes on
+            // every progress tick / speed sample) was pure churn (11 fresh
+            // lambdas/row).
+            val formatBytes = remember(viewModel) { { v: Long -> viewModel.formatBytes(v) } }
+            val formatSpeed = remember(viewModel) { { v: Long -> viewModel.formatSpeed(v) } }
+            val formatEta = remember(viewModel) { { d: Long, t: Long, s: Long -> viewModel.formatEta(d, t, s) } }
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
@@ -155,9 +163,9 @@ fun DownloadsScreen(
                     ) {
                         DownloadItemRow(
                             item = download,
-                            formatBytes = { viewModel.formatBytes(it) },
-                            formatSpeed = { viewModel.formatSpeed(it) },
-                            formatEta = { d, t, s -> viewModel.formatEta(d, t, s) },
+                            formatBytes = formatBytes,
+                            formatSpeed = formatSpeed,
+                            formatEta = formatEta,
                             // Completed downloads open their detail page on tap
                             // (matching the online experience) rather than auto-playing.
                             // A distinct Play action is still available in the row.

--- a/feature/downloads/src/main/java/com/raulshma/jellyplay/feature/downloads/OfflineDetailScreen.kt
+++ b/feature/downloads/src/main/java/com/raulshma/jellyplay/feature/downloads/OfflineDetailScreen.kt
@@ -457,10 +457,15 @@ private fun OfflineDetailContent(
                                 Spacer(Modifier.height(12.dp))
                                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                                     children.forEachIndexed { index, track ->
+                                        // Memoize the per-row click lambda so it isn't reallocated
+                                        // on every recomposition of this detail item.
+                                        val click = remember(track.id, track.mediaType) {
+                                            { onPlayOffline(track.id, track.mediaType) }
+                                        }
                                         OfflineTrackRow(
                                             track = track,
                                             index = index + 1,
-                                            onClick = { onPlayOffline(track.id, track.mediaType) },
+                                            onClick = click,
                                         )
                                     }
                                 }

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeAppBar.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeAppBar.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.Badge
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButtonMenu
@@ -34,9 +33,6 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.ToggleFloatingActionButton
 import androidx.compose.material3.ToggleFloatingActionButtonDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,7 +41,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -80,9 +75,8 @@ import com.composables.icons.tabler.outline.Clock
 
 @Composable
 fun HomeTopDock(
-    listState: LazyListState,
-    transitionRangePx: Float,
-    baseIconColor: Color,
+    appBarIconColor: Color,
+    appBarIconColorFaded: Color,
     isSearchFocused: Boolean,
     searchQuery: String,
     offlineMode: OfflineMode,
@@ -98,14 +92,9 @@ fun HomeTopDock(
     searchResultsContent: @Composable () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val scrollFraction by remember {
-        derivedStateOf {
-            if (listState.firstVisibleItemIndex > 0) 1f
-            else (listState.firstVisibleItemScrollOffset.toFloat() / transitionRangePx).coerceIn(0f, 1f)
-        }
-    }
-    val appBarIconColor = lerp(baseIconColor, MaterialTheme.colorScheme.onSurface, scrollFraction)
-    val appBarIconColorFaded = appBarIconColor.copy(alpha = 0.9f)
+    // Icon colors are now derived once in MainHomeContent and passed in; this
+    // previously recomputed an identical derivedStateOf + lerp on every
+    // recompose, duplicating work the caller had already done.
     val focusManager = LocalFocusManager.current
 
     val isTv = LocalTvMode.current

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHero.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHero.kt
@@ -65,6 +65,7 @@ import com.raulshma.jellyplay.core.designsystem.theme.AlphaEasing
 import com.raulshma.jellyplay.core.designsystem.theme.FancyTransitionEasing
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.MediaItem
+import com.raulshma.jellyplay.core.model.formatFixed
 import com.raulshma.jellyplay.core.ui.adaptive.LocalAdaptiveInfo
 import com.raulshma.jellyplay.core.ui.adaptive.WindowSizeClass
 import com.raulshma.jellyplay.core.ui.image.MediaImage
@@ -206,6 +207,16 @@ fun HeroHeader(
     val detailsTvFocusState = rememberTvFocusState()
     val heroPlayFocusRequester = focusRequester ?: remember { FocusRequester() }
     val heroDetailsFocusRequester = remember { FocusRequester() }
+
+    // Hero recomposes on every parallax/breath animation frame; memoize the
+    // per-item string derivations so they aren't rebuilt per frame.
+    val yearText = remember(item.id, item.year) { item.year?.toString() }
+    val runtimeText = remember(item.id, item.runTimeTicks) {
+        item.runTimeTicks?.let { "${it / 600_000_000}m" }
+    }
+    val ratingText = remember(item.id, item.communityRating) {
+        item.communityRating?.let { formatFixed(it.toDouble(), 1) }
+    }
 
     RequestOrRestoreFocus(
         focusRequester = if (isTv && requestInitialFocus) heroPlayFocusRequester else null,
@@ -363,13 +374,8 @@ fun HeroHeader(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                item.year?.let {
-                    InfoChip(text = it.toString())
-                }
-                item.runTimeTicks?.let { ticks ->
-                    val minutes = ticks / 600_000_000
-                    InfoChip(text = "${minutes}m")
-                }
+                yearText?.let { InfoChip(text = it) }
+                runtimeText?.let { InfoChip(text = it) }
                 item.officialRating?.let {
                     InfoChip(
                         text = it,
@@ -380,7 +386,7 @@ fun HeroHeader(
                         letterSpacing = 0.5.sp,
                     )
                 }
-                item.communityRating?.let { rating ->
+                ratingText?.let {
                     Box(
                         modifier = Modifier
                             .clip(ShapeCache.smooth8)
@@ -402,7 +408,7 @@ fun HeroHeader(
                             )
                             Spacer(Modifier.width(4.dp))
                             Text(
-                                text = String.format("%.1f", rating),
+                                text = ratingText,
                                 style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
                                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.9f),
                             )

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeMediaRows.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeMediaRows.kt
@@ -499,6 +499,11 @@ fun HomeMediaRow(
             ) { _, item, focusModifier ->
                 val memoizedClick = remember(item) { { onItemClick(item) } }
                 val memoizedPlayClick = onPlayClick?.let { click -> remember(item, click) { { click(item) } } }
+                // Memoize progress so per-card arithmetic runs only when ticks change,
+                // not on every scroll/animation-frame recompose (matches WideMediaCard).
+                val progressPercent = remember(item.id, item.playbackPositionTicks, item.runTimeTicks) {
+                    item.progressFraction() ?: 0f
+                }
                 PosterCard(
                     item = item,
                     imageUrl = imageUrlBuilder(item),
@@ -506,9 +511,7 @@ fun HomeMediaRow(
                     onClick = memoizedClick,
                     modifier = focusModifier.width(cardWidth),
                     showProgress = item.playbackPositionTicks != null && item.playbackPositionTicks!! > 0,
-                    progressPercent = if (item.runTimeTicks != null && item.runTimeTicks!! > 0) {
-                        (item.playbackPositionTicks?.toFloat() ?: 0f) / item.runTimeTicks!!.toFloat()
-                    } else 0f,
+                    progressPercent = progressPercent,
                     blurHash = item.blurHashes.primary,
                     onPlayClick = memoizedPlayClick,
                     sharedElementKey = "poster_${item.id}",
@@ -530,6 +533,11 @@ fun HomeMediaRow(
                 val item = effectiveItems[index]
                 val memoizedClick = remember(item) { { onItemClick(item) } }
                 val memoizedPlayClick = onPlayClick?.let { click -> remember(item, click) { { click(item) } } }
+                // Memoize progress so per-card arithmetic runs only when ticks change,
+                // not on every scroll/animation-frame recompose (matches WideMediaCard).
+                val progressPercent = remember(item.id, item.playbackPositionTicks, item.runTimeTicks) {
+                    item.progressFraction() ?: 0f
+                }
                 PosterCard(
                     item = item,
                     imageUrl = imageUrlBuilder(item),
@@ -537,9 +545,7 @@ fun HomeMediaRow(
                     onClick = memoizedClick,
                     modifier = Modifier.width(cardWidth),
                     showProgress = item.playbackPositionTicks != null && item.playbackPositionTicks!! > 0,
-                    progressPercent = if (item.runTimeTicks != null && item.runTimeTicks!! > 0) {
-                        (item.playbackPositionTicks?.toFloat() ?: 0f) / item.runTimeTicks!!.toFloat()
-                    } else 0f,
+                    progressPercent = progressPercent,
                     blurHash = item.blurHashes.primary,
                     onPlayClick = memoizedPlayClick,
                     sharedElementKey = "poster_${item.id}",

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeMediaRows.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeMediaRows.kt
@@ -230,7 +230,12 @@ fun WideMediaCard(
     )
 
     val dominantColor = rememberDominantColor(backdropUrl.ifBlank { imageUrl }, itemId = item.id)
-    val progressPercent = item.progressFraction() ?: 0f
+    // Memoize the progress fraction so it is recomputed only when the item's
+    // identity or its playback position/runtime ticks change (was recomputed
+    // on every recomposition of the card).
+    val progressPercent = remember(item.id, item.playbackPositionTicks, item.runTimeTicks) {
+        item.progressFraction() ?: 0f
+    }
     val playButtonSize = if (isTv) 44.dp else 36.dp
 
     // Press-and-hold "peek" preview; no-op on TV / when no controller is wired.

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeOfflineContent.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeOfflineContent.kt
@@ -84,21 +84,49 @@ fun OfflineHomeContent(
         return
     }
 
-    // Pre-compute sections. Only non-empty ones render.
-    val continueWatching = remember(offlineLibrary) {
-        offlineLibrary
-            .filter { it.playedPercentage in 1.0..94.99 }
-            .sortedWith(compareByDescending<OfflineMediaItem> { it.lastPlayedDate ?: "" }.thenByDescending { it.createdAt })
+    // Single-pass partition + accumulate. Previously this was six independent
+    // full-library traversals (continue-watching filter+sort, recent sort+take,
+    // movies/series/music filters, totalBytes sum) = O(6n) + 6 intermediate
+    // lists on every offline-library emission. Now O(n) for the partition and
+    // byte sum; the two sorts below run on their (small) partition inputs only.
+    val offlineSections = remember(offlineLibrary) {
+        val continueWatching = ArrayList<OfflineMediaItem>()
+        val movies = ArrayList<OfflineMediaItem>()
+        val series = ArrayList<OfflineMediaItem>()
+        val music = ArrayList<OfflineMediaItem>()
+        var totalBytes = 0L
+        for (item in offlineLibrary) {
+            totalBytes += item.totalSizeBytes
+            if (item.playedPercentage in 1.0..94.99) continueWatching += item
+            when (item.mediaType) {
+                MediaType.MOVIE -> movies += item
+                MediaType.SERIES -> series += item
+                MediaType.AUDIO, MediaType.MUSIC, MediaType.ALBUM -> music += item
+                // Other types (PHOTO, PHOTO_FOLDER, etc.) have no home row here.
+                else -> Unit
+            }
+        }
+        // Preserve original comparators for sort stability.
+        continueWatching.sortWith(
+            compareByDescending<OfflineMediaItem> { it.lastPlayedDate ?: "" }
+                .thenByDescending { it.createdAt }
+        )
+        val recent = offlineLibrary.sortedByDescending { it.createdAt }.take(10)
+        OfflineSections(
+            continueWatching = continueWatching,
+            recent = recent,
+            movies = movies,
+            series = series,
+            music = music,
+            totalBytes = totalBytes,
+        )
     }
-    val recent = remember(offlineLibrary) {
-        offlineLibrary.sortedByDescending { it.createdAt }.take(10)
-    }
-    val movies = remember(offlineLibrary) { offlineLibrary.filter { it.mediaType == MediaType.MOVIE } }
-    val series = remember(offlineLibrary) { offlineLibrary.filter { it.mediaType == MediaType.SERIES } }
-    val music = remember(offlineLibrary) {
-        offlineLibrary.filter { it.mediaType == MediaType.AUDIO || it.mediaType == MediaType.MUSIC || it.mediaType == MediaType.ALBUM }
-    }
-    val totalBytes = remember(offlineLibrary) { offlineLibrary.sumOf { it.totalSizeBytes } }
+    val continueWatching = offlineSections.continueWatching
+    val recent = offlineSections.recent
+    val movies = offlineSections.movies
+    val series = offlineSections.series
+    val music = offlineSections.music
+    val totalBytes = offlineSections.totalBytes
 
     LazyColumn(
         modifier = Modifier
@@ -241,6 +269,19 @@ private fun OfflineSection(
         }
     }
 }
+
+/**
+ * Holder for the single-pass partition of the offline library, replacing
+ * six independent full-library traversals. See [OfflineHomeContent].
+ */
+private data class OfflineSections(
+    val continueWatching: List<OfflineMediaItem>,
+    val recent: List<OfflineMediaItem>,
+    val movies: List<OfflineMediaItem>,
+    val series: List<OfflineMediaItem>,
+    val music: List<OfflineMediaItem>,
+    val totalBytes: Long,
+)
 
 /**
  * Inline "Downloaded" row shown on the online home. Upgraded from the old

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeScreen.kt
@@ -242,7 +242,10 @@ private fun MainHomeContent(
 
     var showSurprise by remember { mutableStateOf(false) }
     var featuredIndex by remember { mutableIntStateOf(0) }
-    val isTvForRotation = LocalContext.current.isTv()
+    // Computed once — `context.isTv()` reflects the device's form factor, which
+    // does not change across recompositions of this screen.
+    val context = LocalContext.current
+    val isTvForRotation = remember(context) { context.isTv() }
     var autoRotateEnabled by remember { mutableStateOf(!isTvForRotation) }
     var focusInHero by remember { mutableStateOf(true) }
     val heroFocusRequester = remember { FocusRequester() }
@@ -260,8 +263,11 @@ private fun MainHomeContent(
 
     val backdropUrl = remember(featuredItem?.id) { featuredItem?.let { viewModel.getBackdropUrl(it.id) } }
 
-    val savedScrollPos = viewModel.getHomeScrollPosition()
+    // Fetch the saved scroll position once (it is only consumed by the
+    // rememberSaveable initializer below; the previous form re-fetched it on
+    // every recomposition).
     val listState = rememberSaveable(saver = LazyListState.Saver) {
+        val savedScrollPos = viewModel.getHomeScrollPosition()
         LazyListState(
             firstVisibleItemIndex = if (isTv) 0 else savedScrollPos.firstVisibleItemIndex,
             firstVisibleItemScrollOffset = if (isTv) 0 else savedScrollPos.firstVisibleItemScrollOffset,
@@ -514,6 +520,26 @@ private fun MainHomeContent(
                         musicContent()
                     }
                     else -> {
+                        // Lift the unstable lambdas passed to HomeContentList into remembered
+                        // locals so the (~30-param, mostly unstable) composable becomes
+                        // skippable and the entire subtree stops recomposing per keystroke /
+                        // animation frame. `viewModel`, `callbacks` are stable refs; the
+                        // `focusInHero` MutableState setter is stable, so it needs no key.
+                        val onRetrySectionLoad = remember(viewModel) {
+                            { viewModel.onEvent(HomeUiEvent.Refresh) }
+                        }
+                        val onDismissNewsletterBanner = remember(viewModel) {
+                            { viewModel.onEvent(HomeUiEvent.DismissNewsletterBanner) }
+                        }
+                        val onContentItemClick = remember(callbacks) {
+                            { id: String -> callbacks.onItemClick(id, MediaType.UNKNOWN, null, "") }
+                        }
+                        val onFocusChange = remember { { focused: Boolean -> focusInHero = focused } }
+                        val onSeerrRequest = remember(viewModel) {
+                            { item: SeerrSearchItem ->
+                                viewModel.onEvent(HomeUiEvent.SelectSeerrRequestItem(item))
+                            }
+                        }
                         HomeContentList(
                             isLoading = state.isLoading,
                             homeHeroEnabled = state.homeHeroEnabled,
@@ -523,7 +549,7 @@ private fun MainHomeContent(
                             offlineLibrary = state.offlineLibrary,
                             sections = state.sections,
                             partialLoadError = state.partialLoadError,
-                            onRetrySectionLoad = { viewModel.onEvent(HomeUiEvent.Refresh) },
+                            onRetrySectionLoad = onRetrySectionLoad,
                             featuredItem = featuredItem,
                             listState = listState,
                             backgroundColor = backgroundColor,
@@ -535,7 +561,7 @@ private fun MainHomeContent(
                             mediaBackdropUrlBuilder = mediaBackdropUrlBuilder,
                             getImageUrl = remember { { id: String -> viewModel.getImageUrl(id) } },
                             getBackdropUrl = remember { { id: String -> viewModel.getBackdropUrl(id) } },
-                            onDismissNewsletterBanner = { viewModel.onEvent(HomeUiEvent.DismissNewsletterBanner) },
+                            onDismissNewsletterBanner = onDismissNewsletterBanner,
                             mediaOnItemClick = mediaOnItemClick,
                             mediaOnPlayClick = mediaOnPlayClick,
                             continueWatchingClickBehavior = state.continueWatchingClickBehavior,
@@ -546,9 +572,9 @@ private fun MainHomeContent(
                             seerrPrefetch = seerrPrefetch,
                             onSeerrItemClick = callbacks.onSeerrItemClick,
                             onOfflineLibraryClick = callbacks.onOfflineLibraryClick,
-                            onItemClick = { id -> callbacks.onItemClick(id, MediaType.UNKNOWN, null, "") },
-                            onFocusChange = { focusInHero = it },
-                            onSeerrRequest = { viewModel.onEvent(HomeUiEvent.SelectSeerrRequestItem(it)) },
+                            onItemClick = onContentItemClick,
+                            onFocusChange = onFocusChange,
+                            onSeerrRequest = onSeerrRequest,
                             onNewsletterClick = callbacks.onNewsletterClick,
                             photoFolderChildUrls = photoFolderChildUrls,
                             heroFocusRequester = heroFocusRequester,
@@ -557,10 +583,40 @@ private fun MainHomeContent(
                 }
             }
 
+                // Lift the search-results-overlay lambdas (recreated per keystroke
+                // below) into remembered locals so HomeSearchResultsOverlay's
+                // results LazyColumn stops being re-scored each keystroke.
+                // `viewModel`, `callbacks`, `focusManager` are stable; the
+                // `isSearchExpanded` MutableState delegate is stable, so its
+                // setter needs no remember key.
+                val searchGetImageUrl = remember(viewModel) { { id: String -> viewModel.getImageUrl(id) } }
+                val searchOnJellyfinClick = remember(viewModel, callbacks) {
+                    { item: com.raulshma.jellyplay.core.model.MediaItem ->
+                        isSearchExpanded = false
+                        viewModel.onEvent(HomeUiEvent.ClearSearch)
+                        focusManager.clearFocus()
+                        callbacks.onItemClick(item.id, item.mediaType, item.parentId, item.name)
+                    }
+                }
+                val searchOnSeerrClick = remember(viewModel, callbacks) {
+                    { item: SeerrSearchItem ->
+                        isSearchExpanded = false
+                        viewModel.onEvent(HomeUiEvent.ClearSearch)
+                        focusManager.clearFocus()
+                        callbacks.onSearchSeerrClick(item.id, item.mediaType)
+                    }
+                }
+                val searchOnHistoryClick = remember(viewModel) {
+                    { query: String -> viewModel.onEvent(HomeUiEvent.UpdateSearchQuery(query)) }
+                }
+                val searchOnDeleteHistoryItem = remember(viewModel) {
+                    { id: Long -> viewModel.deleteSearchHistoryItem(id) }
+                }
+                val searchOnClearHistory = remember(viewModel) { { viewModel.clearSearchHistory() } }
+
                 HomeTopDock(
-                    listState = listState,
-                    transitionRangePx = transitionRangePx,
-                    baseIconColor = baseIconColor,
+                    appBarIconColor = appBarIconColor,
+                    appBarIconColorFaded = appBarIconColorFaded,
                     isSearchFocused = isSearchFocused,
                     searchQuery = state.searchState.query,
                     offlineMode = state.offlineMode,
@@ -582,25 +638,13 @@ private fun MainHomeContent(
                                 jellyfinResults = state.searchState.jellyfinResults,
                                 seerrResults = state.searchState.seerrResults,
                                 isSearching = state.searchState.isSearching,
-                                getImageUrl = { viewModel.getImageUrl(it) },
-                                onJellyfinClick = { item ->
-                                    isSearchExpanded = false
-                                    viewModel.onEvent(HomeUiEvent.ClearSearch)
-                                    focusManager.clearFocus()
-                                    callbacks.onItemClick(item.id, item.mediaType, item.parentId, item.name)
-                                },
-                                onSeerrClick = { item ->
-                                    isSearchExpanded = false
-                                    viewModel.onEvent(HomeUiEvent.ClearSearch)
-                                    focusManager.clearFocus()
-                                    callbacks.onSearchSeerrClick(item.id, item.mediaType)
-                                },
+                                getImageUrl = searchGetImageUrl,
+                                onJellyfinClick = searchOnJellyfinClick,
+                                onSeerrClick = searchOnSeerrClick,
                                 searchHistory = searchHistory,
-                                onHistoryClick = { query ->
-                                    viewModel.onEvent(HomeUiEvent.UpdateSearchQuery(query))
-                                },
-                                onDeleteHistoryItem = { id -> viewModel.deleteSearchHistoryItem(id) },
-                                onClearHistory = { viewModel.clearSearchHistory() },
+                                onHistoryClick = searchOnHistoryClick,
+                                onDeleteHistoryItem = searchOnDeleteHistoryItem,
+                                onClearHistory = searchOnClearHistory,
                             )
                         }
                     },
@@ -749,6 +793,13 @@ private fun HomeContentList(
 ) {
     val isTv = LocalTvMode.current
     val adaptiveInfo = LocalAdaptiveInfo.current
+
+    // Discover-row dimensions computed once at the composable scope (not inside
+    // the LazyColumn's LazyListScope, where LocalConfiguration isn't readable).
+    val discoverScreenWidth = LocalConfiguration.current.screenWidthDp.dp
+    val discoverRowWidth = discoverScreenWidth - contentPad * 2
+    val discoverSpacing = adaptiveInfo.itemSpacing(isTv)
+    val discoverPattern = if (adaptiveInfo.windowSizeClass == WindowSizeClass.Compact) COMPACT_DISCOVER_PATTERN else EXPANDED_DISCOVER_PATTERN
 
     var askContinueItem by remember { mutableStateOf<com.raulshma.jellyplay.core.model.MediaItem?>(null) }
 
@@ -979,24 +1030,20 @@ private fun HomeContentList(
                     contentType = { "seerrRow" },
                 ) { rowIndex ->
                     val rowItems = discoverRows[rowIndex]
-                    val pattern = if (adaptiveInfo.windowSizeClass == WindowSizeClass.Compact) COMPACT_DISCOVER_PATTERN else EXPANDED_DISCOVER_PATTERN
-                    val targetSize = pattern[rowIndex % pattern.size]
-                    val spacing = adaptiveInfo.itemSpacing(isTv)
+                    val targetSize = discoverPattern[rowIndex % discoverPattern.size]
 
                     CompositionLocalProvider(
                         LocalSeerrCardLoadingState provides seerrCardLoadingState,
                         LocalSeerrPrefetch provides seerrPrefetch,
                     ) {
-                        val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-                        val rowWidth = screenWidth - contentPad * 2
-                        val itemWidth = (rowWidth - spacing * (targetSize - 1)) / targetSize.toFloat()
+                        val itemWidth = (discoverRowWidth - discoverSpacing * (targetSize - 1)) / targetSize.toFloat()
                         LazyRow(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .then(if (experimentalCardClippingEnabled) Modifier.clipToBounds() else Modifier)
                                 .background(backgroundColor)
-                                .padding(horizontal = contentPad, vertical = spacing / 2),
-                            horizontalArrangement = Arrangement.spacedBy(spacing),
+                                .padding(horizontal = contentPad, vertical = discoverSpacing / 2),
+                            horizontalArrangement = Arrangement.spacedBy(discoverSpacing),
                             userScrollEnabled = false,
                         ) {
                             items(

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeSearchOverlay.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeSearchOverlay.kt
@@ -228,9 +228,11 @@ fun HomeSearchResultsOverlay(
                         contentType = { "libraryItem" },
                     ) { index ->
                         val item = jellyfinResults[index]
-                        SearchItemRow(
-                            title = item.name,
-                            subtitle = buildString {
+                        // Memoized per row on stable primitives so search-as-you-type
+                        // recompositions don't re-run buildString + branches for every
+                        // visible row.
+                        val subtitle = remember(item.id, item.year, item.mediaType) {
+                            buildString {
                                 item.year?.let { append(it) }
                                 if (item.year != null && item.mediaType != null) append(" · ")
                                 when (item.mediaType) {
@@ -239,7 +241,11 @@ fun HomeSearchResultsOverlay(
                                     MediaType.AUDIO, MediaType.MUSIC -> append("Music")
                                     else -> item.mediaType?.name?.lowercase()?.replaceFirstChar { it.uppercase() }?.let { append(it) }
                                 }
-                            },
+                            }
+                        }
+                        SearchItemRow(
+                            title = item.name,
+                            subtitle = subtitle,
                             imageUrl = getImageUrl(item.id),
                             onClick = { onJellyfinClick(item) },
                             index = index,
@@ -274,9 +280,8 @@ fun HomeSearchResultsOverlay(
                         contentType = { "seerrItem" },
                     ) { index ->
                         val item = seerrResults[index]
-                        SearchItemRow(
-                            title = item.displayName,
-                            subtitle = buildString {
+                        val subtitle = remember(item.id, item.year, item.mediaType, item.voteAverage) {
+                            buildString {
                                 item.year?.let { append(it) }
                                 val typeLabel = when {
                                     item.mediaType.equals("movie", ignoreCase = true) -> "Movie"
@@ -291,7 +296,11 @@ fun HomeSearchResultsOverlay(
                                         append(String.format("%.1f", rating))
                                     }
                                 }
-                            },
+                            }
+                        }
+                        SearchItemRow(
+                            title = item.displayName,
+                            subtitle = subtitle,
                             imageUrl = item.posterUrl ?: "",
                             onClick = { onSeerrClick(item) },
                             index = index + jellyfinResults.size,

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeViewModel.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -45,6 +46,8 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import java.time.LocalDate
 import java.time.ZoneOffset
 import javax.inject.Inject
@@ -70,8 +73,19 @@ class HomeViewModel @Inject constructor(
 
     companion object {
         private const val REFRESH_INTERVAL_FOREGROUND_MS = 60_000L
-        private const val REFRESH_INTERVAL_BACKGROUND_MS = 120_000L
+        // Background polling is slowed to a 15-minute cadence. The Home VM
+        // survives while its nav entry is in the back stack, so a short
+        // background interval kept fanning out up to 5 Seerr requests while
+        // the user was on a different screen entirely. The existing
+        // onResume-if-stale refresh (see onStart) re-syncs immediately when
+        // the user returns to the foreground, so the longer background
+        // interval costs nothing in freshness.
+        private const val REFRESH_INTERVAL_BACKGROUND_MS = 15 * 60_000L
         private const val MIN_REFRESH_INTERVAL_MS = 30_000L
+        /** Max concurrent requests when prefetching photo-folder child image URLs. */
+        private const val PHOTO_FOLDER_PREFETCH_CONCURRENCY = 4
+        /** TTL for Seerr discover sections (trending/popular change slowly). */
+        private const val DISCOVER_TTL_MS = 10 * 60_000L
     }
 
     private val _uiState = stateFlow(HomeUiState())
@@ -99,6 +113,9 @@ class HomeViewModel @Inject constructor(
     private var homeFocusPosition = HomeFocusPosition()
     private var lastRefreshTime = 0L
     private var isAppInForeground = true
+    // Discover-sections TTL bookkeeping (see DISCOVER_TTL_MS / fetchDiscoverSections).
+    private var lastDiscoverFetchEpochMs = 0L
+    private var discoverCacheInvalidated = true
 
     private val searchQueryFlow: MutableStateFlow<String> = MutableStateFlow("")
     private var searchJob: Job? = null
@@ -267,11 +284,23 @@ class HomeViewModel @Inject constructor(
     fun prefetchPhotoFolderChildUrls(items: List<com.raulshma.jellyplay.core.model.MediaItem>) {
         launch {
             val current = _photoFolderChildUrls.value
-            items.filter { it.mediaType == com.raulshma.jellyplay.core.model.MediaType.PHOTO_FOLDER && it.id !in current }
-                .forEach { folder ->
-                    val urls = mediaRepository.getPhotoFolderChildImageUrls(folder.id)
-                    _photoFolderChildUrls.value = _photoFolderChildUrls.value + (folder.id to urls)
-                }
+            val toFetch = items.filter {
+                it.mediaType == com.raulshma.jellyplay.core.model.MediaType.PHOTO_FOLDER && it.id !in current
+            }
+            if (toFetch.isEmpty()) return@launch
+            // Parallelize the per-folder network calls with a bounded semaphore
+            // (was a sequential forEach → N× per-request latency) and emit the
+            // combined result once at the end instead of doing an O(N) map
+            // rebuild + StateFlow re-emit per folder.
+            val permits = Semaphore(PHOTO_FOLDER_PREFETCH_CONCURRENCY)
+            val results = coroutineScope {
+                toFetch.map { folder ->
+                    async {
+                        permits.withPermit { folder.id to mediaRepository.getPhotoFolderChildImageUrls(folder.id) }
+                    }
+                }.awaitAll()
+            }
+            _photoFolderChildUrls.value = _photoFolderChildUrls.value + results
         }
     }
 
@@ -316,6 +345,7 @@ class HomeViewModel @Inject constructor(
             resetHomeFocusPosition()
             _uiState.update { it.copy(sections = emptyList(), favorites = emptyList(), discoverSections = emptyMap(), error = null) }
             mediaRepository.invalidateCaches()
+            invalidateDiscoverCache()
             fetchAndUpdateSections()
             startPeriodicRefresh()
         }
@@ -325,6 +355,7 @@ class HomeViewModel @Inject constructor(
         launch {
             _uiState.update { it.copy(isRefreshing = true, error = null) }
             mediaRepository.invalidateCaches()
+            invalidateDiscoverCache()
             fetchAndUpdateSections()
             startPeriodicRefresh()
         }
@@ -537,6 +568,13 @@ class HomeViewModel @Inject constructor(
     private suspend fun fetchDiscoverSections(prefs: SeerrPreferences) {
         if (!prefs.enabled || !prefs.discoverEnabled) return
         if (offlineModeManager.networkStatus.value == NetworkStatus.Local) return
+        // Trending/popular change slowly; cache discover results for
+        // DISCOVER_TTL_MS so "just sitting on Home" doesn't fan out up to 5
+        // Seerr round-trips per minute (C2 periodic refresh + per pref change).
+        // A user-initiated refresh (swipe-to-refresh) sets `force = true` which
+        // bypasses this gate via [invalidateDiscoverCache].
+        val now = System.currentTimeMillis()
+        if (!discoverCacheInvalidated && now - lastDiscoverFetchEpochMs < DISCOVER_TTL_MS) return
 
         val today = LocalDate.now(ZoneOffset.systemDefault())
             .atStartOfDay(ZoneOffset.systemDefault())
@@ -568,7 +606,17 @@ class HomeViewModel @Inject constructor(
             }
         }
 
+        lastDiscoverFetchEpochMs = System.currentTimeMillis()
+        discoverCacheInvalidated = false
         _uiState.update { it.copy(discoverSections = newSections) }
+    }
+
+    /**
+     * Resets the discover-sections TTL so the next [fetchDiscoverSections]
+     * actually hits the network. Called on user-initiated refresh.
+     */
+    fun invalidateDiscoverCache() {
+        discoverCacheInvalidated = true
     }
 
     private fun startPeriodicRefresh() {

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
@@ -14,9 +14,16 @@ import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -59,6 +66,15 @@ enum class PlayedStatus(val displayName: String) {
     PLAYED("Played"),
     UNPLAYED("Unplayed"),
 }
+
+/** Max concurrent requests when prefetching photo-folder child image URLs. */
+private const val PHOTO_FOLDER_PREFETCH_CONCURRENCY = 4
+
+/** Projected slice of [UserPreferences] used to derive the active library view mode. */
+private data class ViewModePrefs(
+    val libraryViewMode: LibraryViewMode,
+    val libraryViewModes: Map<String, String>,
+)
 
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
@@ -122,16 +138,25 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun loadViewMode() {
+        // Project only the view-mode fields (avoid re-evaluating on every
+        // unrelated pref write) and combine with the selected folder so a
+        // folder change also triggers re-evaluation (was a latent correctness
+        // edge: the old collector only read _selectedFolder inside the prefs
+        // collector, so a folder-only change wouldn't re-derive the mode).
         launch {
-            preferencesStore.preferences.collect { prefs ->
-                val folderId = _selectedFolder.value?.id
-                val perLibrary = folderId?.let { id ->
-                    prefs.libraryViewModes[id]?.let { modeName ->
+            combine(
+                preferencesStore.preferences
+                    .map { ViewModePrefs(it.libraryViewMode, it.libraryViewModes) }
+                    .distinctUntilChanged(),
+                _selectedFolder.flow,
+            ) { viewModePrefs, folder ->
+                val perLibrary = folder?.id?.let { id ->
+                    viewModePrefs.libraryViewModes[id]?.let { modeName ->
                         runCatching { LibraryViewMode.valueOf(modeName) }.getOrNull()
                     }
                 }
-                _viewMode.set(perLibrary ?: prefs.libraryViewMode)
-            }
+                perLibrary ?: viewModePrefs.libraryViewMode
+            }.collect { mode -> _viewMode.set(mode) }
         }
     }
 
@@ -299,11 +324,21 @@ class LibraryViewModel @Inject constructor(
     fun prefetchPhotoFolderChildUrls(items: List<MediaItem>) {
         launch {
             val current = _photoFolderChildUrls.value
-            items.filter { it.mediaType == MediaType.PHOTO_FOLDER && it.id !in current }
-                .forEach { folder ->
-                    val urls = mediaRepository.getPhotoFolderChildImageUrls(folder.id)
-                    _photoFolderChildUrls.set(_photoFolderChildUrls.value + (folder.id to urls))
-                }
+            val toFetch = items.filter { it.mediaType == MediaType.PHOTO_FOLDER && it.id !in current }
+            if (toFetch.isEmpty()) return@launch
+            // Parallelize the per-folder network calls with a bounded semaphore
+            // (was a sequential forEach → N× per-request latency) and emit the
+            // combined result once at the end instead of doing an O(N) map
+            // rebuild + StateFlow re-emit per folder.
+            val permits = Semaphore(PHOTO_FOLDER_PREFETCH_CONCURRENCY)
+            val results = coroutineScope {
+                toFetch.map { folder ->
+                    async {
+                        permits.withPermit { folder.id to mediaRepository.getPhotoFolderChildImageUrls(folder.id) }
+                    }
+                }.awaitAll()
+            }
+            _photoFolderChildUrls.set(_photoFolderChildUrls.value + results)
         }
     }
 }

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerViewModel.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerViewModel.kt
@@ -134,11 +134,6 @@ class AudioPlayerViewModel @Inject constructor(
             }.collect {}
         }
         launch {
-            audioPlaybackManager.title.collect { value ->
-                _uiState.update { it.copy(title = value) }
-            }
-        }
-        launch {
             combine(
                 audioPlaybackManager.isPlaying,
                 audioPlaybackManager.duration,

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerViewModel.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerViewModel.kt
@@ -111,24 +111,31 @@ class AudioPlayerViewModel @Inject constructor(
                 _uiState.update { it.copy(isLoading = value) }
             }
         }
+        // Group the track-metadata fields that change together on every track
+        // transition into a single combine so a transition produces one
+        // 95-field uiState copy (rather than 5 separate copies + update
+        // attempts). StateFlow conflation means downstream sees the final
+        // state either way; this just removes the per-field allocation churn.
         launch {
-            audioPlaybackManager.artist.collect { value ->
-                _uiState.update { it.copy(artist = value) }
-            }
+            combine(
+                audioPlaybackManager.artist,
+                audioPlaybackManager.artistId,
+                audioPlaybackManager.album,
+                audioPlaybackManager.albumArtUrl,
+            ) { artist, artistId, album, albumArtUrl ->
+                _uiState.update {
+                    it.copy(
+                        artist = artist,
+                        artistId = artistId,
+                        album = album,
+                        albumArtUrl = albumArtUrl,
+                    )
+                }
+            }.collect {}
         }
         launch {
-            audioPlaybackManager.artistId.collect { value ->
-                _uiState.update { it.copy(artistId = value) }
-            }
-        }
-        launch {
-            audioPlaybackManager.album.collect { value ->
-                _uiState.update { it.copy(album = value) }
-            }
-        }
-        launch {
-            audioPlaybackManager.albumArtUrl.collect { value ->
-                _uiState.update { it.copy(albumArtUrl = value) }
+            audioPlaybackManager.title.collect { value ->
+                _uiState.update { it.copy(title = value) }
             }
         }
         launch {

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlaybackProgressReporter.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlaybackProgressReporter.kt
@@ -92,13 +92,14 @@ internal class PlaybackProgressReporter(
     }
 
     private fun checkAutoSkip(currentPositionMs: Long) {
-        // Compute the active segment from the raw tick position rather than
-        // uiState.currentPosition (which is no longer updated at 4 Hz — see
-        // V-1). The result is identical to the previous behaviour, where the
-        // reporter had just pushed this same position into uiState before
-        // reading state.activeSegment.
-        val state = uiState.value.copy(currentPosition = currentPositionMs)
-        val seg = state.computeActiveSegment() ?: return
+        // Compute the active segment from the raw tick position using the
+        // position-explicit overload. This avoids copying the ~95-field
+        // VideoPlayerUiState on every position tick (the highest-frequency
+        // avoidable allocation on the playback path). Behaviour is identical
+        // to the previous `uiState.value.copy(currentPosition = ...)` form:
+        // the copy was only ever read, never emitted to a StateFlow.
+        val state = uiState.value
+        val seg = state.computeActiveSegment(currentPositionMs) ?: return
         val behavior = state.behaviorForType(seg.type)
         if (behavior != SegmentBehavior.AUTO_SKIP) return
         if (seg.id in autoSkippedSegments) return

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlayerSessionManager.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/PlayerSessionManager.kt
@@ -157,6 +157,19 @@ class PlayerSessionManager(
         val subtitle = offlineItem?.seriesName ?: offlineItem?.overview?.take(60) ?: ""
         val url = Uri.fromFile(localFile).toString()
 
+        // Resolve the real container so ExoPlayer gets the right MIME type and
+        // selects the correct extractor. Precedence:
+        //   1. Container persisted at download time (new downloads).
+        //   2. Magic-byte sniffing fallback (legacy downloads whose on-disk
+        //      extension was hardcoded to .mp4 even when the bytes are MKV/TS/...).
+        // Without this, MKV-in-.mp4 hangs ExoPlayer silently in STATE_BUFFERING
+        // with no error dialog (only MPV plays, because libavformat sniffs content).
+        val containerHint = download?.container
+            ?: com.raulshma.jellyplay.feature.player.video.engine.ContainerSniffer.sniff(localFile)
+        val mimeHint = containerHint?.let {
+            com.raulshma.jellyplay.feature.player.video.engine.ContainerMimeMapper.mapToMime(it)
+        }
+
         _sessionState.update {
             it.copy(
                 title = title,
@@ -188,7 +201,7 @@ class PlayerSessionManager(
             chapters = emptyList(),
         )
 
-        initializeEngine(playerType, detail, null, url, startPositionTicks, prefs)
+        initializeEngine(playerType, detail, null, url, startPositionTicks, prefs, mimeType = mimeHint)
 
         // Attach external subtitles bundled with the download (offline subs).
         loadOfflineSubtitles(downloadPath)
@@ -277,6 +290,7 @@ class PlayerSessionManager(
         startPositionTicks: Long,
         prefs: com.raulshma.jellyplay.core.model.UserPreferences,
         playMethod: PlayMethod = PlayMethod.DIRECT_PLAY,
+        mimeType: String? = null,
     ) {
         _engine.value?.release()
         val eng = playerEngineFactory.create(playerType)
@@ -322,6 +336,7 @@ class PlayerSessionManager(
             authToken = token,
             minBufferMs = prefs.videoPreloadBufferSize.minBufferMs,
             maxBufferMs = prefs.videoPreloadBufferSize.maxBufferMs,
+            mimeType = mimeType,
         )
 
         lastPlaybackRequest = request

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
@@ -58,6 +58,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.StateFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -97,6 +100,7 @@ import com.raulshma.jellyplay.core.model.EffectStrength
 import com.raulshma.jellyplay.core.model.OrientationMode
 import com.raulshma.jellyplay.core.model.SubtitleEdgeType
 import com.raulshma.jellyplay.core.model.SubtitleStyle
+import com.raulshma.jellyplay.core.model.formatFixed
 import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
 import com.raulshma.jellyplay.core.ui.tv.components.rememberDpadSeekState
 import com.raulshma.jellyplay.core.ui.tv.input.onDpadKeyEvent
@@ -1300,18 +1304,35 @@ fun VideoPlayerScreen(
         }
     }
 
-    LaunchedEffect(seekState.timestamp) {
-        if (seekState.direction != 0) {
-            delay(GESTURE_SEEK_LINGER_MS)
-            seekState.reset()
-        }
+    // Single long-lived collector replaces a fresh LaunchedEffect keyed on
+    // seekState.timestamp (which changes per D-pad seek → coroutine create/cancel
+    // per event, thrashing during hold-and-repeat seeking). The reset side-effect
+    // body is unchanged; only the dispatch mechanism changes.
+    LaunchedEffect(Unit) {
+        snapshotFlow { seekState.timestamp to seekState.direction }
+            .filter { (_, direction) -> direction != 0 }
+            .drop(1) // ignore the initial replay (no seek yet)
+            .collectLatest {
+                delay(GESTURE_SEEK_LINGER_MS)
+                seekState.reset()
+            }
     }
 
     LaunchedEffect(Unit) {
-        snapshotFlow { seekPositionMs }
+        // Combine the position with the gating state into one snapshotFlow and
+        // suppress emits where neither the position nor the gating flags changed,
+        // avoiding re-deriving seeking-state on no-op emissions.
+        snapshotFlow {
+            Triple(
+                seekPositionMs,
+                isSeeking && uiState.trickplayEnabled && uiState.trickplayInfo != null,
+                uiState.trickplayInfo,
+            )
+        }
             .conflate()
-            .collect { pos ->
-                if (isSeeking && uiState.trickplayEnabled && uiState.trickplayInfo != null) {
+            .distinctUntilChanged()
+            .collect { (pos, shouldFetch, _) ->
+                if (shouldFetch) {
                     val bitmap = viewModel.getTrickplayThumbnail(pos)
                     seekTrickplayBitmap = bitmap
                     if (isTv) {
@@ -1329,12 +1350,19 @@ fun VideoPlayerScreen(
     }
 
     LaunchedEffect(Unit) {
-        snapshotFlow { gestureSeekPositionMs }
+        snapshotFlow {
+            Triple(
+                gestureSeekPositionMs,
+                isGestureSeeking && uiState.trickplayOnSeekGesture,
+                uiState.trickplayInfo,
+            )
+        }
             .conflate()
-            .collect { pos ->
-                if (isGestureSeeking && uiState.trickplayOnSeekGesture) {
+            .distinctUntilChanged()
+            .collect { (pos, shouldFetch, trickplayInfo) ->
+                if (shouldFetch) {
                     gestureTrickplayVisible = true
-                    gestureTrickplayBitmap = if (uiState.trickplayInfo != null) {
+                    gestureTrickplayBitmap = if (trickplayInfo != null) {
                         viewModel.getTrickplayThumbnail(pos)
                     } else {
                         null
@@ -1483,6 +1511,9 @@ private fun BoxScope.ZoomBadge(videoZoom: Float) {
         }
     }
 
+    // Format once per distinct zoom value rather than per badge recompose.
+    val zoomText = remember(videoZoom) { "${formatFixed(videoZoom.toDouble(), 1)}×" }
+
     AnimatedVisibility(
         visible = showBadge,
         enter = fadeIn(tween(150, easing = AlphaEasing)),
@@ -1496,7 +1527,7 @@ private fun BoxScope.ZoomBadge(videoZoom: Float) {
             color = playerOnScrim().copy(alpha = 0.12f),
         ) {
             Text(
-                text = "%.1f×".format(videoZoom),
+                text = zoomText,
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                 color = MaterialTheme.colorScheme.primary,
                 style = MaterialTheme.typography.labelMedium.copy(

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerUiState.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerUiState.kt
@@ -202,7 +202,15 @@ data class VideoPlayerUiState(
      * recomputation cost is negligible. Kept as a `fun` (not a `val`) so it
      * is only evaluated when actually needed.
      */
-    fun computeActiveSegment(): MediaSegment? = computeActiveSegmentInternal()
+    fun computeActiveSegment(): MediaSegment? = computeActiveSegmentInternal(currentPosition)
+
+    /**
+     * Position-explicit overload. Lets high-frequency callers (e.g. the
+     * position-tick auto-skip check) compute the active segment for a raw
+     * engine position WITHOUT copying this 95-field state (which is the
+     * highest-frequency avoidable allocation on the playback path).
+     */
+    fun computeActiveSegment(positionMs: Long): MediaSegment? = computeActiveSegmentInternal(positionMs)
 
     companion object {
         private val INTRO_CHAPTER_NAMES = setOf("intro", "introduction", "opening", "op")
@@ -220,8 +228,8 @@ data class VideoPlayerUiState(
         )
     }
 
-    private fun computeActiveSegmentInternal(): MediaSegment? {
-        val posTicks = currentPosition * 10_000
+    private fun computeActiveSegmentInternal(positionMs: Long): MediaSegment? {
+        val posTicks = positionMs * 10_000
         val apiMatches = segments.filter { seg ->
             seg.hasSegment && posTicks >= seg.startTicks && posTicks < seg.endTicks
         }
@@ -230,12 +238,12 @@ data class VideoPlayerUiState(
                 apiMatches.firstOrNull { it.type == priority }
             } ?: apiMatches.first()
         }
-        return detectChapterSegment()
+        return detectChapterSegment(positionMs)
     }
 
-    private fun detectChapterSegment(): MediaSegment? {
+    private fun detectChapterSegment(positionMs: Long): MediaSegment? {
         if (chapters.isEmpty()) return null
-        val posTicks = currentPosition * 10_000
+        val posTicks = positionMs * 10_000
         val idx = chapters.indexOfLast { it.startPositionTicks <= posTicks }
         if (idx < 0) return null
         val chapter = chapters[idx]

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -101,6 +101,15 @@ private const val POSITION_PERSIST_MIN_INTERVAL_MS = 5_000L
 private const val CONFIG_SYNC_DEBOUNCE_MS = 150L
 
 /**
+ * Initial-buffering watchdog. If the engine has not reached READY within this
+ * window since load, the playback-error dialog is surfaced so the user can
+ * retry with another engine. Long enough to cover legitimate cold-start
+ * buffering on slow networks, short enough to feel responsive when playback is
+ * genuinely stuck (e.g. undecodable content).
+ */
+private const val BUFFERING_TIMEOUT_MS = 20_000L
+
+/**
  * Segment-relevant slice of [VideoPlayerUiState], used by
  * [VideoPlayerViewModel.segmentOverlayState]. Projecting only these fields
  * (and `distinctUntilChanged`-ing them) means a 4 Hz [currentPositionMs][VideoPlayerViewModel.currentPositionMs]
@@ -844,6 +853,49 @@ class VideoPlayerViewModel @Inject constructor(
                             } }
                             launch { engine.availableTracks.collect { trackSelectionHelper.updateTracksFromEngine() } }
                             launch { engine.errorFlow.collect { e -> _uiState.update { s -> s.copy(playerError = e, showPlaybackErrorDialog = true) } } }
+                            // Buffering watchdog: if the engine never reaches
+                            // READY within BUFFERING_TIMEOUT_MS during the
+                            // *initial* buffer (before first READY), surface the
+                            // playback-error dialog so the user can retry with a
+                            // different engine. Without this, ExoPlayer can sit
+                            // in STATE_BUFFERING forever for undecodable content
+                            // (e.g. wrong extractor on a misnamed download) — no
+                            // PlaybackException is raised, so the errorFlow
+                            // collector above never fires and the spinner spins
+                            // indefinitely. Only armed before first READY so it
+                            // does not trigger on legitimate mid-playback rebuffer
+                            // (seeks, quality switches, network blips).
+                            launch {
+                                var hasReachedReady = false
+                                var watchdogJob: kotlinx.coroutines.Job? = null
+                                engine.playbackState.collect { state ->
+                                    when (state) {
+                                        com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.BUFFERING -> {
+                                            if (!hasReachedReady && watchdogJob == null) {
+                                                watchdogJob = launch {
+                                                    delay(BUFFERING_TIMEOUT_MS)
+                                                    if (!hasReachedReady) {
+                                                        _uiState.update { s -> s.copy(
+                                                            playerError = "Playback failed to start. Try a different player engine.",
+                                                            showPlaybackErrorDialog = true,
+                                                            isBuffering = false,
+                                                        ) }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.READY -> {
+                                            hasReachedReady = true
+                                            watchdogJob?.cancel()
+                                            watchdogJob = null
+                                        }
+                                        else -> {
+                                            watchdogJob?.cancel()
+                                            watchdogJob = null
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 } else {

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -35,8 +35,11 @@ import com.raulshma.jellyplay.core.model.AudioNormalizationMode
 import com.raulshma.jellyplay.core.model.ChannelMixMode
 import com.raulshma.jellyplay.core.model.DecoderMode
 import com.raulshma.jellyplay.core.model.EffectStrength
+import com.raulshma.jellyplay.core.model.ChapterInfo
 import com.raulshma.jellyplay.core.model.MediaDetail
+import com.raulshma.jellyplay.core.model.MediaItem as JellyfinMediaItem
 import com.raulshma.jellyplay.core.model.MediaSegment
+import com.raulshma.jellyplay.core.model.MediaSegmentType
 import com.raulshma.jellyplay.core.model.MediaStream
 import com.raulshma.jellyplay.core.model.PlaybackMode
 import com.raulshma.jellyplay.core.model.PlaybackPrefScope
@@ -74,6 +77,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -93,6 +97,72 @@ private const val SAVED_KEY_ITEM_ID = "video_player.saved_item_id"
 private const val SAVED_KEY_POSITION_MS = "video_player.saved_position_ms"
 private const val SAVED_KEY_PLAY_SESSION_ID = "video_player.saved_play_session_id"
 private const val POSITION_PERSIST_MIN_INTERVAL_MS = 5_000L
+/** Debounce window for engine config syncs driven by slider drags (C11). */
+private const val CONFIG_SYNC_DEBOUNCE_MS = 150L
+
+/**
+ * Segment-relevant slice of [VideoPlayerUiState], used by
+ * [VideoPlayerViewModel.segmentOverlayState]. Projecting only these fields
+ * (and `distinctUntilChanged`-ing them) means a 4 Hz [currentPositionMs][VideoPlayerViewModel.currentPositionMs]
+ * tick does not allocate a fresh 95-field `VideoPlayerUiState.copy(...)` or
+ * re-run `computeActiveSegment()` unless one of these fields actually changed.
+ *
+ * Note: `isInIntro` / `isInCredits` / `shouldShowUpNext` are deliberately NOT
+ * captured here — they are computed properties on [VideoPlayerUiState] that
+ * depend on the live position/duration, so they are re-derived inside
+ * [computeOverlay] from the position-aware state. Only the *inputs* that do
+ * not change every tick are projected.
+ */
+private data class SegmentProjection(
+    val segments: List<MediaSegment>,
+    val chapters: List<ChapterInfo>,
+    val segmentBehaviors: Map<MediaSegmentType, SegmentBehavior>,
+    val autoplayCancelled: Boolean,
+    val isInSyncPlaySession: Boolean,
+    val nextEpisode: JellyfinMediaItem?,
+    val seriesId: String?,
+) {
+    constructor(state: VideoPlayerUiState) : this(
+        segments = state.segments,
+        chapters = state.chapters,
+        segmentBehaviors = state.segmentBehaviors,
+        autoplayCancelled = state.autoplayCancelled,
+        isInSyncPlaySession = state.isInSyncPlaySession,
+        nextEpisode = state.nextEpisode,
+        seriesId = state.seriesId,
+    )
+
+    /**
+     * Builds the [SegmentOverlayState] for a given live position/duration.
+     * Reconstructs a position-aware [VideoPlayerUiState] carrying only the
+     * segment-relevant fields so the existing `computeActiveSegment()` /
+     * `behaviorForType()` / `shouldShowUpNext` logic is reused verbatim (no
+     * duplication of the chapter-name-matching rules). This reconstruction
+     * runs only when the projection changes — not on every 4 Hz tick.
+     */
+    fun computeOverlay(positionMs: Long, durationMs: Long): SegmentOverlayState {
+        val positioned = VideoPlayerUiState(
+            currentPosition = positionMs,
+            duration = durationMs,
+            segments = segments,
+            chapters = chapters,
+            segmentBehaviors = segmentBehaviors,
+            autoplayCancelled = autoplayCancelled,
+            isInSyncPlaySession = isInSyncPlaySession,
+            nextEpisode = nextEpisode,
+            seriesId = seriesId,
+        )
+        val activeSegment = positioned.computeActiveSegment()
+        return SegmentOverlayState(
+            activeSegment = activeSegment,
+            activeSegmentBehavior = activeSegment?.let { positioned.behaviorForType(it.type) }
+                ?: SegmentBehavior.IGNORE,
+            isInIntro = positioned.isInIntro,
+            isInCredits = positioned.isInCredits,
+            shouldShowUpNext = positioned.shouldShowUpNext,
+        )
+    }
+}
 
 @HiltViewModel
 class VideoPlayerViewModel @Inject constructor(
@@ -147,20 +217,20 @@ class VideoPlayerViewModel @Inject constructor(
      * to compute the active segment. The result is `distinctUntilChanged` via
      * [StateFlow], so collectors (the screen root) only recompose when one of
      * these values actually changes — i.e. at segment boundaries, not at 4 Hz.
+     *
+     * Only the segment-relevant slice of [uiState] is projected (via
+     * [SegmentProjection] + `distinctUntilChanged`) so a 4 Hz position tick does
+     * not allocate a fresh 95-field `VideoPlayerUiState.copy(...)` and re-run
+     * `computeActiveSegment()` when no segment-relevant field changed.
      */
     val segmentOverlayState: StateFlow<SegmentOverlayState> = stateIn(
         initial = SegmentOverlayState(),
-        flow = combine(currentPositionMs, durationMs, uiState) { pos, dur, state ->
-            val positioned = state.copy(currentPosition = pos, duration = dur)
-            val seg = positioned.computeActiveSegment()
-            SegmentOverlayState(
-                activeSegment = seg,
-                activeSegmentBehavior = seg?.let { positioned.behaviorForType(it.type) }
-                    ?: SegmentBehavior.IGNORE,
-                isInIntro = positioned.isInIntro,
-                isInCredits = positioned.isInCredits,
-                shouldShowUpNext = positioned.shouldShowUpNext,
-            )
+        flow = combine(
+            currentPositionMs,
+            durationMs,
+            uiState.map(::SegmentProjection).distinctUntilChanged(),
+        ) { pos, dur, proj ->
+            proj.computeOverlay(pos, dur)
         },
     )
 
@@ -244,7 +314,6 @@ class VideoPlayerViewModel @Inject constructor(
     private var transientAudioFocusRequest: android.media.AudioFocusRequest? = null
     private var preDuckVolume: Float? = null
     private var wasPlayingBeforeTransientLoss = false
-    private var duckingEnabledJob: Job? = null
 
     private val _passOutEvents = Channel<String>(Channel.BUFFERED)
     val passOutEvents: kotlinx.coroutines.flow.Flow<String> = _passOutEvents.receiveAsFlow()
@@ -581,6 +650,14 @@ class VideoPlayerViewModel @Inject constructor(
                         updateConfigWithUiState()
                     }
                 }
+                // Duck on transient audio focus loss (phone calls). Folded into
+                // this single preferences collector (was a duplicate collector)
+                // so a pref write rebuilds the snapshot once, not twice.
+                if (prefs.duckOnTransientFocusLoss && transientAudioFocusRequest == null) {
+                    registerTransientFocusLossListener()
+                } else if (!prefs.duckOnTransientFocusLoss && transientAudioFocusRequest != null) {
+                    unregisterTransientFocusLossListener()
+                }
             }
         }
         launch {
@@ -649,19 +726,6 @@ class VideoPlayerViewModel @Inject constructor(
                 } else 0,
             )
         } catch (_: Exception) {}
-
-        // Duck on transient audio focus loss (phone calls). Observed dynamically so
-        // toggling the preference at runtime re-registers without requiring screen re-entry.
-        duckingEnabledJob?.cancel()
-        duckingEnabledJob = launch {
-            preferencesStore.preferences.collect { prefs ->
-                if (prefs.duckOnTransientFocusLoss && transientAudioFocusRequest == null) {
-                    registerTransientFocusLossListener()
-                } else if (!prefs.duckOnTransientFocusLoss && transientAudioFocusRequest != null) {
-                    unregisterTransientFocusLossListener()
-                }
-            }
-        }
 
         launch {
             var lastItemId: String? = null
@@ -749,7 +813,13 @@ class VideoPlayerViewModel @Inject constructor(
                     engineCollectionJob = launch {
                         kotlinx.coroutines.coroutineScope {
                             launch { engine.isPlaying.collect { isPlaying ->
-                                _uiState.update { s -> s.copy(isPlaying = isPlaying) }
+                                // Guard against same-value updates (mirrors the isBuffering
+                                // branch below) so a redundant isPlaying emission does not
+                                // allocate a fresh 95-field uiState copy and invalidate
+                                // every uiState collector.
+                                _uiState.update { s ->
+                                    if (s.isPlaying == isPlaying) s else s.copy(isPlaying = isPlaying)
+                                }
                                 syncPlayBridge.onIsPlayingChanged(isPlaying)
                                 // Mirror play state so the Activity can render the correct
                                 // play/pause icon on the PiP window.
@@ -1670,14 +1740,27 @@ class VideoPlayerViewModel @Inject constructor(
         playerSessionManager.engine?.updateConfig(config)
     }
 
-    private var configDebounceJob: Job? = null
+    /**
+     * Backing flow for the debounced config-sync. Slider drags fire 60–120
+     * value-changed callbacks/sec; previously each launched a new coroutine
+     * and cancelled the previous (allocating a DispatchedContinuation per call
+     * and walking the job tree on each cancel). A SharedFlow + debounce emits
+     * one coroutine that only fires after the drag settles.
+     */
+    private val configChangeIntent = kotlinx.coroutines.flow.MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
+    )
 
-    private fun updateConfigWithUiStateDebounced() {
-        configDebounceJob?.cancel()
-        configDebounceJob = launch {
-            delay(50)
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    private val configSyncJob: Job = launch {
+        configChangeIntent.debounce(CONFIG_SYNC_DEBOUNCE_MS).collect {
             updateConfigWithUiState()
         }
+    }
+
+    private fun updateConfigWithUiStateDebounced() {
+        configChangeIntent.tryEmit(Unit)
     }
 
     fun playNextEpisode() {
@@ -2464,8 +2547,6 @@ class VideoPlayerViewModel @Inject constructor(
             try { context.unregisterReceiver(it) } catch (_: Exception) {}
         }
         becomingNoisyReceiver = null
-        duckingEnabledJob?.cancel()
-        duckingEnabledJob = null
         unregisterTransientFocusLossListener()
         sleepTimerManager.setOnFadeProgress(null)
         releaseInternals()

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/AspectRatioSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/AspectRatioSheet.kt
@@ -100,7 +100,7 @@ fun AspectRatioSheet(
 
             if (isTv) {
                 LazyColumn(modifier = Modifier.verticalWrapAround()) {
-                    items(AspectRatio.entries) { ratio ->
+                    items(AspectRatio.entries, key = { it.name }) { ratio ->
                         val isSelected = ratio == currentRatio
                         val isFirstOrSelected = isSelected || (currentRatio !in AspectRatio.entries && ratio == AspectRatio.AUTO)
                         val ratioFocusState = rememberTvFocusState(focusedScale = 1.02f)

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/CompanionDashboard.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/CompanionDashboard.kt
@@ -650,10 +650,14 @@ fun SubtitlesTabContent(
 
         Box(modifier = Modifier.weight(1f)) {
             if (lyricsLines.isNotEmpty() && subTabSelected == 0) {
-                // Real-time scrolling lyrics
-                val activeLineIndex = remember(lyricsLines, currentPositionMs) {
-                    val idx = lyricsLines.indexOfLast { it.timeMs <= currentPositionMs }
-                    idx.coerceAtLeast(0)
+                // Real-time scrolling lyrics. derivedStateOf ensures recomposition fires
+                // only when the active line index actually crosses a lyric boundary —
+                // currentPositionMs ticks multiple times per second but most ticks do
+                // not change the active line.
+                val activeLineIndex by remember {
+                    derivedStateOf {
+                        lyricsLines.indexOfLast { it.timeMs <= currentPositionMs }.coerceAtLeast(0)
+                    }
                 }
 
                 LazyColumn(
@@ -662,7 +666,9 @@ fun SubtitlesTabContent(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    itemsIndexed(lyricsLines) { index, line ->
+                    // Keyed by index — stable per line so slot identity survives any
+                    // re-emission of the same lyrics list (e.g. a parent recomposition).
+                    itemsIndexed(lyricsLines, key = { idx, _ -> "lyric_$idx" }) { index, line ->
                         val isActive = index == activeLineIndex
                         val textColor by animateColorAsState(
                             targetValue = if (isActive) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.7f),

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/DecoderPickerSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/DecoderPickerSheet.kt
@@ -85,7 +85,7 @@ fun DecoderPickerSheet(
 
             if (isTv) {
                 LazyColumn(modifier = Modifier.verticalWrapAround()) {
-                    items(DecoderMode.entries) { mode ->
+                    items(DecoderMode.entries, key = { it.name }) { mode ->
                         val isSelected = mode == currentMode
                         val isFirstOrSelected = isSelected || (currentMode !in DecoderMode.entries && mode == DecoderMode.entries.firstOrNull())
                         val modeFocusState = rememberTvFocusState(focusedScale = 1.02f)

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/GestureOverlay.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/GestureOverlay.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import android.os.SystemClock
 import kotlin.math.abs
 import kotlin.math.pow
 import com.composables.icons.tabler.Tabler
@@ -152,7 +153,11 @@ internal fun GestureOverlay(
                                     val dy = change.position.y - change.previousPosition.y
                                     val rawDelta = -(dy / size.height) * 0.5f
                                     val delta = applySensitivityCurve(rawDelta)
-                                    val now = System.currentTimeMillis()
+                                    // Monotonic clock — avoids the wall-clock syscall of
+                                    // System.currentTimeMillis() per move event and is immune
+                                    // to wall-clock jumps. Gesture timing is duration-based
+                                    // (hapticMinInterval), so this is strictly more correct.
+                                    val now = SystemClock.elapsedRealtime()
                                     if (change.position.x > halfWidth) {
                                         currentOnVolumeGesture(delta)
                                         if ((volumeValue <= 0f && delta < 0f) || (volumeValue >= 1f && delta > 0f)) {

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlaybackModeSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlaybackModeSheet.kt
@@ -86,7 +86,7 @@ fun PlaybackModeSheet(
 
             if (isTv) {
                 LazyColumn(modifier = Modifier.verticalWrapAround()) {
-                    items(PlaybackMode.entries) { mode ->
+                    items(PlaybackMode.entries, key = { it.name }) { mode ->
                         val isSelected = mode == currentMode
                         val isFirstOrSelected = isSelected ||
                             (currentMode !in PlaybackMode.entries && mode == PlaybackMode.AUTO)

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerControls.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerControls.kt
@@ -365,7 +365,7 @@ internal fun PlayerControls(
                             if (showEndsAt) {
                                 val remainingMs = (duration - currentPosition).coerceAtLeast(0)
                                 val realRemainingMs = if (playbackSpeed > 0f) (remainingMs / playbackSpeed).toLong() else remainingMs
-                                val endsAt = rememberEndsAtTime(realRemainingMs)
+                                val endsAt = rememberEndsAtTime(realRemainingMs, isVisible)
                                 Text(
                                     text = "Ends at $endsAt",
                                     style = MaterialTheme.typography.bodyMedium,
@@ -1248,16 +1248,22 @@ private fun TvControllableSeekBar(
 }
 
 @Composable
-private fun rememberEndsAtTime(remainingMs: Long): String {
+private fun rememberEndsAtTime(remainingMs: Long, controlsVisible: Boolean): String {
     val context = LocalContext.current
     val is24Hour = remember(context) { android.text.format.DateFormat.is24HourFormat(context) }
     val pattern = if (is24Hour) "HH:mm" else "h:mm a"
     val formatter = remember(pattern) { SimpleDateFormat(pattern, Locale.getDefault()) }
     var currentSystemTime by remember { mutableStateOf(System.currentTimeMillis()) }
-    LaunchedEffect(Unit) {
+    // Only poll while the controls (and therefore the "ends-at" label) are
+    // visible, and align the delay to the wall-clock minute boundary — the
+    // label only needs minute precision, so sub-minute updates are invisible.
+    // Was an unconditional 5 s poll for the lifetime of PlayerControls.
+    LaunchedEffect(controlsVisible) {
+        if (!controlsVisible) return@LaunchedEffect
         while (true) {
-            kotlinx.coroutines.delay(5000)
             currentSystemTime = System.currentTimeMillis()
+            val msToNextMinute = 60_000L - (currentSystemTime % 60_000L)
+            kotlinx.coroutines.delay(msToNextMinute.coerceAtLeast(1_000L))
         }
     }
     return remember(currentSystemTime, remainingMs, formatter) {

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerControls.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerControls.kt
@@ -969,6 +969,17 @@ private fun TvControllableSeekBar(
 
     val seekStep = if (isTv) 30_000f / duration else 10_000f / duration
 
+    // Position-derived labels memoized by second to cut formatDuration allocations
+    // during the 4 Hz position tick (most recomposes only move the playhead).
+    val currentPositionText = remember(currentPosition / 1000) { formatDuration(currentPosition) }
+    val durationText = remember(duration / 1000) { formatDuration(duration) }
+    val remainingText = remember(duration, currentPosition / 1000, showTimeRemaining) {
+        if (duration > 0 && showTimeRemaining) {
+            val remainingMs = (duration - currentPosition).coerceAtLeast(0)
+            "-" + formatDuration(remainingMs)
+        } else null
+    }
+
     Column(modifier = Modifier.fillMaxWidth()) {
         if (isTv && isSeekBarFocused && trickplayBitmap != null) {
             val displayMs = (tvSeekPosition * duration).toLong()
@@ -1217,7 +1228,7 @@ private fun TvControllableSeekBar(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    formatDuration(currentPosition),
+                    currentPositionText,
                     style = MaterialTheme.typography.labelSmall.copy(
                         fontFamily = FontFamily.Monospace,
                         fontWeight = FontWeight.Medium,
@@ -1225,12 +1236,7 @@ private fun TvControllableSeekBar(
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
                 )
                 val endLabel = if (duration > 0) {
-                    if (showTimeRemaining) {
-                        val remainingMs = (duration - currentPosition).coerceAtLeast(0)
-                        "-" + formatDuration(remainingMs)
-                    } else {
-                        formatDuration(duration)
-                    }
+                    remainingText ?: durationText
                 } else {
                     "--:--"
                 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/QualityPickerSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/QualityPickerSheet.kt
@@ -90,7 +90,7 @@ fun QualityPickerSheet(
 
             if (isTv) {
                 LazyColumn(modifier = Modifier.verticalWrapAround()) {
-                    items(StreamingQuality.entries) { quality ->
+                    items(StreamingQuality.entries, key = { it.name }) { quality ->
                         val isSelected = quality == currentQuality
                         val isFirstOrSelected = isSelected || (currentQuality !in StreamingQuality.entries && quality == StreamingQuality.AUTO)
                         val qualityFocusState = rememberTvFocusState(focusedScale = 1.02f)

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/SleepTimerSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/SleepTimerSheet.kt
@@ -171,7 +171,7 @@ internal fun SleepTimerSheet(
                         }
                     }
 
-                    items(PRESET_DURATIONS) { durationMs ->
+                    items(PRESET_DURATIONS, key = { it }) { durationMs ->
                         val isSelected = !isEndOfEpisodeMode && isActive && remainingMs == durationMs
                         val isLastUsed = !isActive && durationMs == lastUsedDurationMs
                         val isTarget = isSelected || isLastUsed

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/SpeedPickerSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/SpeedPickerSheet.kt
@@ -79,7 +79,12 @@ internal fun SpeedPickerSheet(
 
             if (isTv) {
                 LazyColumn(modifier = Modifier.verticalWrapAround()) {
-                    items(SPEED_OPTIONS.toList()) { speed ->
+                    items(
+                        count = SPEED_OPTIONS.size,
+                        key = { SPEED_OPTIONS[it] },
+                        contentType = { "speed" },
+                    ) { i ->
+                        val speed = SPEED_OPTIONS[i]
                         val isSelected = speed == currentSpeed
                         val isFirstOrSelected = isSelected || (SPEED_OPTIONS.none { it == currentSpeed } && speed == 1.0f)
                         val speedFocusState = rememberTvFocusState(focusedScale = 1.02f)

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/TrickplayOverlay.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/TrickplayOverlay.kt
@@ -195,9 +195,11 @@ private fun formatTime(ms: Long): String {
     val hours = totalSeconds / 3600
     val minutes = (totalSeconds % 3600) / 60
     val seconds = totalSeconds % 60
+    // String templates avoid the per-call Formatter allocation — this runs
+    // per-frame during trickplay scrubbing.
     return if (hours > 0) {
-        String.format("%d:%02d:%02d", hours, minutes, seconds)
+        "$hours:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
     } else {
-        String.format("%02d:%02d", minutes, seconds)
+        "${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}"
     }
 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/VideoStatsOverlay.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/VideoStatsOverlay.kt
@@ -28,6 +28,7 @@ import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.designsystem.theme.extendedColors
 import com.raulshma.jellyplay.core.designsystem.theme.playerOnScrim
 import com.raulshma.jellyplay.core.designsystem.theme.playerScrimColor
+import com.raulshma.jellyplay.core.model.formatFixed
 import com.raulshma.jellyplay.feature.player.video.engine.EngineVideoStats
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -75,7 +76,7 @@ fun VideoStatsOverlay(
             StatsRow("Duration", formatDurationMsLocal(durationMs))
             if (durationMs > 0) {
                 val progress = (currentPositionMs.toFloat() / durationMs.toFloat() * 100f)
-                StatsRow("Progress", String.format("%.1f%%", progress))
+                StatsRow("Progress", "${formatFixed(progress.toDouble(), 1)}%")
             }
             StatsRow("Speed", "${playbackSpeed}x")
             val bufferHealthMs = (stats.bufferedPositionMs - currentPositionMs).coerceAtLeast(0L)
@@ -89,7 +90,7 @@ fun VideoStatsOverlay(
                 stats.videoCodec?.let { StatsRow("Codec", it.uppercase()) }
                 stats.videoDecoder?.let { StatsRow("Decoder", it) }
                 stats.videoResolution?.let { StatsRow("Resolution", it) }
-                stats.videoFrameRate?.let { StatsRow("Frame Rate", String.format("%.2f fps", it)) }
+                stats.videoFrameRate?.let { StatsRow("Frame Rate", "${formatFixed(it.toDouble(), 2)} fps") }
                 stats.videoBitrate?.let { StatsRow("Bitrate", formatBitrate(it)) }
                 stats.videoHdrType?.let { StatsRow("HDR", it) }
                 stats.videoColorRange?.let { StatsRow("Color Range", it) }
@@ -132,7 +133,7 @@ fun VideoStatsOverlay(
                     stats.droppedFrames.toFloat() /
                         (stats.droppedFrames + stats.totalVideoFrames) * 100f
                 } else 0f
-                StatsRow("Drop Rate", String.format("%.2f%%", dropPct))
+                StatsRow("Drop Rate", "${formatFixed(dropPct.toDouble(), 2)}%")
             }
             if (stats.bufferSizeBytes > 0) {
                 StatsRow("Buffer Size", formatBytes(stats.bufferSizeBytes))
@@ -199,20 +200,20 @@ private fun StatsRow(
 private fun formatDurationMsLocal(ms: Long): String = com.raulshma.jellyplay.core.ui.components.formatDurationMs(ms)
 
 private fun formatBitrate(bps: Int): String = when {
-    bps >= 1_000_000 -> String.format("%.1f Mbps", bps / 1_000_000.0)
-    bps >= 1_000 -> String.format("%.0f kbps", bps / 1_000.0)
+    bps >= 1_000_000 -> "${formatFixed(bps / 1_000_000.0, 1)} Mbps"
+    bps >= 1_000 -> "${Math.round(bps / 1_000.0)} kbps"
     else -> "$bps bps"
 }
 
 private fun formatBandwidth(bps: Long): String = when {
-    bps >= 1_000_000 -> String.format("%.1f Mbps", bps / 1_000_000.0)
-    bps >= 1_000 -> String.format("%.0f kbps", bps / 1_000.0)
+    bps >= 1_000_000 -> "${formatFixed(bps / 1_000_000.0, 1)} Mbps"
+    bps >= 1_000 -> "${Math.round(bps / 1_000.0)} kbps"
     else -> "$bps bps"
 }
 
 private fun formatBytes(bytes: Long): String = when {
-    bytes >= 1_048_576 -> String.format("%.1f MB", bytes / 1_048_576.0)
-    bytes >= 1_024 -> String.format("%.0f KB", bytes / 1_024.0)
+    bytes >= 1_048_576 -> "${formatFixed(bytes / 1_048_576.0, 1)} MB"
+    bytes >= 1_024 -> "${Math.round(bytes / 1_024.0)} KB"
     else -> "$bytes B"
 }
 
@@ -227,11 +228,15 @@ private fun formatChannels(ch: Int): String = when (ch) {
 @Composable
 private fun rememberCurrentTimeString(): String {
     val formatter = remember { SimpleDateFormat("HH:mm:ss", Locale.getDefault()) }
-    var time by remember { mutableStateOf(formatter.format(Date())) }
+    // Reuse a single Date instance and mutate its underlying time field each
+    // tick instead of allocating a fresh Date() every second.
+    val date = remember { Date() }
+    var time by remember { mutableStateOf(formatter.format(date)) }
     LaunchedEffect(Unit) {
         while (true) {
             kotlinx.coroutines.delay(1000)
-            time = formatter.format(Date())
+            date.time = System.currentTimeMillis()
+            time = formatter.format(date)
         }
     }
     return time

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerMimeMapper.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerMimeMapper.kt
@@ -1,0 +1,41 @@
+package com.raulshma.jellyplay.feature.player.video.engine
+
+import androidx.media3.common.MimeTypes
+
+/**
+ * Maps a container format string (as reported by the Jellyfin MediaSource or
+ * sniffed from file magic bytes) to a Media3 MIME type.
+ *
+ * Why: ExoPlayer's [androidx.media3.common.MediaItem] selects its extractor
+ * from the URI extension by default. Downloaded files historically carry a
+ * hardcoded `.mp4` extension regardless of the real container, so MKV/TS/AVI
+ * bytes get fed to the MP4 extractor and ExoPlayer hangs silently in
+ * `STATE_BUFFERING`. Attaching the correct MIME type via
+ * [androidx.media3.common.MediaItem.Builder.setMimeType] forces the right
+ * extractor and unblocks playback.
+ *
+ * Mirrors the [com.raulshma.jellyplay.feature.player.video.subtitle.SubtitleMimeMapper]
+ * pattern: lowercase-normalizes input, returns `null` for unknown containers
+ * so the caller can fall back to extension-based inference.
+ */
+internal object ContainerMimeMapper {
+    fun mapToMime(container: String?): String? {
+        if (container.isNullOrBlank()) return null
+        return when (container.lowercase().trim()) {
+            "mp4", "m4v", "m4a", "mov", "ismv", "isma" -> MimeTypes.APPLICATION_MP4
+            "mkv", "webm", "mka" -> MimeTypes.APPLICATION_MATROSKA
+            "ts", "m2ts", "mts", "tsa", "tsv" -> MimeTypes.VIDEO_MP2T
+            "flac" -> MimeTypes.AUDIO_FLAC
+            "mp3" -> MimeTypes.AUDIO_MPEG
+            "aac", "adts" -> MimeTypes.AUDIO_AAC
+            "ogg", "oga", "opus" -> MimeTypes.AUDIO_OGG
+            "wav" -> MimeTypes.AUDIO_WAV
+            "flv" -> MimeTypes.VIDEO_FLV
+            // AVI: Media3 has no dedicated AVI MIME constant and no first-class
+            // AVI extractor on all versions. Return null so ExoPlayer falls back
+            // to content sniffing; if it still cannot decode, the buffering
+            // watchdog surfaces the retry-with-engine dialog.
+            else -> null
+        }
+    }
+}

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerSniffer.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerSniffer.kt
@@ -1,0 +1,121 @@
+package com.raulshma.jellyplay.feature.player.video.engine
+
+import java.io.File
+import java.io.InputStream
+
+/**
+ * Sniffs the real container format of a downloaded file by reading its magic
+ * bytes, regardless of the on-disk file extension.
+ *
+ * Why: downloads created before the container-persistence migration carry a
+ * hardcoded `.mp4` extension even when the underlying bytes are MKV/TS/FLV/AVI.
+ * ExoPlayer picks its extractor from the URI extension and hangs silently on a
+ * mismatch; the sniffer lets the offline playback path recover the real
+ * container so the correct MIME type can be attached to the [androidx.media3.common.MediaItem].
+ *
+ * Returns one of the container codes recognized by [ContainerMimeMapper]
+ * (`"mkv"`, `"webm"`, `"mp4"`, `"ts"`, `"flv"`, `"avi"`), or `null` if no known
+ * magic signature matches (or the file cannot be read).
+ *
+ * Pure-JVM (no Android deps) so it is unit-testable on the host JVM.
+ */
+internal object ContainerSniffer {
+
+    private const val TS_PACKET_SIZE = 188
+
+    fun sniff(file: File): String? {
+        if (!file.exists() || !file.canRead()) return null
+        // MPEG-TS sync-byte detection needs at least three packet boundaries
+        // (offsets 0, 188, 376) to be reliable; everything else fits in 16 bytes.
+        val buf = ByteArray(TS_PACKET_SIZE * 3)
+        return try {
+            file.inputStream().use { input ->
+                val read = readFully(input, buf)
+                if (read < 16) null else detect(buf, read)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun detect(buf: ByteArray, len: Int): String? {
+        // EBML header (Matroska/WebM): 1A 45 DF A3.
+        if (len >= 4 &&
+            (buf[0].toInt() and 0xFF) == 0x1A &&
+            (buf[1].toInt() and 0xFF) == 0x45 &&
+            (buf[2].toInt() and 0xFF) == 0xDF &&
+            (buf[3].toInt() and 0xFF) == 0xA3
+        ) {
+            return distinguishWebm(buf, len)
+        }
+
+        // ISO BMFF (MP4/MOV/M4A): "ftyp" box at offset 4 → bytes 4-7 = "ftyp".
+        if (len >= 8 &&
+            buf[4] == 'f'.code.toByte() &&
+            buf[5] == 't'.code.toByte() &&
+            buf[6] == 'y'.code.toByte() &&
+            buf[7] == 'p'.code.toByte()
+        ) {
+            return "mp4"
+        }
+
+        // FLV: ASCII "FLV".
+        if (len >= 3 &&
+            buf[0] == 'F'.code.toByte() &&
+            buf[1] == 'L'.code.toByte() &&
+            buf[2] == 'V'.code.toByte()
+        ) {
+            return "flv"
+        }
+
+        // RIFF → AVI ("RIFF"...."AVI ").
+        if (len >= 12 &&
+            buf[0] == 'R'.code.toByte() && buf[1] == 'I'.code.toByte() &&
+            buf[2] == 'F'.code.toByte() && buf[3] == 'F'.code.toByte() &&
+            buf[8] == 'A'.code.toByte() && buf[9] == 'V'.code.toByte() &&
+            buf[10] == 'I'.code.toByte() && buf[11] == ' '.code.toByte()
+        ) {
+            return "avi"
+        }
+
+        // MPEG-TS: 0x47 sync byte at offsets 0, 188, 376.
+        if (len >= TS_PACKET_SIZE * 3 &&
+            (buf[0].toInt() and 0xFF) == 0x47 &&
+            (buf[TS_PACKET_SIZE].toInt() and 0xFF) == 0x47 &&
+            (buf[TS_PACKET_SIZE * 2].toInt() and 0xFF) == 0x47
+        ) {
+            return "ts"
+        }
+
+        return null
+    }
+
+    /**
+     * Both WebM and MKV start with an EBML header. The DocType element
+     * (`42 82 ...`) follows the EBML root and carries the string `"webm"` or
+     * `"matroska"`. We only need a coarse answer, so scan the first ~24 bytes
+     * for the ASCII literal `webm`; default to `mkv` otherwise.
+     */
+    private fun distinguishWebm(buf: ByteArray, len: Int): String {
+        val window = if (len >= 32) 32 else len
+        for (i in 0 until window - 4) {
+            if (
+                buf[i] == 'w'.code.toByte() && buf[i + 1] == 'e'.code.toByte() &&
+                buf[i + 2] == 'b'.code.toByte() && buf[i + 3] == 'm'.code.toByte()
+            ) {
+                return "webm"
+            }
+        }
+        return "mkv"
+    }
+
+    private fun readFully(input: InputStream, buf: ByteArray): Int {
+        var total = 0
+        while (total < buf.size) {
+            val n = input.read(buf, total, buf.size - total)
+            if (n < 0) break
+            total += n
+        }
+        return total
+    }
+}

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
@@ -554,7 +554,18 @@ class ExoPlayerEngine(
         // sit at the bottom of the *video*, and setBottomPaddingFraction /
         // fractional text sizes compute against the video height, not the much
         // taller screen height.
-        pv.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+        //
+        // Layout passes fire frequently during playback (controls show/hide,
+        // seekbar interaction, immersive transitions, video-size callbacks);
+        // only reparent on genuine geometry changes to suppress no-op work.
+        var lastFrameW = -1
+        var lastFrameH = -1
+        pv.addOnLayoutChangeListener { _, left, top, right, bottom, _, _, _, _ ->
+            val w = right - left
+            val h = bottom - top
+            if (w == lastFrameW && h == lastFrameH) return@addOnLayoutChangeListener
+            lastFrameW = w
+            lastFrameH = h
             pv.post { reparentSubtitleViewIntoVideoFrame(pv) }
         }
         playerView = pv

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
@@ -345,6 +345,7 @@ class ExoPlayerEngine(
 
         val mediaItem = MediaItem.Builder()
             .setUri(request.uri)
+            .apply { request.mimeType?.let { setMimeType(it) } }
             .setSubtitleConfigurations(subtitleConfigs)
             .setMediaMetadata(metadataBuilder.build())
             .build()

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MediaEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MediaEngine.kt
@@ -2,6 +2,7 @@ package com.raulshma.jellyplay.feature.player.video.engine
 
 import android.content.Context
 import android.view.View
+import androidx.compose.runtime.Stable
 import com.raulshma.jellyplay.core.data.playback.PlayerLifecycleCallbacks
 import com.raulshma.jellyplay.core.model.AudioNormalizationMode
 import com.raulshma.jellyplay.core.model.ChannelMixMode
@@ -242,6 +243,7 @@ interface VideoSurfaceBinding {
  * [com.raulshma.jellyplay.core.data.remote.RemotePlayableEngine] (which cannot
  * move into a role) or special-case internal hooks kept on the composite type.
  */
+@Stable
 interface MediaEngine :
     PlayerLifecycleCallbacks,
     com.raulshma.jellyplay.core.data.remote.RemotePlayableEngine,

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MediaEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MediaEngine.kt
@@ -29,6 +29,13 @@ data class PlaybackRequest(
     val authToken: String? = null,
     val minBufferMs: Int = 15_000,
     val maxBufferMs: Int = 50_000,
+    /**
+     * Optional MIME type hint for the primary media item. When set, ExoPlayer
+     * uses it in preference to URI-extension inference to pick the extractor,
+     * which is essential for downloaded files whose on-disk extension does not
+     * match their actual container (e.g. an MKV stream saved as `.mp4`).
+     */
+    val mimeType: String? = null,
 )
 
 data class SubtitleSource(

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
@@ -62,10 +62,8 @@ class MpvPlayerEngine(
     }
 
     private val isLowRamDevice by lazy { EngineDeviceProfile.isLowRamDevice(context) }
-    // `var` so [load] can recreate it if a prior [release] cancelled the
-    // SupervisorJob. Without this the engine is permanently unusable after
-    // release() (positionFlow's ticker launches on this scope and would
-    // silently never emit). Recreated lazily, only when inactive.
+    // `var` because [release] cancels the SupervisorJob and immediately
+    // recreates a fresh scope, keeping the engine reusable without a `load`.
     private var engineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     override val capabilities = EngineCapabilityMatrix.MPV
@@ -390,6 +388,10 @@ class MpvPlayerEngine(
         _availableTracks.value = emptyList()
         _bufferedPositionMs.value = 0L
         _videoStats.value = EngineVideoStats()
+        // Recreate the scope so a re-used engine stays usable without waiting
+        // for the next load(). A cancelled scope silently swallows new
+        // launches (no-ops), which would otherwise lose the position ticker.
+        engineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     }
 
     override fun play() {

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
@@ -26,6 +26,7 @@ import com.raulshma.jellyplay.core.model.MpvScaler
 import com.raulshma.jellyplay.core.model.MpvSkipLoopFilter
 import com.raulshma.jellyplay.core.model.MpvVideoOutput
 import com.raulshma.jellyplay.core.model.SubtitleEdgeType
+import com.raulshma.jellyplay.core.model.formatFixed
 import com.raulshma.jellyplay.core.model.SubtitleStyle
 import com.raulshma.jellyplay.core.model.TrackType
 import com.raulshma.jellyplay.core.model.VideoEffectsConfig
@@ -414,7 +415,14 @@ class MpvPlayerEngine(
     }
 
     override fun seekTo(positionMs: Long) {
-        try { mpvView?.mpv?.command("seek", "%.6f".format(positionMs / 1000.0), "absolute") } catch (e: Exception) { Log.w(TAG, "seekTo failed", e) }
+        try {
+            // Fixed-precision seconds with 6 decimals (byte-identical to
+            // "%.6f".format for positionMs >= 0; MPV clamps anyway). Avoids the
+            // Formatter + StringBuilder allocation per seek, which fires many
+            // times/sec during scrub / gesture-seek.
+            val secsStr = formatFixed(positionMs / 1000.0, 6)
+            mpvView?.mpv?.command("seek", secsStr, "absolute")
+        } catch (e: Exception) { Log.w(TAG, "seekTo failed", e) }
     }
 
     override fun setPlaybackSpeed(speed: Float) {

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/trickplay/OfflineTrickplayHelper.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/trickplay/OfflineTrickplayHelper.kt
@@ -8,6 +8,16 @@ import java.io.File
 
 object OfflineTrickplayHelper {
 
+    // Compiled once and reused — previously `Regex` was recompiled on every
+    // `loadLocalTrickplayInfo` call (7× per call).
+    private val WIDTH_REGEX = Regex("\"width\"\\s*:\\s*(\\d+)")
+    private val HEIGHT_REGEX = Regex("\"height\"\\s*:\\s*(\\d+)")
+    private val TILE_WIDTH_REGEX = Regex("\"tileWidth\"\\s*:\\s*(\\d+)")
+    private val TILE_HEIGHT_REGEX = Regex("\"tileHeight\"\\s*:\\s*(\\d+)")
+    private val THUMBNAIL_COUNT_REGEX = Regex("\"thumbnailCount\"\\s*:\\s*(\\d+)")
+    private val INTERVAL_REGEX = Regex("\"interval\"\\s*:\\s*(\\d+)")
+    private val BANDWIDTH_REGEX = Regex("\"bandwidth\"\\s*:\\s*(\\d+)")
+
     suspend fun downloadTrickplayData(
         itemId: String,
         trickplayInfo: TrickplayInfo,
@@ -58,13 +68,13 @@ object OfflineTrickplayHelper {
 
         return try {
             val text = withContext(Dispatchers.IO) { metaFile.readText() }
-            val width = text.regexMatch("\"width\"\\s*:\\s*(\\d+)")?.toIntOrNull() ?: return null
-            val height = text.regexMatch("\"height\"\\s*:\\s*(\\d+)")?.toIntOrNull() ?: return null
-            val tileWidth = text.regexMatch("\"tileWidth\"\\s*:\\s*(\\d+)")?.toIntOrNull() ?: return null
-            val tileHeight = text.regexMatch("\"tileHeight\"\\s*:\\s*(\\d+)")?.toIntOrNull() ?: return null
-            val thumbnailCount = text.regexMatch("\"thumbnailCount\"\\s*:\\s*(\\d+)")?.toIntOrNull() ?: return null
-            val interval = text.regexMatch("\"interval\"\\s*:\\s*(\\d+)")?.toIntOrNull() ?: return null
-            val bandwidth = text.regexMatch("\"bandwidth\"\\s*:\\s*(\\d+)")?.toIntOrNull() ?: 0
+            val width = WIDTH_REGEX.find(text)?.groupValues?.getOrNull(1)?.toIntOrNull() ?: return null
+            val height = HEIGHT_REGEX.find(text)?.groupValues?.getOrNull(1)?.toIntOrNull() ?: return null
+            val tileWidth = TILE_WIDTH_REGEX.find(text)?.groupValues?.getOrNull(1)?.toIntOrNull() ?: return null
+            val tileHeight = TILE_HEIGHT_REGEX.find(text)?.groupValues?.getOrNull(1)?.toIntOrNull() ?: return null
+            val thumbnailCount = THUMBNAIL_COUNT_REGEX.find(text)?.groupValues?.getOrNull(1)?.toIntOrNull() ?: return null
+            val interval = INTERVAL_REGEX.find(text)?.groupValues?.getOrNull(1)?.toIntOrNull() ?: return null
+            val bandwidth = BANDWIDTH_REGEX.find(text)?.groupValues?.getOrNull(1)?.toIntOrNull() ?: 0
 
             TrickplayInfo(
                 width = width,
@@ -76,10 +86,5 @@ object OfflineTrickplayHelper {
                 bandwidth = bandwidth,
             )
         } catch (_: Exception) { null }
-    }
-
-    private fun String.regexMatch(pattern: String): String? {
-        val regex = Regex(pattern)
-        return regex.find(this)?.groupValues?.getOrNull(1)
     }
 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/trickplay/TrickplayManager.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/trickplay/TrickplayManager.kt
@@ -15,7 +15,10 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import java.io.BufferedInputStream
 import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
 import java.util.concurrent.ConcurrentHashMap
 
 class TrickplayManager(
@@ -254,8 +257,15 @@ class TrickplayManager(
                 val localDir = localCacheDir
                 val localFile = if (localDir != null) File(localDir, "trickplay_${sheetIndex}.jpg") else null
                 val persistDirectory = persistDir
-                val data = if (localFile != null && localFile.exists()) {
-                    localFile.readBytes()
+                if (localFile != null && localFile.exists()) {
+                    // Decode directly from a stream so the compressed JPEG bytes
+                    // never sit in heap alongside the decoded bitmap (which can
+                    // reach MAX_SPRITE_SHEET_PIXELS × 2 bytes). A single
+                    // FileInputStream is fed to BitmapFactory; the file pages in
+                    // from disk instead of doubling the heap footprint.
+                    FileInputStream(localFile).use { fis ->
+                        decodeSpriteSheetSafelyFromStream(fis, trickplayInfo)
+                    }
                 } else {
                     val fetched = playbackRepository.getTrickplayTileImage(id, trickplayInfo.width, sheetIndex)
                         ?: return@withContext null
@@ -267,10 +277,8 @@ class TrickplayManager(
                             } catch (_: Exception) { }
                         }
                     }
-                    fetched
+                    decodeSpriteSheetSafely(fetched, trickplayInfo)
                 }
-
-                decodeSpriteSheetSafely(data, trickplayInfo)
             }.also { bitmap ->
                 if (bitmap != null) {
                     spriteSheetCache.put(sheetIndex, bitmap)
@@ -292,12 +300,7 @@ class TrickplayManager(
     private fun decodeSpriteSheetSafely(data: ByteArray, trickplayInfo: TrickplayInfo): Bitmap? {
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         BitmapFactory.decodeByteArray(data, 0, data.size, bounds)
-        val expectedWidth = trickplayInfo.width * trickplayInfo.tileWidth
-        val expectedHeight = trickplayInfo.height * trickplayInfo.tileHeight
-        val widthCap = expectedWidth.coerceAtLeast(1) * 2
-        val heightCap = expectedHeight.coerceAtLeast(1) * 2
-        if (bounds.outWidth > widthCap || bounds.outHeight > heightCap) return null
-        if (bounds.outWidth.toLong() * bounds.outHeight.toLong() > MAX_SPRITE_SHEET_PIXELS) return null
+        if (!isWithinBounds(bounds, trickplayInfo)) return null
 
         val options = BitmapFactory.Options().apply {
             inPreferredConfig = Bitmap.Config.RGB_565
@@ -308,6 +311,42 @@ class TrickplayManager(
         } catch (t: Throwable) {
             null
         }
+    }
+
+    /**
+     * Stream-based twin of [decodeSpriteSheetSafely] for the local-cache path.
+     * Decoding from an [InputStream] avoids holding the full compressed JPEG
+     * [ByteArray] in heap alongside the decoded bitmap. Uses a marked stream
+     * so the bounds-check pass can rewind before the real decode.
+     */
+    private fun decodeSpriteSheetSafelyFromStream(stream: InputStream, trickplayInfo: TrickplayInfo): Bitmap? {
+        // Buffer + mark so the two-pass (bounds then decode) read works on a
+        // single stream. 1 MB marks comfortably fit any sprite-sheet JPEG.
+        val marked = if (stream.markSupported()) stream else BufferedInputStream(stream, MARK_READLIMIT)
+        return try {
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            marked.mark(MARK_READLIMIT)
+            BitmapFactory.decodeStream(marked, null, bounds)
+            if (!isWithinBounds(bounds, trickplayInfo)) return null
+            marked.reset()
+            val options = BitmapFactory.Options().apply {
+                inPreferredConfig = Bitmap.Config.RGB_565
+                inMutable = false
+            }
+            BitmapFactory.decodeStream(marked, null, options)
+        } catch (t: Throwable) {
+            null
+        }
+    }
+
+    private fun isWithinBounds(bounds: BitmapFactory.Options, trickplayInfo: TrickplayInfo): Boolean {
+        val expectedWidth = trickplayInfo.width * trickplayInfo.tileWidth
+        val expectedHeight = trickplayInfo.height * trickplayInfo.tileHeight
+        val widthCap = expectedWidth.coerceAtLeast(1) * 2
+        val heightCap = expectedHeight.coerceAtLeast(1) * 2
+        if (bounds.outWidth > widthCap || bounds.outHeight > heightCap) return false
+        if (bounds.outWidth.toLong() * bounds.outHeight.toLong() > MAX_SPRITE_SHEET_PIXELS) return false
+        return true
     }
 
     fun clear() {
@@ -347,5 +386,9 @@ class TrickplayManager(
         // pathological payloads even when reported tile dimensions are huge.
         // ~40 MP fits well within the RGB_565 sprite-sheet cache budget.
         private const val MAX_SPRITE_SHEET_PIXELS = 40_000_000L
+        // Mark limit for the BufferedInputStream wrapping the local sprite-sheet
+        // file. 1 MB comfortably exceeds any single sprite-sheet JPEG size, so
+        // the two-pass (bounds-check → real decode) rewind always succeeds.
+        private const val MARK_READLIMIT = 1 * 1024 * 1024
     }
 }

--- a/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerMimeMapperTest.kt
+++ b/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerMimeMapperTest.kt
@@ -1,0 +1,87 @@
+package com.raulshma.jellyplay.feature.player.video.engine
+
+import androidx.media3.common.MimeTypes
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ContainerMimeMapperTest {
+
+    @Test
+    fun mp4_mapsToApplicationMp4() {
+        assertEquals(MimeTypes.APPLICATION_MP4, ContainerMimeMapper.mapToMime("mp4"))
+    }
+
+    @Test
+    fun m4v_mapsToApplicationMp4() {
+        assertEquals(MimeTypes.APPLICATION_MP4, ContainerMimeMapper.mapToMime("m4v"))
+    }
+
+    @Test
+    fun mov_mapsToApplicationMp4() {
+        assertEquals(MimeTypes.APPLICATION_MP4, ContainerMimeMapper.mapToMime("mov"))
+    }
+
+    @Test
+    fun mkv_mapsToMatroska() {
+        assertEquals(MimeTypes.APPLICATION_MATROSKA, ContainerMimeMapper.mapToMime("mkv"))
+    }
+
+    @Test
+    fun webm_mapsToMatroska() {
+        assertEquals(MimeTypes.APPLICATION_MATROSKA, ContainerMimeMapper.mapToMime("webm"))
+    }
+
+    @Test
+    fun ts_mapsToVideoMp2t() {
+        assertEquals(MimeTypes.VIDEO_MP2T, ContainerMimeMapper.mapToMime("ts"))
+    }
+
+    @Test
+    fun m2ts_mapsToVideoMp2t() {
+        assertEquals(MimeTypes.VIDEO_MP2T, ContainerMimeMapper.mapToMime("m2ts"))
+    }
+
+    @Test
+    fun flac_mapsToAudioFlac() {
+        assertEquals(MimeTypes.AUDIO_FLAC, ContainerMimeMapper.mapToMime("flac"))
+    }
+
+    @Test
+    fun mp3_mapsToAudioMpeg() {
+        assertEquals(MimeTypes.AUDIO_MPEG, ContainerMimeMapper.mapToMime("mp3"))
+    }
+
+    @Test
+    fun flv_mapsToVideoFlv() {
+        assertEquals(MimeTypes.VIDEO_FLV, ContainerMimeMapper.mapToMime("flv"))
+    }
+
+    @Test
+    fun nullContainer_mapsToNull() {
+        assertNull(ContainerMimeMapper.mapToMime(null))
+    }
+
+    @Test
+    fun blankContainer_mapsToNull() {
+        assertNull(ContainerMimeMapper.mapToMime("   "))
+    }
+
+    @Test
+    fun unknownContainer_mapsToNull() {
+        assertNull(ContainerMimeMapper.mapToMime("totally_unknown_format"))
+    }
+
+    @Test
+    fun caseInsensitive() {
+        assertEquals(MimeTypes.APPLICATION_MATROSKA, ContainerMimeMapper.mapToMime("MKV"))
+        assertEquals(MimeTypes.APPLICATION_MATROSKA, ContainerMimeMapper.mapToMime("Mkv"))
+        assertEquals(MimeTypes.APPLICATION_MP4, ContainerMimeMapper.mapToMime("MP4"))
+        assertEquals(MimeTypes.VIDEO_MP2T, ContainerMimeMapper.mapToMime("TS"))
+    }
+
+    @Test
+    fun whitespace_isTrimmed() {
+        assertEquals(MimeTypes.APPLICATION_MATROSKA, ContainerMimeMapper.mapToMime("  mkv  "))
+    }
+}

--- a/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerSnifferTest.kt
+++ b/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/engine/ContainerSnifferTest.kt
@@ -1,0 +1,102 @@
+package com.raulshma.jellyplay.feature.player.video.engine
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ContainerSnifferTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private fun b(vararg ints: Int): ByteArray = ByteArray(ints.size) { ints[it].toByte() }
+
+    /**
+     * Pads a header to the sniffer's minimum sniffable length (16 bytes) with
+     * zeros so the fixture exercises the magic-byte logic rather than the
+     * too-short-header early-return. Real media files are kilobytes minimum.
+     */
+    private fun pad(header: ByteArray, minLen: Int = 16): ByteArray =
+        if (header.size >= minLen) header else header + ByteArray(minLen - header.size)
+
+    @Test
+    fun matroskaEbmlHeader_detectedAsMkv() {
+        val file = writeBytes(pad(b(0x1A, 0x45, 0xDF, 0xA3, 0x42, 0x82, 0x88, 0x6D)))
+        assertEquals("mkv", ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun webmEbmlHeader_detectedAsWebm() {
+        // EBML header + DocType payload containing the literal "webm".
+        val file = writeBytes(pad(b(0x1A, 0x45, 0xDF, 0xA3, 0x42, 0x82, 0x84, 0x77, 0x65, 0x62, 0x6D)))
+        assertEquals("webm", ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun mp4FtypBox_detectedAsMp4() {
+        // 4-byte size + "ftyp" + major brand "isom"
+        val file = writeBytes(pad(b(0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6F, 0x6D)))
+        assertEquals("mp4", ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun flvHeader_detectedAsFlv() {
+        val file = writeBytes(pad(b(0x46, 0x4C, 0x56, 0x01, 0x05, 0x00, 0x00, 0x00)))
+        assertEquals("flv", ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun aviRiffHeader_detectedAsAvi() {
+        val file = writeBytes(pad(b(0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x41, 0x56, 0x49, 0x20)))
+        assertEquals("avi", ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun mpegTs_syncBytesAtPacketBoundaries_detectedAsTs() {
+        // Sync byte 0x47 at offsets 0, 188, 376 (three TS packets).
+        val buf = ByteArray(188 * 3)
+        buf[0] = 0x47
+        buf[188] = 0x47
+        buf[376] = 0x47
+        val file = writeBytes(buf)
+        assertEquals("ts", ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun mpegTs_missingThirdSyncByte_returnsNull() {
+        val buf = ByteArray(188 * 3)
+        buf[0] = 0x47
+        buf[188] = 0x47
+        // No sync byte at 376 → must not false-positive.
+        val file = writeBytes(buf)
+        assertNull(ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun unknownBytes_returnNull() {
+        val file = writeBytes(ByteArray(64) { 0xFF.toByte() })
+        assertNull(ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun tooFewBytes_returnNull() {
+        // Less than the 16-byte minimum header window.
+        val file = writeBytes(b(0x1A, 0x45, 0xDF, 0xA3))
+        assertNull(ContainerSniffer.sniff(file))
+    }
+
+    @Test
+    fun missingFile_returnNull() {
+        val ghost = File(tempFolder.root, "does-not-exist")
+        assertNull(ContainerSniffer.sniff(ghost))
+    }
+
+    private fun writeBytes(data: ByteArray): File {
+        val file = tempFolder.newFile()
+        file.writeBytes(data)
+        return file
+    }
+}

--- a/feature/search/src/main/java/com/raulshma/jellyplay/feature/search/SearchScreen.kt
+++ b/feature/search/src/main/java/com/raulshma/jellyplay/feature/search/SearchScreen.kt
@@ -777,10 +777,18 @@ fun SearchScreen(
                                 if (item != null) {
                                     AnimatedSearchItem(index = index) {
                                         val itemProgress = item.progressFraction()
+                                        // Memoize the per-item URL + click lambda (LibraryScreen
+                                        // already does this) so a results re-emit (paging,
+                                        // typing) doesn't recompute getImageUrl or allocate a
+                                        // fresh onClick lambda per visible item.
+                                        val imageUrl = remember(item.id) { viewModel.getImageUrl(item.id) }
+                                        val onClick = remember(item.id, item.mediaType, item.parentId, item.name) {
+                                            { onItemClick(item.id, item.mediaType, item.parentId, item.name) }
+                                        }
                                         PosterCard(
                                             item = item,
-                                            imageUrl = viewModel.getImageUrl(item.id),
-                                            onClick = { onItemClick(item.id, item.mediaType, item.parentId, item.name) },
+                                            imageUrl = imageUrl,
+                                            onClick = onClick,
                                             showProgress = itemProgress != null && itemProgress > 0f,
                                             progressPercent = itemProgress ?: 0f,
                                             blurHash = item.blurHashes.primary,

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsViewModel.kt
@@ -56,6 +56,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -334,36 +335,53 @@ class SettingsViewModel @Inject constructor(
 
     private fun calculateCacheSize() {
         launch {
-            val cacheSize = withContext(Dispatchers.IO) { getDirSize(context.cacheDir) }
-            val externalCacheSize = withContext(Dispatchers.IO) {
-                context.externalCacheDir?.let { getDirSize(it) } ?: 0L
-            }
-            cacheSizeMb = (cacheSize + externalCacheSize) / (1024 * 1024)
-
-            val downloadsDir = withContext(Dispatchers.IO) {
-                val prefs = preferencesStore.preferences.value
-                val location = prefs.downloadStorageLocation
-                if (location == "EXTERNAL" && context.getExternalFilesDir(null) != null) {
-                    context.getExternalFilesDir(null)!!
-                } else {
-                    context.filesDir
+            // Five independent recursive FS walks — collapse into a single IO
+            // context-switch and run the walks concurrently rather than one
+            // after another. Each walk can take seconds on large directories.
+            val (cacheSize, externalCacheSize, downloadsSize, imagesSize) = withContext(Dispatchers.IO) {
+                val cacheAsync = async { getDirSize(context.cacheDir) }
+                val extAsync = async { context.externalCacheDir?.let { getDirSize(it) } ?: 0L }
+                val dlAsync = async {
+                    val prefs = preferencesStore.preferences.value
+                    val location = prefs.downloadStorageLocation
+                    val downloadsDir = if (location == "EXTERNAL" && context.getExternalFilesDir(null) != null) {
+                        context.getExternalFilesDir(null)!!
+                    } else {
+                        context.filesDir
+                    }
+                    getDirSize(downloadsDir)
                 }
+                val imgAsync = async {
+                    val imageDir = File(context.cacheDir, "image_cache")
+                    if (imageDir.exists()) getDirSize(imageDir) else 0L
+                }
+                QuadLongs(cacheAsync.await(), extAsync.await(), dlAsync.await(), imgAsync.await())
             }
-            val downloadsSize = withContext(Dispatchers.IO) { getDirSize(downloadsDir) }
 
-            val imagesSize = withContext(Dispatchers.IO) {
-                val imageDir = File(context.cacheDir, "image_cache")
-                if (imageDir.exists()) getDirSize(imageDir) else 0L
-            }
-
-            val total = cacheSizeMb + (downloadsSize / (1024 * 1024)) + (imagesSize / (1024 * 1024))
+            cacheSizeMb = (cacheSize + externalCacheSize) / (1024 * 1024)
+            val downloadsMb = downloadsSize / (1024 * 1024)
+            val imagesMb = imagesSize / (1024 * 1024)
+            val total = cacheSizeMb + downloadsMb + imagesMb
             storageBreakdown = StorageBreakdown(
                 cacheMb = cacheSizeMb,
-                downloadsMb = downloadsSize / (1024 * 1024),
-                imagesMb = imagesSize / (1024 * 1024),
+                downloadsMb = downloadsMb,
+                imagesMb = imagesMb,
                 totalMb = total,
             )
         }
+    }
+
+    /** 4-tuple of `Long` for destructuring the four parallel FS-walk results. */
+    private class QuadLongs(
+        val first: Long,
+        val second: Long,
+        val third: Long,
+        val fourth: Long,
+    ) {
+        operator fun component1(): Long = first
+        operator fun component2(): Long = second
+        operator fun component3(): Long = third
+        operator fun component4(): Long = fourth
     }
 
     private fun getDirSize(dir: File): Long {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,12 @@ biometric = "1.4.0-alpha07"
 # Track for deprecation; if a Tink migration becomes necessary
 security = "1.1.0-alpha06"
 sentry = "8.14.0"
-benchmarkMacro = "1.4.0-beta02"
+benchmarkMacro = "1.5.0-alpha07"
+# androidx.benchmark 1.5.x alphas: required for the Baseline Profile Gradle plugin
+# to be compatible with AGP 9.x (fixes b/443311090 in 1.5.0-alpha01). The plugin
+# and benchmark-macro-junit4 share the androidx.benchmark release train, so the
+# same version.ref is used for both.
+baselineprofile = "1.5.0-alpha07"
 
 [libraries]
 # AndroidX Core
@@ -185,6 +190,12 @@ benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
+# Baseline Profile Gradle plugin (androidx.benchmark 1.5.x — AGP 9 compatible).
+# - `androidx.baselineprofile`          → applied by the app/consumer module.
+# - `androidx.baselineprofile.producer` → applied by the com.android.test module
+#                                         that runs the macrobenchmark generator.
+androidx-baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
+androidx-baselineprofile-producer = { id = "androidx.baselineprofile.producer", version.ref = "baselineprofile" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
This pull request introduces several optimizations and improvements across the app, focusing on performance, memory management, and code robustness. Key changes include deferring expensive object construction off the main thread during app startup, optimizing memory cache usage based on device RAM, improving widget update efficiency and safety, and preventing unnecessary recomputation in the navigation logic. There are also enhancements to widget image handling to avoid bitmap recycling crashes, and some dependency and build configuration updates.

**Performance and Memory Optimizations**
- Deferred construction of `AudioPlaybackManager` and its dependencies off the main thread during app startup by injecting a `Provider` and only constructing it in an IO coroutine, reducing cold-start impact. (`JellyPlayApplication.kt`) [[1]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dL38-R46) [[2]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dL55-R63)
- Adjusted the memory cache size for images based on device RAM class, using a lower percentage for low-RAM devices to avoid over-reserving memory. (`JellyPlayApplication.kt`)

**Widget Improvements and Safety**
- Hoisted the widget refresh coroutine scope to avoid rebuilding it on every update, and ensured proper cancellation when the widget is disabled, preventing resource leaks. (`NowPlayingWidget.kt`) [[1]](diffhunk://#diff-10529f09741817562be30b798132215685f68cd65181f0e724fe2dbff55c1338R34-R42) [[2]](diffhunk://#diff-10529f09741817562be30b798132215685f68cd65181f0e724fe2dbff55c1338R53-R57)
- Ensured that widget update coroutines always call `pending.finish()` even on exceptions, preventing potential ANRs. (`NowPlayingWidget.kt`)
- Disabled memory cache for widget image requests to guarantee a unique bitmap instance, avoiding crashes from recycling shared bitmaps. (`WidgetImageLoader.kt`)
- Added try/finally to promptly recycle input bitmaps after use in widget image processing, reducing memory pressure. (`WidgetImageLoader.kt`) [[1]](diffhunk://#diff-bfdb936c9873572b471f666a49aafa285a3a92cc98948eb0c189f5dafe1060e7R94) [[2]](diffhunk://#diff-bfdb936c9873572b471f666a49aafa285a3a92cc98948eb0c189f5dafe1060e7R106-R111)

**Navigation and UI Efficiency**
- Memoized the computation of active top-level routes in the main navigation to prevent unnecessary allocations and recomputation on every recomposition. (`JellyPlayApp.kt`) [[1]](diffhunk://#diff-d15400c9a1dbea5fbd61979efa08030b490a7544bb027dbac9270284a1db29a8L380-R391) [[2]](diffhunk://#diff-d15400c9a1dbea5fbd61979efa08030b490a7544bb027dbac9270284a1db29a8R416-R417)
- Marked `TvNavItem` as `@Stable` to improve Compose UI performance by signaling that its state does not change unexpectedly. (`TvNavigationDrawer.kt`) [[1]](diffhunk://#diff-b89df30c454963c8b7d5a66fabc856a76ea55c2f9def9f82f02f81757a37f472R5) [[2]](diffhunk://#diff-b89df30c454963c8b7d5a66fabc856a76ea55c2f9def9f82f02f81757a37f472R85-R88)

**Startup and Download Recovery**
- Updated download recovery logic to use a more specific DAO method for fetching recovery rows, ensuring more accurate resumption of downloads. (`DownloadRecoveryInitializer.kt`) [[1]](diffhunk://#diff-2fb042bba01ab679bd1d112fdb15765af802681135c5a0340fec1072b7bad761L41-R41) [[2]](diffhunk://#diff-2fb042bba01ab679bd1d112fdb15765af802681135c5a0340fec1072b7bad761L57-R57)

**Build Configuration and Dependency Updates**
- Added the `androidx.baselineprofile` plugin and dependency to enable baseline profile generation and merging for improved app startup performance. (`app/build.gradle.kts`) [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R7) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R185-R191)

**Other Improvements**
- Added stable keys to widget configuration option lists to prevent recomposition issues in the widget config UI. (`WidgetConfigActivity.kt`)
- Prepared for parallel image fetching in the screensaver by importing coroutine utilities. (`DreamImageProvider.kt`)