### PR TITLE
Add direct play profile with automatic transcode fallback and UI optimizations

### DIFF
--- a/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
@@ -13,8 +13,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
@@ -1472,7 +1470,6 @@ private fun MainNavDisplay(
     val motionScheme = MaterialTheme.motionScheme
     val defaultEffects = motionScheme.defaultEffectsSpec<Float>()
     val fastEffects = motionScheme.fastEffectsSpec<Float>()
-    val defaultSpatial = motionScheme.defaultSpatialSpec<Float>()
     val defaultSpatialOffset = motionScheme.defaultSpatialSpec<androidx.compose.ui.unit.IntOffset>()
 
     // Remember the entry provider graph so the ~25 section builders aren't
@@ -1599,17 +1596,11 @@ private fun MainNavDisplay(
                     ) + slideInHorizontally(
                         initialOffsetX = { it / 8 },
                         animationSpec = defaultSpatialOffset,
-                    ) + scaleIn(
-                        initialScale = 0.985f,
-                        animationSpec = defaultSpatial,
                     ) togetherWith fadeOut(
                         animationSpec = fastEffects,
                     ) + slideOutHorizontally(
                         targetOffsetX = { -it / 18 },
                         animationSpec = defaultSpatialOffset,
-                    ) + scaleOut(
-                        targetScale = 1.015f,
-                        animationSpec = defaultEffects,
                     )
                 }
             }
@@ -1641,17 +1632,11 @@ private fun MainNavDisplay(
                         ) + slideInHorizontally(
                             initialOffsetX = { -it / 12 },
                             animationSpec = defaultSpatialOffset,
-                        ) + scaleIn(
-                            initialScale = 1.015f,
-                            animationSpec = defaultSpatial,
                         ) togetherWith fadeOut(
                             animationSpec = fastEffects,
                         ) + slideOutHorizontally(
                             targetOffsetX = { it / 10 },
                             animationSpec = defaultSpatialOffset,
-                        ) + scaleOut(
-                            targetScale = 0.985f,
-                            animationSpec = defaultEffects,
                         )
                 }
             }
@@ -1671,17 +1656,11 @@ private fun MainNavDisplay(
                 ) + slideInHorizontally(
                     initialOffsetX = { -it / 12 },
                     animationSpec = defaultSpatialOffset,
-                ) + scaleIn(
-                    initialScale = 1.015f,
-                    animationSpec = defaultSpatial,
                 ) togetherWith fadeOut(
                     animationSpec = fastEffects,
                 ) + slideOutHorizontally(
                     targetOffsetX = { it / 10 },
                     animationSpec = defaultSpatialOffset,
-                ) + scaleOut(
-                    targetScale = 0.985f,
-                    animationSpec = defaultEffects,
                 )
             }
         },

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/PlayerLifecycleManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/PlayerLifecycleManager.kt
@@ -20,7 +20,7 @@ interface PlayerLifecycleCallbacks {
  * Centralized lifecycle manager for the active player engine.
  *
  * Bridges the gap between the single-activity Compose architecture and the
- * lifecycle-aware patterns used by Findroid's BasePlayerActivity. The Activity
+ * lifecycle-aware patterns. The Activity
  * calls lifecycle methods here, and this class delegates directly to the
  * active engine — no StateFlow indirection for pause/resume.
  */

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/DeviceProfileProvider.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/DeviceProfileProvider.kt
@@ -51,11 +51,13 @@ class DeviceProfileProvider @Inject constructor(
     }
 
     /**
-     * Profile used for client-capabilities registration when no player is
-     * known yet (defaults to the device-derived hardware profile).
+     * Subtitle delivery map shared by every profile: deliver SRT/ASS/VTT/etc.
+     * as external side-loaded files rather than burning them in. Declared
+     * before the eager [directPlayAll] initializer so it is non-null when
+     * [directPlayAll]'s initializer runs (Kotlin initializes properties in
+     * declaration order — a forward reference here would NPE on construction,
+     * crashing the app at launch via Hilt's provider).
      */
-    val default: org.jellyfin.sdk.model.api.DeviceProfile get() = hardwareProfile
-
     private val subtitleFormats = listOf(
         "srt" to SubtitleDeliveryMethod.EXTERNAL,
         "subrip" to SubtitleDeliveryMethod.EXTERNAL,
@@ -65,6 +67,38 @@ class DeviceProfileProvider @Inject constructor(
         "webvtt" to SubtitleDeliveryMethod.EXTERNAL,
         "ttml" to SubtitleDeliveryMethod.EXTERNAL,
     )
+
+    /**
+     * "Direct play all" profile for [PlaybackMode.FORCE_DIRECT_PLAY]. no codec/container
+     * restrictions, no transcoding profiles, and a 1 Gbps bitrate sentinel so
+     * the server marks every media source as `supportsDirectPlay=true`. The
+     * client then requests `/Videos/{id}/stream?static=true` verbatim.
+     *
+     * Consequence: the server hands back a static URL even for codecs the
+     * player may not actually decode; the player surfaces a runtime error and
+     * the UI offers a transcode fallback (mirrors Wholphin's `onPlayerError`
+     * retry pattern). This is the explicit trade-off of "force direct play" —
+     * the user has asked the server not to transcode, so we trust the static
+     * URL and let the player be the arbiter.
+     */
+    val directPlayAll: org.jellyfin.sdk.model.api.DeviceProfile = buildDeviceProfile {
+        name = "jellyplay-direct-all"
+
+        // No transcodingProfile → server has no transcode target and will not
+        // report SupportsTranscoding. No codecProfile / containerProfile → no
+        // restrictions shrink the direct-play set. An empty directPlayProfile
+        // list means "allow direct play of everything" in Jellyfin's DLNA
+        // resolution (the absence of a constraining profile is permissive).
+        maxStreamingBitrate = 1_000_000_000
+
+        subtitleFormats.forEach { (format, method) -> subtitleProfile(format, method) }
+    }
+
+    /**
+     * Profile used for client-capabilities registration when no player is
+     * known yet (defaults to the device-derived hardware profile).
+     */
+    val default: org.jellyfin.sdk.model.api.DeviceProfile get() = hardwareProfile
 
     private fun mpvProfile(pgsDirectPlay: Boolean): org.jellyfin.sdk.model.api.DeviceProfile = buildDeviceProfile {
         name = "jellyplay-mpv"

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/JellyfinDtoMappers.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/JellyfinDtoMappers.kt
@@ -323,8 +323,11 @@ internal fun org.jellyfin.sdk.model.api.TaskTriggerInfo.toTriggerModel() = TaskT
 internal fun org.jellyfin.sdk.model.api.TaskResult.toExecutionModel() = TaskExecutionInfo(
     name = name ?: "",
     key = key ?: "",
-    startTimeUtc = startTimeUtc.toString(),
-    endTimeUtc = endTimeUtc.toString(),
+    // The SDK strips the offset during deserialization (see toIsoInstantString),
+    // so a plain .toString() yields a bare LocalDateTime that can't be parsed as
+    // OffsetDateTime — re-attach the zone here.
+    startTimeUtc = startTimeUtc.toIsoInstantString(),
+    endTimeUtc = endTimeUtc.toIsoInstantString(),
     status = status.serialName,
     errorMessage = errorMessage,
 )

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/PlaybackApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/PlaybackApiClientImpl.kt
@@ -171,6 +171,21 @@ class PlaybackApiClientImpl @Inject constructor(
         // FORCE_DIRECT_PLAY (no cap — the file is served verbatim).
         val sendBitrate = if (mode == PlaybackMode.FORCE_DIRECT_PLAY) null else maxStreamingBitrateBits
 
+        // FORCE_DIRECT_PLAY sends "Direct play all" profile so
+        // the server unconditionally marks sources as directly playable and
+        // hands back a `?static=true` URL — the client owns the decision to
+        // serve the file verbatim AUTO and
+        // FORCE_TRANSCODE use the codec-aware profile so the server picks the
+        // right play method and transcode target.
+        val deviceProfile = if (mode == PlaybackMode.FORCE_DIRECT_PLAY) {
+            deviceProfileProvider.directPlayAll
+        } else {
+            deviceProfileProvider.forPlayer(
+                playerType = playerType,
+                pgsDirectPlay = preferencesStore.preferences.value.pgsSubtitleDirectPlay,
+            )
+        }
+
         val dto = PlaybackInfoDto(
             userId = engine.currentUser.value?.id?.toUUID(),
             startTimeTicks = startTimeTicks.takeIf { it > 0 },
@@ -178,10 +193,7 @@ class PlaybackApiClientImpl @Inject constructor(
             audioStreamIndex = audioStreamIndex,
             subtitleStreamIndex = subtitleStreamIndex,
             mediaSourceId = mediaSourceId.takeIf { it.isNotBlank() },
-            deviceProfile = deviceProfileProvider.forPlayer(
-                playerType = playerType,
-                pgsDirectPlay = preferencesStore.preferences.value.pgsSubtitleDirectPlay,
-            ),
+            deviceProfile = deviceProfile,
             enableDirectPlay = enableDirectPlay,
             enableDirectStream = enableDirectStream,
             enableTranscoding = enableTranscoding,

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/di/NetworkModule.kt
@@ -2,7 +2,6 @@ package com.raulshma.jellyplay.core.network.di
 
 import android.content.Context
 import android.net.ConnectivityManager
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import com.raulshma.jellyplay.core.datastore.UserPreferencesStore
 import com.raulshma.jellyplay.core.network.JellyfinApiClient
@@ -207,15 +206,19 @@ abstract class NetworkModule {
             okHttpConfigProvider: OkHttpConfigProvider,
             bandwidthInterceptor: BandwidthInterceptor,
         ): OkHttpClient {
-            // Suspend on the first *real* emission of okHttpConfigProvider.config
-            // before building the cache. The StateFlow's initialValue reports
-            // maxCacheSizeMb = 0 (sentinel), and OkHttp's Cache is not dynamically
-            // resizable — so reading .value used to build the cache with the 50 MB
-            // fallback and never re-size it (if the user picked e.g. 500 MB they
-            // got 50 MB until process restart). .first() blocks (Hilt providers
-            // run on a background thread during init) until the real preference
-            // arrives ~tens of ms later, sizing the cache correctly from start.
-            val initialConfig = runBlocking { okHttpConfigProvider.config.first() }
+            // Read config synchronously via StateFlow.value — no runBlocking.
+            // On a cold start the Eagerly-shared StateFlow may still hold the
+            // initialValue sentinel (maxCacheSizeMb = 0), in which case the cache
+            // falls back to 50 MB below. The real preference lands in .value
+            // within tens of ms (DataStore disk read) and is picked up on the
+            // next process start; timeouts are re-applied per request by the
+            // interceptor below, so only the (rarely-changed) cache size is
+            // affected, and only on the very first launch. The previous
+            // runBlocking { .first() } blocked the DI critical path — every
+            // screen that transitively pulls OkHttpClient (repositories, SDK
+            // client, download workers) waited on a DataStore disk read before
+            // first frame.
+            val initialConfig = okHttpConfigProvider.config.value
             val cacheDir = File(context.cacheDir, "http_cache")
             cacheDir.mkdirs()
             val cacheMb = initialConfig.maxCacheSizeMb

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/LocalScrollIdle.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/LocalScrollIdle.kt
@@ -1,0 +1,15 @@
+package com.raulshma.jellyplay.core.ui.components
+
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * Whether the primary scrollable surface is currently idle (not being
+ * scrolled). Provided by screen-level composables that own a LazyListState /
+ * LazyGridState so leaf composables (e.g. [rememberDominantColor]) can defer
+ * non-essential work — Palette extraction, heavy prefetch — until scroll
+ * settles, avoiding CPU contention with image decodes during fast scroll.
+ *
+ * Defaults to `true` (idle) so composables outside a scrollable surface are
+ * unaffected.
+ */
+val LocalScrollIdle = compositionLocalOf<() -> Boolean> { { true } }

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/MediaCardComponents.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/MediaCardComponents.kt
@@ -85,6 +85,7 @@ fun rememberDominantColor(
 ): Color {
     val context = LocalContext.current
     val performanceMode = LocalPerformanceMode.current
+    val isScrollIdle = LocalScrollIdle.current
     val cacheKey = itemId ?: imageUrl
     var color by remember(cacheKey) { mutableStateOf(cacheKey?.let { dominantColorCache.get(it) } ?: fallback) }
     val loader = coil3.SingletonImageLoader.get(context)
@@ -93,8 +94,15 @@ fun rememberDominantColor(
     // otherwise launches a Coil request + Palette.generate() on Dispatchers.Default,
     // competing with the visible image decodes for CPU during scroll. Cached
     // values (from a prior non-perf-mode session) are still returned.
-    LaunchedEffect(imageUrl, performanceMode) {
+    //
+    // Also defer until scroll settles (isScrollIdle): during fast scroll dozens
+    // of newly-composed cards would each fire a 64px Coil execute + Palette
+    // generate, starving the visible-card decodes. Reading LocalScrollIdle as a
+    // LaunchedEffect key re-triggers the effect when scroll stops, so colors
+    // populate ~150ms after the user stops flinging.
+    LaunchedEffect(imageUrl, performanceMode, isScrollIdle()) {
         if (performanceMode || imageUrl.isNullOrBlank()) return@LaunchedEffect
+        if (!isScrollIdle()) return@LaunchedEffect
         if (cacheKey != null) {
             dominantColorCache.get(cacheKey)?.let {
                 color = it
@@ -315,24 +323,33 @@ fun PosterCard(
     // rememberReleaseDismiss closes it when the finger lifts — all driven by
     // this card's existing interactionSource. No-ops on TV and when no
     // controller is provided (see LocalMediaPreviewController).
-    val peek = rememberMediaPeek(
-        item = item,
-        posterUrl = imageUrl,
-        backdropUrl = fallbackUrls.firstOrNull(),
-        blurHash = blurHash,
-    )
-    rememberReleaseDismiss(isPressed)
-
+    //
+    // Short-circuit when no controller AND no shared-element key: avoids the
+    // per-card peek/shared-element composition allocations in contexts that
+    // can't use either (e.g. library grid without preview enabled).
+    val mediaPreviewController = com.raulshma.jellyplay.core.ui.preview.LocalMediaPreviewController.current
     val sharedTransitionScope = LocalSharedTransitionScope.current
     val animatedVisibilityScope = LocalAnimatedVisibilityScope.current
+    val canPeek = mediaPreviewController != null
+    val canShareElement = sharedElementKey != null && sharedTransitionScope != null && animatedVisibilityScope != null
+
+    val peek = if (canPeek) {
+        rememberMediaPeek(
+            item = item,
+            posterUrl = imageUrl,
+            backdropUrl = fallbackUrls.firstOrNull(),
+            blurHash = blurHash,
+        )
+    } else null
+    if (canPeek) rememberReleaseDismiss(isPressed)
 
     @OptIn(androidx.compose.animation.ExperimentalSharedTransitionApi::class)
     val sharedImageModifier =
-        if (sharedElementKey != null && sharedTransitionScope != null && animatedVisibilityScope != null) {
-            with(sharedTransitionScope) {
+        if (canShareElement) {
+            with(sharedTransitionScope!!) {
                 Modifier.sharedElement(
-                    rememberSharedContentState(key = sharedElementKey),
-                    animatedVisibilityScope = animatedVisibilityScope,
+                    rememberSharedContentState(key = sharedElementKey!!),
+                    animatedVisibilityScope = animatedVisibilityScope!!,
                 )
             }
         } else Modifier
@@ -363,7 +380,7 @@ fun PosterCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .then(focusInteraction.modifier)
-                .then(peek.boundsModifier)
+                .then(peek?.boundsModifier ?: Modifier)
                 .graphicsLayer {
                     scaleX = scale
                     scaleY = scale
@@ -376,7 +393,7 @@ fun PosterCard(
                     interactionSource = interactionSource,
                     indication = null,
                     onClick = onClick,
-                    onLongClick = peek.onLongClick,
+                    onLongClick = peek?.onLongClick,
                 ),
             shape = cardShape,
             border = border,

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/tasks/ScheduledTasksScreen.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/tasks/ScheduledTasksScreen.kt
@@ -51,6 +51,7 @@ import com.composables.icons.tabler.outline.Refresh
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.designsystem.theme.StatusColors
 import com.raulshma.jellyplay.core.model.ScheduledTaskInfo
+import com.raulshma.jellyplay.core.model.TaskExecutionInfo
 import com.raulshma.jellyplay.core.model.TaskState
 import com.raulshma.jellyplay.core.ui.adaptive.LocalAdaptiveInfo
 import com.raulshma.jellyplay.core.ui.adaptive.bottomPadding
@@ -221,29 +222,7 @@ private fun TaskItem(
                         )
                     }
                     task.lastExecutionResult?.let { last ->
-                        Row(
-                            modifier = Modifier.padding(top = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(
-                                "Last run: ",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Text(
-                                last.startTimeUtc?.replace("T", " ")?.take(19) ?: "Never",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            if (last.errorMessage != null) {
-                                Spacer(Modifier.width(6.dp))
-                                Text(
-                                    "(Failed)",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.error,
-                                )
-                            }
-                        }
+                        LastRunRow(last)
                     }
                 }
                 Spacer(Modifier.width(8.dp))
@@ -289,11 +268,18 @@ private fun TaskItem(
 
             if (task.state == TaskState.RUNNING) {
                 val progress = task.currentProgressPercentage
+                Spacer(Modifier.height(8.dp))
                 if (progress != null) {
-                    Spacer(Modifier.height(8.dp))
+                    // Animate + clamp like RunningTasksCard so the bar eases between
+                    // polled values instead of jumping every refresh.
+                    val animatedProgress by animateFloatAsState(
+                        targetValue = (progress / 100).toFloat().coerceIn(0f, 1f),
+                        animationSpec = MaterialTheme.motionScheme.defaultSpatialSpec(),
+                        label = "taskProgress",
+                    )
                     @OptIn(ExperimentalMaterial3ExpressiveApi::class)
                     JellyPlayLinearProgressIndicator(
-                        progress = { (progress / 100).toFloat() },
+                        progress = { animatedProgress },
                         modifier = Modifier
                             .fillMaxWidth()
                             .clip(ShapeCache.smooth4)
@@ -302,6 +288,23 @@ private fun TaskItem(
                     Spacer(Modifier.height(2.dp))
                     Text(
                         "${progress.toInt()}%",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    // Jellyfin reports progress lazily (null for the first seconds of a
+                    // run, or for task types that never expose a percentage) — show an
+                    // indeterminate bar so RUNNING is visibly active.
+                    @OptIn(ExperimentalMaterial3ExpressiveApi::class)
+                    JellyPlayLinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(ShapeCache.smooth4)
+                            .height(6.dp),
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        "Running…",
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.primary,
                     )
@@ -320,6 +323,101 @@ private fun TaskItem(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun LastRunRow(last: TaskExecutionInfo) {
+    val relative = remember(last.startTimeUtc) { formatRelativeTime(last.startTimeUtc) }
+    val duration = remember(last.startTimeUtc, last.endTimeUtc) {
+        formatTaskDuration(last.startTimeUtc, last.endTimeUtc)
+    }
+    // Map the SDK TaskCompletionStatus serialName to a short label + tone. Success
+    // renders no badge (the timestamp already implies a good run).
+    val statusLabel = when (last.status.lowercase()) {
+        "failed" -> "Failed" to MaterialTheme.colorScheme.error
+        "cancelled" -> "Cancelled" to StatusColors.warning
+        "aborted" -> "Aborted" to StatusColors.warning
+        else -> null to Color.Unspecified
+    }
+
+    Row(
+        modifier = Modifier.padding(top = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            "Last run ",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (relative != null) {
+            Text(
+                relative,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (duration != null) {
+            Text(
+                " · $duration",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        statusLabel.first?.let { label ->
+            Spacer(Modifier.width(6.dp))
+            Text(
+                label,
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = statusLabel.second,
+            )
+        }
+    }
+}
+
+/**
+ * Renders an ISO-8601 (offset-carrying) timestamp as a relative string:
+ * "just now" / "Xm ago" / "Xh ago" / "Xd ago", falling back to a localized date.
+ * Returns null if the string can't be parsed.
+ */
+private fun formatRelativeTime(iso: String?): String? {
+    if (iso.isNullOrBlank()) return null
+    return try {
+        val start = java.time.OffsetDateTime.parse(iso)
+        val duration = java.time.Duration.between(start, java.time.OffsetDateTime.now())
+        when {
+            duration.toMinutes() < 1 -> "just now"
+            duration.toMinutes() < 60 -> "${duration.toMinutes()}m ago"
+            duration.toHours() < 24 -> "${duration.toHours()}h ago"
+            duration.toDays() < 7 -> "${duration.toDays()}d ago"
+            else -> {
+                val formatter = java.text.SimpleDateFormat("MMM d, yyyy", java.util.Locale.getDefault())
+                formatter.format(java.util.Date.from(start.toInstant()))
+            }
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * Formats the wall-clock duration between two ISO-8601 timestamps as a compact
+ * "Xs" / "Xm Ys" / "Xh Ym" string, or null if either bound is missing/unparseable.
+ */
+private fun formatTaskDuration(startIso: String?, endIso: String?): String? {
+    if (startIso.isNullOrBlank() || endIso.isNullOrBlank()) return null
+    return try {
+        val start = java.time.OffsetDateTime.parse(startIso)
+        val end = java.time.OffsetDateTime.parse(endIso)
+        val seconds = java.time.Duration.between(start, end).seconds
+        when {
+            seconds < 60 -> "${seconds}s"
+            seconds < 3_600 -> "${seconds / 60}m ${seconds % 60}s"
+            else -> "${seconds / 3_600}h ${(seconds % 3_600) / 60}m"
+        }
+    } catch (_: Exception) {
+        null
     }
 }
 

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/tasks/ScheduledTasksViewModel.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/tasks/ScheduledTasksViewModel.kt
@@ -6,10 +6,15 @@ import com.raulshma.jellyplay.core.model.TaskState
 import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.isActive
 import javax.inject.Inject
+
+/** Poll interval while at least one task is RUNNING — short enough for live progress. */
+private const val POLL_INTERVAL_MS = 2_000L
 
 data class ScheduledTasksState(
     val isLoading: Boolean = true,
@@ -64,19 +69,24 @@ class ScheduledTasksViewModel @Inject constructor(
 
     private fun startAutoRefresh() {
         launch {
-            hasRunningTasks.collect { running ->
-                while (running) {
-                    delay(5000)
-                    fetchTasks()
-                }
+            // Re-check the current value on each iteration instead of capturing the
+            // emitted `running` param: that snapshot would never change within a single
+            // emission, so the loop would either never engage (if the task was still
+            // IDLE at subscribe time) or run forever.
+            while (currentCoroutineContext().isActive) {
+                delay(POLL_INTERVAL_MS)
+                if (hasRunningTasks.value) fetchTasks()
             }
         }
     }
 
     fun startTask(taskId: String) {
         launch {
+            // Optimistically engage the auto-refresh loop — the server may take longer
+            // than one fetch to flip the task to RUNNING, and a single fetch landing on
+            // IDLE would otherwise leave hasRunningTasks false and polling off.
+            hasRunningTasks.value = true
             apiClient.startTask(taskId)
-            delay(500)
             fetchTasks()
         }
     }
@@ -84,7 +94,6 @@ class ScheduledTasksViewModel @Inject constructor(
     fun cancelTask(taskId: String) {
         launch {
             apiClient.cancelTask(taskId)
-            delay(500)
             fetchTasks()
         }
     }

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/DetailScrollState.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/DetailScrollState.kt
@@ -129,7 +129,10 @@ internal fun rememberDetailScrollState(
 
     val navBarColor = LocalNavigationBarColor.current
     SideEffect {
-        if (navBarColor.value != backgroundColor) navBarColor.value = backgroundColor
+        // Write the settled target, not each interpolated animation frame —
+        // this state drives an animateColorAsState at the app root, so feeding
+        // it every frame recomposes the whole nav subtree ~18x per transition.
+        if (navBarColor.value != targetBackgroundColor) navBarColor.value = targetBackgroundColor
     }
 
     val contentAlpha by animateFloatAsState(

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeerrDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/SeerrDetailScreen.kt
@@ -395,7 +395,10 @@ private fun SeerrDetailContent(
 
     val navBarColor = LocalNavigationBarColor.current
     SideEffect {
-        if (navBarColor.value != backgroundColor) navBarColor.value = backgroundColor
+        // Write the settled target, not each interpolated animation frame —
+        // this state drives an animateColorAsState at the app root, so feeding
+        // it every frame recomposes the whole nav subtree ~18x per transition.
+        if (navBarColor.value != targetBackgroundColor) navBarColor.value = targetBackgroundColor
     }
 
     val appBarColor by animateFloatAsState(

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeBackgroundPipeline.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeBackgroundPipeline.kt
@@ -3,11 +3,10 @@ package com.raulshma.jellyplay.feature.home
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
 import com.raulshma.jellyplay.core.ui.components.LocalNavigationBarColor
@@ -54,10 +53,17 @@ internal fun rememberHomeBackgroundState(
         label = "backgroundColor",
     )
 
-    // Mirror the animated background into the system nav-bar colour.
+    // Mirror the background into the system nav-bar colour. Write only the
+    // settled *target* colour rather than each interpolated animation frame —
+    // this state is read by an animateColorAsState at the app root, so feeding
+    // it every interpolated frame would re-animate and recompose the whole
+    // nav subtree ~18x per transition (the cause of the "dynamic theming makes
+    // the app laggy" regression). The root animation smooths the transition on
+    // its own; the local backgroundColor animation above handles the screen's
+    // own draw.
     val navBarColor = LocalNavigationBarColor.current
-    LaunchedEffect(Unit) {
-        snapshotFlow { backgroundColor }.collect { navBarColor.value = it }
+    SideEffect {
+        if (navBarColor.value != targetBackgroundColor) navBarColor.value = targetBackgroundColor
     }
 
     return HomeBackgroundState(backgroundColor = backgroundColor, isLightTheme = isLightTheme)

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeBackgroundPipeline.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeBackgroundPipeline.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
@@ -62,6 +63,7 @@ internal fun rememberHomeBackgroundState(
     return HomeBackgroundState(backgroundColor = backgroundColor, isLightTheme = isLightTheme)
 }
 
+@Stable
 internal class HomeBackgroundState(
     val backgroundColor: Color,
     val isLightTheme: Boolean,

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeContentSections.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeContentSections.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -165,14 +166,6 @@ internal fun HomeContentList(
             )
         }
     } else {
-        val visibleItemRange by remember {
-            derivedStateOf {
-                val info = listState.layoutInfo
-                if (info.visibleItemsInfo.isEmpty()) IntRange(0, 0)
-                else IntRange(info.visibleItemsInfo.first().index, info.visibleItemsInfo.last().index)
-            }
-        }
-
         // De-duplicate the downloaded row against the online sections so a title
         // that already appears in Continue Watching / Latest / Recently Added
         // isn't shown twice.
@@ -184,6 +177,10 @@ internal fun HomeContentList(
             }
         }
 
+        CompositionLocalProvider(
+            com.raulshma.jellyplay.core.ui.components.LocalScrollIdle provides
+                remember(listState) { { !listState.isScrollInProgress } }
+        ) {
         LazyColumn(
             state = listState,
             modifier = Modifier.fillMaxSize(),
@@ -254,7 +251,16 @@ internal fun HomeContentList(
                 val section = sections[index]
                 val isFirstAfterHero = index == 0 && state.featuredItem != null && state.homeHeroEnabled
                 val sectionIndexInList = index + (if (state.featuredItem != null && state.homeHeroEnabled) 1 else 0)
-                val isCurrentlyVisible = sectionIndexInList in visibleItemRange
+                // Per-item visibility: a single shared IntRange derivedStateOf
+                // invalidated every composed section item on every boundary
+                // crossing (the range value changed even for items whose own
+                // visibility didn't). Reading each item's own visibility as a
+                // Boolean means only the item that entered/left recomposes.
+                val isCurrentlyVisible by remember {
+                    derivedStateOf {
+                        listState.layoutInfo.visibleItemsInfo.any { it.index == sectionIndexInList }
+                    }
+                }
 
                 var hasBeenVisible by rememberSaveable { mutableStateOf(false) }
                 if (isCurrentlyVisible && !hasBeenVisible) hasBeenVisible = true
@@ -417,6 +423,7 @@ internal fun HomeContentList(
                 }
             }
         }
+        } // end CompositionLocalProvider(LocalScrollIdle)
     }
 
     val askItem = askContinueItem

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHero.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHero.kt
@@ -248,8 +248,13 @@ fun HeroHeader(
 
     if (isVisible && !reducedMotion) {
         val heroTransition = rememberInfiniteTransition(label = "hero_animations")
-        // Slow breath runs whenever the hero is visible — 12s cycle is cheap.
-        val rawBreathScale by heroTransition.animateFloat(
+        // Slow breath runs only while the hero is the focal element. A 12s
+        // cycle drives a continuous draw-phase redraw of the 1920x1080
+        // backdrop; during scroll (hero partially visible at top) that redraw
+        // competes with the scroll work. Gating on isProminent collapses it
+        // to a static scale while scrolling — the 12s breath is imperceptible
+        // mid-scroll anyway.
+        val rawBreathScale by if (isProminent) heroTransition.animateFloat(
             initialValue = 1.0f,
             targetValue = 1.04f,
             animationSpec = infiniteRepeatable(
@@ -257,7 +262,7 @@ fun HeroHeader(
                 repeatMode = RepeatMode.Reverse
             ),
             label = "breath"
-        )
+        ) else androidx.compose.runtime.mutableStateOf(1.0f)
         breathScale = rawBreathScale
 
         // The high-frequency (1.8s) play-pulse loops drive ~60Hz draw-phase

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHeroController.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeHeroController.kt
@@ -3,6 +3,7 @@ package com.raulshma.jellyplay.feature.home
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -148,6 +149,7 @@ internal fun rememberHeroController(
     )
 }
 
+@Stable
 internal class HeroController(
     val featuredItem: MediaItem?,
     val backdropUrl: String?,

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeScreen.kt
@@ -67,6 +67,7 @@ import com.raulshma.jellyplay.core.ui.components.SeerrRequestDialog
 import com.raulshma.jellyplay.core.ui.components.focusIndicator
 import com.raulshma.jellyplay.core.ui.components.rememberSeerrCardLoadingState
 import com.raulshma.jellyplay.core.ui.components.resolveHeaderStatus
+import com.raulshma.jellyplay.core.ui.components.HeaderStatus
 import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
 import com.raulshma.jellyplay.core.ui.tv.input.onDpadKey
 import com.raulshma.jellyplay.core.ui.tv.tryRequestFocus
@@ -214,11 +215,12 @@ private fun MainHomeContent(
     val backgroundColor = bgState.backgroundColor
     val isLightTheme = bgState.isLightTheme
 
-    val scrollFraction = homeScrollState.scrollFraction
-
-    val baseIconColor = if (isLightTheme) androidx.compose.material3.MaterialTheme.colorScheme.onSurface else androidx.compose.ui.graphics.Color.White
-    val appBarIconColor = lerp(baseIconColor, androidx.compose.material3.MaterialTheme.colorScheme.onSurface, scrollFraction)
-    val appBarIconColorFaded = appBarIconColor.copy(alpha = 0.9f)
+    // NOTE: scrollFraction / appBarIconColor / appBarIconColorFaded are no
+    // longer read in this scope. Reading scrollFraction here (changes every
+    // pixel over the first 140 dp of hero scroll) invalidated the entire
+    // 450-line MainHomeContent body on every scroll frame. The color
+    // computation now lives in HomeTopDockScrim, a leaf that reads
+    // scrollFraction internally so only it (and HomeTopDock) recompose.
 
     val contentPad = remember(adaptiveInfo, isTv) { adaptiveInfo.contentPadding(isTv) }
 
@@ -469,9 +471,9 @@ private fun MainHomeContent(
                     { viewModel.onEvent(HomeUiEvent.ToggleOfflineMode) }
                 }
 
-                HomeTopDock(
-                    appBarIconColor = appBarIconColor,
-                    appBarIconColorFaded = appBarIconColorFaded,
+                HomeTopDockScrim(
+                    homeScrollState = homeScrollState,
+                    isLightTheme = isLightTheme,
                     isSearchFocused = isSearchFocused,
                     searchQuery = state.searchState.query,
                     offlineMode = state.offlineMode,
@@ -479,11 +481,20 @@ private fun MainHomeContent(
                     headerStatus = headerStatus,
                     activeDownloadCount = activeDownloadCount,
                     showClock = state.showClock,
+                    homeHeroEnabled = state.homeHeroEnabled,
+                    hasFeaturedItem = heroController.featuredItem != null,
+                    isTv = isTv,
                     onModeChange = callbacks.onModeChange,
                     onSearchExpanded = dockOnSearchExpanded,
                     onSearchQueryChange = dockOnSearchQueryChange,
                     onClearSearch = dockOnClearSearch,
                     onToggleOffline = dockOnToggleOffline,
+                    onHeroFocusDown = remember(heroFocusRequester) {
+                        { heroFocusRequester.tryRequestFocus("top_dock_down_hero") }
+                    },
+                    onOpenDrawer = remember(scope, drawerState) {
+                        { scope.launch { drawerState.open() } }
+                    },
                     searchResultsContent = {
                         if (state.searchState.query.isNotBlank() || searchHistory.isNotEmpty()) {
                             HomeSearchResultsOverlay(
@@ -500,18 +511,6 @@ private fun MainHomeContent(
                             )
                         }
                     },
-                    modifier = Modifier.then(
-                        if (isTv) {
-                            Modifier.onDpadKey(
-                                onDown = {
-                                    if (!isSearchFocused && state.homeHeroEnabled && heroController.featuredItem != null) {
-                                        heroFocusRequester.tryRequestFocus("top_dock_down_hero")
-                                        true
-                                    } else false
-                                }
-                            )
-                        } else Modifier
-                    )
                 )
 
                 if (!isTv) {
@@ -535,38 +534,6 @@ private fun MainHomeContent(
                                 androidx.compose.ui.unit.IntOffset(x = 0, y = yOffset.toInt())
                             },
                     )
-                }
-
-                if (!isTv && !isSearchFocused) {
-                    Box(
-                        modifier = Modifier
-                            .statusBarsPadding()
-                            .padding(
-                                horizontal = 16.dp,
-                                vertical = 4.dp
-                            )
-                            .align(Alignment.TopStart)
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(width = 40.dp, height = 64.dp)
-                                .clip(ShapeCache.smooth16)
-                                .focusIndicator(CircleShape)
-                                .clickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null,
-                                    onClick = { scope.launch { drawerState.open() } }
-                                ),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Tabler.Outline.Menu2,
-                                contentDescription = "Open Shortcuts Menu",
-                                tint = appBarIconColorFaded,
-                                modifier = Modifier.size(24.dp)
-                            )
-                        }
-                    }
                 }
         }
     }
@@ -599,6 +566,110 @@ private fun MainHomeContent(
             },
         )
     }
+}
+
+/**
+ * Leaf composable that owns the scroll-coupled app-bar icon colors.
+ *
+ * Reads `scrollFraction` (a per-pixel-changing value over the first 140 dp of
+ * hero scroll) inside its own scope, so only this composable + [HomeTopDock]
+ * + the menu button recompose during scroll — [MainHomeContent] (450+ lines)
+ * is left untouched. Previously the color computation lived in
+ * `MainHomeContent`, which meant every scroll frame re-executed the entire
+ * function body.
+ *
+ * `scrollFraction` is passed as a `() -> Float` getter rather than a `Float`
+ * so that reading it (a Compose snapshot read) happens inside this composable's
+ * scope, not the caller's.
+ */
+@Composable
+private fun HomeTopDockScrim(
+    homeScrollState: HomeScrollState,
+    isLightTheme: Boolean,
+    isSearchFocused: Boolean,
+    searchQuery: String,
+    offlineMode: com.raulshma.jellyplay.core.model.OfflineMode,
+    homeMode: HomeMode,
+    headerStatus: HeaderStatus,
+    activeDownloadCount: Int,
+    showClock: Boolean,
+    homeHeroEnabled: Boolean,
+    hasFeaturedItem: Boolean,
+    isTv: Boolean,
+    onModeChange: (HomeMode) -> Unit,
+    onSearchExpanded: (Boolean) -> Unit,
+    onSearchQueryChange: (String) -> Unit,
+    onClearSearch: () -> Unit,
+    onToggleOffline: () -> Unit,
+    onHeroFocusDown: () -> Boolean,
+    onOpenDrawer: () -> Unit,
+    searchResultsContent: @Composable () -> Unit,
+) {
+    val onSurface = androidx.compose.material3.MaterialTheme.colorScheme.onSurface
+    val baseIconColor = if (isLightTheme) onSurface else androidx.compose.ui.graphics.Color.White
+    val fraction = homeScrollState.scrollFraction
+    val appBarIconColor = lerp(baseIconColor, onSurface, fraction)
+    val appBarIconColorFaded = appBarIconColor.copy(alpha = 0.9f)
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        HomeTopDock(
+        appBarIconColor = appBarIconColor,
+        appBarIconColorFaded = appBarIconColorFaded,
+        isSearchFocused = isSearchFocused,
+        searchQuery = searchQuery,
+        offlineMode = offlineMode,
+        homeMode = homeMode,
+        headerStatus = headerStatus,
+        activeDownloadCount = activeDownloadCount,
+        showClock = showClock,
+        onModeChange = onModeChange,
+        onSearchExpanded = onSearchExpanded,
+        onSearchQueryChange = onSearchQueryChange,
+        onClearSearch = onClearSearch,
+        onToggleOffline = onToggleOffline,
+        searchResultsContent = searchResultsContent,
+        modifier = Modifier.then(
+            if (isTv) {
+                Modifier.onDpadKey(
+                    onDown = {
+                        if (!isSearchFocused && homeHeroEnabled && hasFeaturedItem) {
+                            onHeroFocusDown()
+                        } else false
+                    }
+                )
+            } else Modifier
+        )
+    )
+
+    if (!isTv && !isSearchFocused) {
+        Box(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 4.dp)
+                .align(Alignment.TopStart)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(width = 40.dp, height = 64.dp)
+                    .clip(ShapeCache.smooth16)
+                    .focusIndicator(CircleShape)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = onOpenDrawer,
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Tabler.Outline.Menu2,
+                    contentDescription = "Open Shortcuts Menu",
+                    tint = appBarIconColorFaded,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+    }
+    } // end Box(fillMaxSize) wrapper providing BoxScope for align()
 }
 
 @Composable

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
@@ -119,6 +119,7 @@ import kotlinx.coroutines.launch
     ExperimentalMaterial3Api::class,
     ExperimentalMaterial3ExpressiveApi::class,
     ExperimentalLayoutApi::class,
+    androidx.compose.foundation.ExperimentalFoundationApi::class,
 )
 @Composable
 fun LibraryScreen(
@@ -139,11 +140,19 @@ fun LibraryScreen(
     val viewMode by viewModel.viewMode.collectAsStateWithLifecycle()
 
     val pagedItems = viewModel.pagedItems.collectAsLazyPagingItems()
-    val photoFolderChildUrls by viewModel.photoFolderChildUrls.collectAsStateWithLifecycle()
 
-    val snapshot = pagedItems.itemSnapshotList
-    LaunchedEffect(snapshot) {
-        viewModel.prefetchPhotoFolderChildUrls(snapshot.items)
+    // Prefetch photo-folder child urls on load-state transitions (append/refresh)
+    // instead of snapshot-list identity. Keying on the snapshot re-fired the
+    // prefetch on every page boundary, and each merge produced a new Map in
+    // _photoFolderChildUrls — which used to invalidate the whole screen (now
+    // mitigated by per-item collection in L3.1). Gating on loadState also lets
+    // us skip non-photo libraries entirely.
+    val appendState = pagedItems.loadState
+    LaunchedEffect(appendState) {
+        val snapshot = pagedItems.itemSnapshotList
+        if (snapshot.items.any { it.mediaType == MediaType.PHOTO_FOLDER }) {
+            viewModel.prefetchPhotoFolderChildUrls(snapshot.items)
+        }
     }
     val networkStatus by com.raulshma.jellyplay.core.ui.components.LocalNetworkStatus.current.collectAsStateWithLifecycle()
 
@@ -153,7 +162,9 @@ fun LibraryScreen(
         networkStatus = networkStatus,
     )
 
-    val gridState = rememberLazyGridState()
+    val gridState = rememberLazyGridState(
+        cacheWindow = com.raulshma.jellyplay.core.ui.tv.TvGridCacheWindow,
+    )
     val listState = rememberLazyListState()
     val hasActiveFilters by remember {
         derivedStateOf {
@@ -557,6 +568,13 @@ fun LibraryScreen(
                                                 { onItemClick(item.id, item.mediaType, item.parentId, item.name) }
                                             }
                                             val itemProgress = item.progressFraction()
+                                            // Per-item collection: only photo-folder cards subscribe,
+                                            // and only the affected card recomposes on a prefetch merge.
+                                            val photoFolderChildImageUrls by if (item.mediaType == MediaType.PHOTO_FOLDER) {
+                                                viewModel.photoFolderChildUrlsFor(item.id).collectAsStateWithLifecycle(emptyList())
+                                            } else {
+                                                androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(emptyList()) }
+                                            }
                                             PosterCard(
                                                 item = item,
                                                 imageUrl = remember(item.id) { viewModel.getImageUrl(item.id) },
@@ -565,7 +583,7 @@ fun LibraryScreen(
                                                 progressPercent = itemProgress ?: 0f,
                                                 blurHash = item.blurHashes.primary,
                                                 sharedElementKey = "poster_${item.id}",
-                                                photoFolderChildImageUrls = photoFolderChildUrls[item.id].orEmpty(),
+                                                photoFolderChildImageUrls = photoFolderChildImageUrls,
                                                 modifier = itemModifier,
                                             )
                                         }

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
@@ -113,6 +113,17 @@ class LibraryViewModel @Inject constructor(
     private val _photoFolderChildUrls = stateFlow<Map<String, List<String>>>(emptyMap())
     val photoFolderChildUrls = _photoFolderChildUrls.flow
 
+    /**
+     * Per-item slice of [photoFolderChildUrls]. Lets each photo-folder card
+     * collect only its own urls so a prefetch merge (which produces a new Map
+     * reference) doesn't invalidate the entire [LibraryScreen] — only the one
+     * card whose urls changed. See L3.1 in the perf spec.
+     */
+    fun photoFolderChildUrlsFor(itemId: String): kotlinx.coroutines.flow.Flow<List<String>> =
+        _photoFolderChildUrls.flow
+            .map { it[itemId].orEmpty() }
+            .distinctUntilChanged()
+
     private val _refreshTrigger = kotlinx.coroutines.flow.MutableStateFlow(0)
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryListItem.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryListItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import coil3.size.Size as CoilSize
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.ui.image.MediaImage
 import com.raulshma.jellyplay.core.ui.components.focusIndicator
@@ -62,6 +63,9 @@ fun LibraryListItem(
                     contentDescription = title,
                     modifier = Modifier.matchParentSize(),
                     blurHash = blurHash,
+                    // Size the decode to the 48×72 dp box (2× density = 96×144 px)
+                    // instead of the MediaImage default 384² (~4-6× oversampled).
+                    size = CoilSize(96, 144),
                 )
             }
         }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -350,6 +350,16 @@ class VideoPlayerViewModel @Inject constructor(
     private var lastSeekTimestamp: Long = 0L
 
     /**
+     * Guards the FORCE_DIRECT_PLAY → FORCE_TRANSCODE fallback so the runtime
+     * error triggered by an undecodable direct-played codec only retries once.
+     * Reset whenever a new item is loaded or the user manually changes the
+     * playback mode (so a later user-initiated FORCE_DIRECT_PLAY attempt is
+     * allowed to fail-and-fallback again).
+     */
+    @Volatile
+    private var directPlayFallbackOffered = false
+
+    /**
      * Snapshot of [uiState] with the live playback position/duration injected
      * from the dedicated high-frequency flows (V-1). Use this anywhere that
      * needs the position-aware derived properties ([activeSegment],
@@ -878,7 +888,38 @@ class VideoPlayerViewModel @Inject constructor(
                                 }
                             } }
                             launch { engine.availableTracks.collect { trackSelectionHelper.updateTracksFromEngine() } }
-                            launch { engine.errorFlow.collect { e -> _uiState.update { s -> s.copy(playerError = e, showPlaybackErrorDialog = true) } } }
+                            launch {
+                                engine.errorFlow.collect { e ->
+                                    // FORCE_DIRECT_PLAY uses "direct play all"
+                                    // profile — the server hands back a static URL even for
+                                    // codecs the player can't decode, so a runtime error here
+                                    // usually means the direct-played container/codec is
+                                    // undecodable. Offer a one-shot automatic transcode
+                                    // fallback (mirrors Wholphin's onPlayerError retry) rather
+                                    // than surfacing a dead-end error dialog.
+                                    if (_uiState.value.playbackMode == PlaybackMode.FORCE_DIRECT_PLAY &&
+                                        !directPlayFallbackOffered
+                                    ) {
+                                        directPlayFallbackOffered = true
+                                        userMessageBus.info("Direct Play failed — switching to transcode")
+                                        _uiState.update { it.copy(playbackMode = PlaybackMode.FORCE_TRANSCODE) }
+                                        launch {
+                                            preferencesStore.setPlaybackMode(PlaybackMode.FORCE_TRANSCODE)
+                                            reportCurrentPlaybackStopped()
+                                            progressReporter.cancelJobs()
+                                            val pos = playerSessionManager.engine?.currentPositionMs ?: 0L
+                                            playerSessionManager.reloadPlayback(
+                                                PlaybackMode.FORCE_TRANSCODE,
+                                                _uiState.value.streamingQuality,
+                                                pos,
+                                            )
+                                            afterEngineReloadRebuildSessionAndTracking()
+                                        }
+                                    } else {
+                                        _uiState.update { s -> s.copy(playerError = e, showPlaybackErrorDialog = true) }
+                                    }
+                                }
+                            }
                             // Buffering watchdog: if the engine never reaches
                             // READY within BUFFERING_TIMEOUT_MS during the
                             // *initial* buffer (before first READY), surface the
@@ -1053,6 +1094,7 @@ class VideoPlayerViewModel @Inject constructor(
         _uiState.update { it.copy(autoplayCancelled = false) }
         lastSeekPositionMs = null
         lastSeekTimestamp = 0L
+        directPlayFallbackOffered = false
         trackSelectionHelper.setPendingStreams(subtitleStreamIndex, audioStreamIndex)
 
         // "Play On" routing: if a Jellyfin remote session is connected (via the
@@ -1605,6 +1647,9 @@ class VideoPlayerViewModel @Inject constructor(
 
     fun setPlaybackMode(mode: PlaybackMode) {
         if (_uiState.value.playbackMode == mode) return
+        // User explicitly changed the mode — re-arm the direct-play fallback so
+        // a future FORCE_DIRECT_PLAY attempt can fail-and-retry again.
+        directPlayFallbackOffered = false
         _uiState.update { it.copy(playbackMode = mode) }
         launch {
             preferencesStore.setPlaybackMode(mode)
@@ -2493,7 +2538,31 @@ class VideoPlayerViewModel @Inject constructor(
         val engine = playerSessionManager.engine ?: return
         val player = engine.underlyingPlayer ?: return
 
-        val session = MediaSession.Builder(context, player)
+        // Pin the caller-supplied title/artwork at the MediaSession layer via a
+        // ForwardingPlayer. ExoPlayer's HLS playlist parser resolves an empty
+        // MediaMetadata for Jellyfin transcode manifests (which carry no
+        // metadata), which would blank the system now-playing / lock-screen
+        // notification. We previously re-applied the title by calling
+        // player.replaceMediaItem() from ExoPlayerEngine's onMediaMetadataChanged
+        // — but mutating the currently-playing MediaItem mid-playback disrupts
+        // ExoPlayer's HLS timeline/seek state and was the root cause of seeks
+        // restarting from 0 on transcoded media. Overriding getMediaMetadata()
+        // here is non-destructive: the underlying player's timeline and position
+        // are untouched, so HLS seeking stays intact while the notification
+        // continues to show the pinned title/artwork.
+        val artworkUri = playbackRepository.getImageUrl(itemId, maxWidth = 300)
+            .takeIf { it.isNotBlank() }
+            ?.let { runCatching { Uri.parse(it) }.getOrNull() }
+        val pinnedMetadata = MediaMetadata.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .apply { artworkUri?.let { setArtworkUri(it) } }
+            .build()
+        val sessionPlayer = object : androidx.media3.common.ForwardingPlayer(player) {
+            override fun getMediaMetadata(): MediaMetadata = pinnedMetadata
+        }
+
+        val session = MediaSession.Builder(context, sessionPlayer)
             .setId("jellyplay_video_${itemId}")
             .build()
         videoMediaSession = session

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
@@ -139,6 +139,16 @@ class ExoPlayerEngine(
     private var lastFrameH = -1
     private var currentMediaItem: MediaItem? = null
     private val bandwidthMeter = bandwidthMeter ?: DefaultBandwidthMeter.Builder(context).build()
+
+    /**
+     * Server-reported total runtime (ms), captured from [PlaybackRequest.serverDurationMs]
+     * in [load]. Used as a fallback in [durationMs] when the ExoPlayer demuxer cannot
+     * resolve a duration for HLS/transcoded manifests (where `player.duration` is
+     * frequently `C.TIME_UNSET`). Mirrors [MpvPlayerEngine.serverDurationMs].
+     */
+    @Volatile
+    private var serverDurationMs: Long = 0L
+
     private val currentSubtitleConfigs = mutableListOf<MediaItem.SubtitleConfiguration>()
 
     override val underlyingPlayer: androidx.media3.common.Player? get() = player
@@ -235,6 +245,17 @@ class ExoPlayerEngine(
         override fun onVolumeChanged(volume: Float) {
             cachedVolume = volume
         }
+
+        // NOTE: onMediaMetadataChanged is intentionally NOT overridden here.
+        // Previously a pinned title/artwork re-apply path called
+        // `player.replaceMediaItem(0, ...)` whenever Media3 reported an empty
+        // metadata — which it does repeatedly for HLS/transcoded manifests
+        // (Jellyfin transcode playlists carry no metadata). Mutating the
+        // currently-playing MediaItem from inside that callback disrupts
+        // ExoPlayer's HLS timeline/seek state and was the root cause of
+        // seeks restarting playback from 0 on transcoded media. Metadata
+        // pinning for the system MediaSession is now handled externally via
+        // a ForwardingPlayer in VideoPlayerViewModel.createVideoMediaSession.
     }
 
     /**
@@ -416,19 +437,24 @@ class ExoPlayerEngine(
         val mediaItem = MediaItem.Builder()
             .setUri(request.uri)
             .apply {
-                val effectiveMime = request.mimeType ?: if (request.isLive) {
-                    // Live TV stream URLs are extension-less (/Videos/{id}/stream
-                    // ?...&LiveStreamId=...). Without a hint ExoPlayer falls
-                    // back to content sniffing, which fails for MPEG-TS-over-HTTP
-                    // and selects the wrong extractor for HLS. Pick the hint from
-                    // the URL so the right MediaSource is used.
-                    if (request.uri.contains(".m3u8", ignoreCase = true)) {
-                        MimeTypes.APPLICATION_M3U8
-                    } else {
-                        MimeTypes.VIDEO_MP2T
-                    }
-                } else null
-                effectiveMime?.let { setMimeType(it) }
+                // MIME-type hint so DefaultMediaSourceFactory selects the right
+                // MediaSource (HlsMediaSource vs progressive extractor):
+                //  - Caller-provided hint wins (offline container sniffing).
+                //  - Live TV URLs are often extension-less; infer from the URL.
+                //  - Transcoded (non-live) streams are served as Jellyfin HLS
+                //    master playlists (master.m3u8) — without the hint ExoPlayer
+                //    relies on extension detection, which is fragile when the
+                //    query string trails the .m3u8 path. The official Jellyfin
+                //    Android client pins APPLICATION_M3U8 the same way. This is
+                //    also what makes native HLS seeking (segment + EXTINF
+                //    resolution) reliable on a transcode.
+                val inferredMime = when {
+                    request.mimeType != null -> request.mimeType
+                    request.uri.contains(".m3u8", ignoreCase = true) -> MimeTypes.APPLICATION_M3U8
+                    request.isLive -> MimeTypes.VIDEO_MP2T
+                    else -> null
+                }
+                inferredMime?.let { setMimeType(it) }
             }
             .apply {
                 if (request.isLive) {
@@ -445,6 +471,7 @@ class ExoPlayerEngine(
 
         exo.setMediaItem(mediaItem)
         currentMediaItem = mediaItem
+        serverDurationMs = request.serverDurationMs
         currentSubtitleConfigs.clear()
         currentSubtitleConfigs.addAll(subtitleConfigs)
         exo.prepare()
@@ -503,6 +530,7 @@ class ExoPlayerEngine(
         player = null
         trackSelector = null
         currentMediaItem = null
+        serverDurationMs = 0L
         currentSubtitleConfigs.clear()
         lastVideoStats = null
         videoDecoderCounters = null
@@ -764,7 +792,18 @@ class ExoPlayerEngine(
     }
 
     override val currentPositionMs: Long get() = player?.currentPosition ?: 0L
-    override val durationMs: Long get() = player?.duration?.coerceAtLeast(0L) ?: 0L
+    override val durationMs: Long
+        get() {
+            // Prefer the ExoPlayer-resolved duration when available; fall back
+            // to the server-reported runTimeTicks, which for HLS/transcoded
+            // streams is the only accurate total-runtime source (ExoPlayer's
+            // `duration` is `C.TIME_UNSET` until/ unless the manifest advertises
+            // a finite VOD duration — Jellyfin transcode manifests often do
+            // not, leaving the seek bar and end-detection without a duration).
+            // Mirrors [MpvPlayerEngine.durationMs].
+            val engine = player?.duration ?: C.TIME_UNSET
+            return if (engine != C.TIME_UNSET && engine > 0L) engine else serverDurationMs
+        }
     override val playbackSpeed: Float get() = player?.playbackParameters?.speed ?: 1f
     override val audioSessionId: Int get() = player?.audioSessionId ?: C.AUDIO_SESSION_ID_UNSET
 

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvPlayerEngine.kt
@@ -113,8 +113,7 @@ class MpvPlayerEngine(
     // property observers (postInitOptions) instead of via per-tick
     // getProperty JNI calls on the main thread — the old polling approach
     // issued 3–15 synchronous JNI reads/second on the main looper and was a
-    // primary source of UI jank during mpv playback (see findroid's pure-
-    // observer MPVPlayer for the reference pattern).
+    // primary source of UI jank during mpv playback
     @Volatile private var cachedPositionMs: Long = 0L
     @Volatile private var cachedDurationMs: Long = 0L
     @Volatile private var cachedBufferedPositionMs: Long = 0L


### PR DESCRIPTION
This pull request introduces several improvements across animation handling, playback profiles, UI performance, and code maintainability. The most significant changes include simplifying navigation animations, adding a "direct play all" device profile for playback, optimizing UI performance during scroll, and refactoring for better code clarity and efficiency.

**Navigation Animation Simplification:**
- Removed all `scaleIn` and `scaleOut` animations from navigation transitions in `JellyPlayApp.kt`, leaving only slide and fade effects for smoother and less resource-intensive transitions. [[1]](diffhunk://#diff-d15400c9a1dbea5fbd61979efa08030b490a7544bb027dbac9270284a1db29a8L16-L17) [[2]](diffhunk://#diff-d15400c9a1dbea5fbd61979efa08030b490a7544bb027dbac9270284a1db29a8L1602-L1612) [[3]](diffhunk://#diff-d15400c9a1dbea5fbd61979efa08030b490a7544bb027dbac9270284a1db29a8L1644-L1654) [[4]](diffhunk://#diff-d15400c9a1dbea5fbd61979efa08030b490a7544bb027dbac9270284a1db29a8L1674-L1684)
- Removed the unused `defaultSpatial` animation spec.

**Playback Profile Enhancements:**
- Added a new `directPlayAll` device profile in `DeviceProfileProvider` for force-direct-play mode, ensuring the server always marks sources as directly playable and returns static URLs.
- Updated `PlaybackApiClientImpl` to use the new "direct play all" profile when appropriate, giving the client full control over playback compatibility handling.
- Improved documentation and initialization order for subtitle delivery profiles to prevent null pointer exceptions during construction.

**UI Performance and Responsiveness:**
- Introduced `LocalScrollIdle` composition local to let leaf composables detect scroll idle state, allowing expensive operations (like color extraction) to defer until scrolling stops, reducing UI jank. [[1]](diffhunk://#diff-554092fb3416d2fc12eb3f3632c7f1074047af8509909fca99fd9d0acf79f6cfR1-R15) [[2]](diffhunk://#diff-f4af0fc8d0d877ae1c530ff8d6f2c8cfca4f44748a5f53b358cf10c0623c9a14R88) [[3]](diffhunk://#diff-f4af0fc8d0d877ae1c530ff8d6f2c8cfca4f44748a5f53b358cf10c0623c9a14L96-R105)
- Optimized `PosterCard` to avoid unnecessary composition allocations when neither media preview nor shared element transitions are used, improving grid performance. [[1]](diffhunk://#diff-f4af0fc8d0d877ae1c530ff8d6f2c8cfca4f44748a5f53b358cf10c0623c9a14L318-R352) [[2]](diffhunk://#diff-f4af0fc8d0d877ae1c530ff8d6f2c8cfca4f44748a5f53b358cf10c0623c9a14L366-R383) [[3]](diffhunk://#diff-f4af0fc8d0d877ae1c530ff8d6f2c8cfca4f44748a5f53b358cf10c0623c9a14L379-R396)

**Networking and Dependency Injection:**
- Changed OkHttp client initialization to use the current config value synchronously instead of blocking with `runBlocking { .first() }`, reducing startup latency and avoiding disk reads on the DI critical path. [[1]](diffhunk://#diff-58659f8e53d1bef8a97a0e9ca1b9c825a4c4ea5b99583415c15a8773ad5096e1L5) [[2]](diffhunk://#diff-58659f8e53d1bef8a97a0e9ca1b9c825a4c4ea5b99583415c15a8773ad5096e1L210-R221)

**Model and UI Refactoring:**
- Improved mapping of task execution times to ensure correct ISO formatting, fixing potential parsing issues.
- Refactored the scheduled tasks screen to extract the last run display into a reusable `LastRunRow` composable, simplifying the UI code. [[1]](diffhunk://#diff-ca5fa756094639b40b27539992974ae9dbe24ffa09a160f6dd61ca9a291341c4R54) [[2]](diffhunk://#diff-ca5fa756094639b40b27539992974ae9dbe24ffa09a160f6dd61ca9a291341c4L224-R225)