### PR TITLE
Enhance widgets, storage, music, requests, and admin features

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -205,6 +205,26 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".widget.config.ContinueWatchingWidgetConfigActivity"
+            android:exported="true"
+            android:theme="@style/Theme.JellyPlay.Starting"
+            android:label="@string/widget_continue_watching_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".widget.config.NowPlayingWidgetConfigActivity"
+            android:exported="true"
+            android:theme="@style/Theme.JellyPlay.Starting"
+            android:label="@string/widget_now_playing_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
         <receiver android:name="androidx.mediarouter.media.MediaTransferReceiver" />
 
         <receiver

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,7 +62,8 @@
             android:theme="@style/Theme.JellyPlay.Starting"
             android:windowSoftInputMode="adjustResize"
             android:supportsPictureInPicture="true"
-            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize">
+            android:resizeableActivity="true"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|uiMode|keyboard|keyboardHidden|navigation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -105,17 +105,6 @@
             android:value="com.raulshma.jellyplay.cast.JellyPlayCastOptionsProvider" />
 
         <service
-            android:name="com.raulshma.jellyplay.core.data.playback.JellyPlayPlaybackService"
-            android:exported="true"
-            android:foregroundServiceType="mediaPlayback"
-            tools:ignore="Instantiatable">
-            <intent-filter>
-                <action android:name="androidx.media3.session.MediaLibraryService" />
-                <action android:name="android.media.browse.MediaBrowserService" />
-            </intent-filter>
-        </service>
-
-        <service
             android:name=".floating.FloatingPlayerService"
             android:exported="false"
             android:foregroundServiceType="mediaPlayback" />

--- a/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt
@@ -67,8 +67,13 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory, Config
     @Inject lateinit var playbackSyncSchedulerProvider: javax.inject.Provider<com.raulshma.jellyplay.core.data.worker.PlaybackSyncScheduler>
     @Inject lateinit var playbackSyncReconnectListenerProvider: javax.inject.Provider<com.raulshma.jellyplay.core.data.worker.PlaybackSyncReconnectListener>
     @Inject lateinit var downloadReconnectListenerProvider: javax.inject.Provider<com.raulshma.jellyplay.core.data.worker.DownloadReconnectListener>
+    @Inject lateinit var notificationReconnectListenerProvider: javax.inject.Provider<com.raulshma.jellyplay.core.notification.scheduler.NotificationReconnectListener>
     @Inject lateinit var widgetWorkSchedulerProvider: javax.inject.Provider<com.raulshma.jellyplay.widget.WidgetWorkScheduler>
     @Inject lateinit var downloadRecoveryInitializerProvider: javax.inject.Provider<com.raulshma.jellyplay.startup.DownloadRecoveryInitializer>
+    // javax.inject.Provider defers construction of AppUpdateRepository (which
+    // pulls GitHub + OkHttp) off the cold-start path. cleanupDownloadedApk is a
+    // cheap file delete, but construction is the cost worth deferring.
+    @Inject lateinit var appUpdateRepositoryProvider: javax.inject.Provider<com.raulshma.jellyplay.core.data.update.AppUpdateRepository>
 
     @Inject @ApplicationScope lateinit var applicationScope: CoroutineScope
 
@@ -90,12 +95,20 @@ class JellyPlayApplication : Application(), SingletonImageLoader.Factory, Config
             playbackSyncSchedulerProvider.get().enqueuePeriodic()
             playbackSyncReconnectListenerProvider.get().start()
             downloadReconnectListenerProvider.get().start()
+            notificationReconnectListenerProvider.get().start()
             autoDownloadSchedulerProvider.get().sync()
             notificationSchedulerProvider.get().scheduleOrUpdate()
         }
         // Best-effort download recovery — independent of the above groups.
         applicationScope.launch(Dispatchers.IO) {
             downloadRecoveryInitializerProvider.get().recover()
+        }
+        // Sweep any APK left by a prior self-update. A successful install
+        // restarts the process (so this runs in the new version) and leaves the
+        // old APK orphaned; a cancelled/failed install also leaves it behind.
+        // Safe at startup: onCreate precedes any new download.
+        applicationScope.launch(Dispatchers.IO) {
+            runCatching { appUpdateRepositoryProvider.get().cleanupDownloadedApk() }
         }
     }
 

--- a/app/src/main/java/com/raulshma/jellyplay/MainActivity.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/MainActivity.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.graphics.Rect
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.os.Bundle
@@ -57,6 +58,8 @@ import com.raulshma.jellyplay.core.ui.components.colorBlindFilter
 import com.raulshma.jellyplay.core.ui.tv.isTv
 import com.raulshma.jellyplay.navigation.JellyPlayApp
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -145,14 +148,25 @@ class MainActivity : FragmentActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
             packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
         ) {
+            // One collector drives param application for both the pre-arm path
+            // (not yet in PiP: setAutoEnterEnabled + aspect + source rect, no
+            // actions) and the in-PiP refresh path (resolution/track swap while
+            // already in PiP: actions + aspect). Branching here avoids a second
+            // aspect collector that would double-apply params on a track change.
             lifecycleScope.launch {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    pipController.shouldAutoEnterPip.collect { shouldAutoEnter ->
-                        val params = PictureInPictureParams.Builder()
-                            .setAutoEnterEnabled(shouldAutoEnter)
-                            .build()
-                        setPictureInPictureParams(params)
-                    }
+                    combine(
+                        pipController.shouldAutoEnterPip,
+                        pipController.pipAspectRatio,
+                    ) { shouldAutoEnter, aspect -> shouldAutoEnter to aspect }
+                        .distinctUntilChanged()
+                        .collect {
+                            if (isInPictureInPictureMode) {
+                                applyPipParams(includeActions = true)
+                            } else {
+                                applyPipParams(includeActions = false)
+                            }
+                        }
                 }
             }
             // Keep the PiP play/pause action icon in sync with playback state.
@@ -160,6 +174,19 @@ class MainActivity : FragmentActivity() {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     pipController.isPlaying.collect {
                         refreshPipActions()
+                    }
+                }
+            }
+            // Auto-exit: when the ViewModel signals END/ERROR in PiP, reuse the
+            // existing dismiss path (pause + navigate back) so no new exit
+            // plumbing is needed.
+            lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    pipController.autoExitPip.collect { exit ->
+                        if (exit && isInPictureInPictureMode) {
+                            pipController.consumeAutoExitPip()
+                            pipController.notifyPipDismissed()
+                        }
                     }
                 }
             }
@@ -516,29 +543,81 @@ class MainActivity : FragmentActivity() {
         }
     }
 
-    fun enterPipMode(aspectRatio: Rational? = null) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)) return
-
-        val shouldAutoEnter = pipController.shouldAutoEnterPip.value
+    fun enterPipMode() {
+        if (!isPipCapable()) return
 
         registerPipActionReceiver()
 
-        val params = PictureInPictureParams.Builder().apply {
-            val ratio = aspectRatio ?: Rational(16, 9)
-            val clamped = clampAspectRatio(ratio)
-            setAspectRatio(clamped)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                setAutoEnterEnabled(shouldAutoEnter)
-                setSeamlessResizeEnabled(shouldAutoEnter)
-            }
-            // PiP remote actions require API 26+ (RemoteAction itself); the actions
-            // list is accepted on all PiP-capable versions but only rendered by the
-            // system on API 26+.
-            setActions(buildPipActions())
-        }.build()
+        val params = buildPipParams(preArm = false, includeActions = true)
+        // Wrap the system call: some OEMs/ROMs throw IllegalArgumentException on
+        // out-of-range aspect ratios or malformed source rects even after our
+        // clamping. Fail open (no entry) rather than crashing — VLC's defense.
+        runCatching { enterPictureInPictureMode(params) }
+            .onFailure { Log.w(TAG, "PiP enter failed", it) }
+    }
 
-        enterPictureInPictureMode(params)
+    private fun isPipCapable(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+
+    /**
+     * Builds [PictureInPictureParams] from the live [PipController] state: the
+     * video aspect ratio (from server streams, clamped to the legal range), the
+     * source-rect hint (from the surface's window bounds, for a smooth enter
+     * animation), seamless resize, auto-enter flag, and remote actions.
+     *
+     * @param preArm `true` for the pre-arm path (not yet in PiP): sets
+     *  `setAutoEnterEnabled`/`setSeamlessResizeEnabled` from the controller so
+     *  the system can auto-enter on a home gesture; omits actions (only
+     *  rendered once in PiP). `false` for an explicit enter or an in-PiP
+     *  refresh, where actions are attached.
+     * @param includeActions whether to attach the play/pause/skip/next
+     *  RemoteActions. Omitted during pre-arm; attached on enter and refresh.
+     */
+    private fun buildPipParams(
+        preArm: Boolean,
+        includeActions: Boolean,
+    ): PictureInPictureParams = PictureInPictureParams.Builder().apply {
+        val ratio = pipController.pipAspectRatio.value ?: Rational(16, 9)
+        setAspectRatio(clampAspectRatio(ratio))
+        // Source-rect hint: the video surface's window bounds. Gives the system
+        // the crop source for a seamless enter animation (Jellyfin's pattern).
+        // Only set when the surface is laid out and within the window; a hint
+        // outside the window bounds is ignored or can throw on some ROMs.
+        pipController.pipSourceRect?.let { src ->
+            if (isValidSourceRect(src)) setSourceRectHint(src)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val autoEnter = if (preArm) pipController.shouldAutoEnterPip.value else false
+            setAutoEnterEnabled(autoEnter)
+            setSeamlessResizeEnabled(autoEnter)
+        }
+        if (includeActions) setActions(buildPipActions())
+    }.build()
+
+    /**
+     * A source-rect hint is valid only when it has non-zero area and is fully
+     * within the visible window bounds (off-screen edges can cause the system to
+     * drop the hint or throw).
+     */
+    private fun isValidSourceRect(src: Rect): Boolean {
+        if (src.width() <= 0 || src.height() <= 0) return false
+        if (src.left < 0 || src.top < 0) return false
+        val w = window.decorView.width
+        val h = window.decorView.height
+        return w <= 0 || h <= 0 || (src.right <= w && src.bottom <= h)
+    }
+
+    /**
+     * Re-applies the current PiP params via [setPictureInPictureParams]. Used
+     * both for pre-arming (when auto-enter/aspect change) and for live updates
+     * while in PiP. Guarded against [IllegalArgumentException].
+     */
+    private fun applyPipParams(includeActions: Boolean) {
+        if (!isPipCapable()) return
+        val params = buildPipParams(preArm = !isInPictureInPictureMode, includeActions = includeActions)
+        runCatching { setPictureInPictureParams(params) }
+            .onFailure { Log.w(TAG, "PiP setPictureInPictureParams failed", it) }
     }
 
     /**
@@ -596,12 +675,8 @@ class MainActivity : FragmentActivity() {
      * playback state changes while in PiP. No-op outside PiP.
      */
     fun refreshPipActions() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
         if (!isInPictureInPictureMode) return
-        val params = PictureInPictureParams.Builder()
-            .setActions(buildPipActions())
-            .build()
-        runCatching { setPictureInPictureParams(params) }
+        applyPipParams(includeActions = true)
     }
 
     private fun registerPipActionReceiver() {

--- a/app/src/main/java/com/raulshma/jellyplay/MainActivity.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/MainActivity.kt
@@ -12,6 +12,7 @@ import android.content.pm.PackageManager
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.graphics.Color
 import androidx.activity.SystemBarStyle
@@ -617,7 +618,14 @@ class MainActivity : FragmentActivity() {
                     PIP_ACTION_NEXT -> PipAction.NEXT
                     else -> return
                 }
-                pipController.pipTransport?.handle(action)
+                val transport = pipController.pipTransport
+                if (transport == null) {
+                    // A stale/unregistered transport silently drops PiP actions.
+                    // Log so it's diagnosable instead of dead PIP buttons.
+                    Log.w(TAG, "PiP action $action dropped: pipTransport is null")
+                } else {
+                    transport.handle(action)
+                }
                 // The play/pause toggle changes the icon — refresh immediately.
                 refreshPipActions()
             }
@@ -647,6 +655,7 @@ class MainActivity : FragmentActivity() {
     }
 
     private companion object {
+        const val TAG = "MainActivity"
         const val PIP_ACTION_BROADCAST = "com.raulshma.jellyplay.PIP_ACTION"
         const val PIP_ACTION_EXTRA = "pip_action_id"
         const val PIP_ACTION_PLAY = 1

--- a/app/src/main/java/com/raulshma/jellyplay/MainViewModel.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/MainViewModel.kt
@@ -27,6 +27,7 @@ import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import com.raulshma.jellyplay.deeplink.DeepLinkHandler
 import com.raulshma.jellyplay.core.data.playback.VideoMiniPlayerState
 import com.raulshma.jellyplay.core.data.update.AppUpdateRepository
+import com.raulshma.jellyplay.core.data.update.PendingAppUpdate
 import com.raulshma.jellyplay.update.UpdateState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -207,10 +208,23 @@ class MainViewModel @Inject constructor(
                 }
             }
             _isRestoring.set(false)
-            // Best-effort app-update check once the UI is up. Gated by the
-            // user's "check for updates automatically" preference so the
-            // toggle on the About screen remains the single off-switch.
-            checkForAppUpdate()
+            // Best-effort app-update check once the UI is up. First restore any
+            // update APK already downloaded but not yet installed (kept on disk
+            // across restarts); only if there's nothing pending do we hit the
+            // network. Gated by the "check for updates automatically" toggle so
+            // that off-switch stays the single way to silence update UI on
+            // launch — the file itself is still retained for a manual check.
+            val experimental = experimentalStore.experimental.first()
+            if (experimental.selfUpdateCheckEnabled) {
+                val pending = runCatching { appUpdateRepository.getPendingUpdate() }.getOrNull()
+                if (pending != null &&
+                    !isUpdateRecentlyDismissed(pending.info.latestVersion, experimental)
+                ) {
+                    _updateState.set(UpdateState.Downloaded(pending.info, pending.apkFile))
+                } else {
+                    checkForAppUpdate()
+                }
+            }
         }
 
         launch {
@@ -377,22 +391,57 @@ class MainViewModel @Inject constructor(
         launch {
             _updateState.set(UpdateState.Checking)
             val experimental = experimentalStore.experimental.first()
+            val pending = runCatching { appUpdateRepository.getPendingUpdate() }.getOrNull()
             val result = appUpdateRepository.checkForUpdate(
                 supportedAbis = android.os.Build.SUPPORTED_ABIS,
             )
-            result
-                .onSuccess { info ->
-                    when {
-                        // Always surface the "up to date" result with release notes.
-                        !info.isUpdateAvailable -> _updateState.set(UpdateState.NoUpdate(info))
-                        // Auto-download enabled → begin streaming without the prompt.
-                        experimental.selfUpdateDownloadEnabled && info.downloadAssetUrl != null ->
-                            startUpdateDownload(info)
-                        else -> _updateState.set(UpdateState.UpdateAvailable(info))
+            // Manual checks ignore the 24h dismissal — the user explicitly asked.
+            // Always hit the network so a release published *after* the on-disk
+            // APK was downloaded can still surface: when both are present, prefer
+            // the newer version (ties keep the pending APK so its already-downloaded
+            // bytes stay the install path). On network failure fall back to pending.
+            val remote = result.getOrNull()
+            val surface = pickUpdateToSurface(pending?.info, remote)
+            when {
+                // A newer version is available to download.
+                surface != null && surface.isUpdateAvailable -> {
+                    // If the chosen version is already on disk, show install-ready;
+                    // otherwise prompt (or auto-download) as usual.
+                    if (pending != null && surface.latestVersion == pending.info.latestVersion) {
+                        _updateState.set(UpdateState.Downloaded(pending.info, pending.apkFile))
+                    } else if (experimental.selfUpdateDownloadEnabled && surface.downloadAssetUrl != null) {
+                        startUpdateDownload(surface)
+                    } else {
+                        _updateState.set(UpdateState.UpdateAvailable(surface))
                     }
                 }
-                .onFailure { _updateState.set(UpdateState.Error(it.message ?: "Update check failed")) }
+                // Up to date — show the result (with release notes).
+                surface != null -> _updateState.set(UpdateState.NoUpdate(surface))
+                // Network failed but a pending APK exists — fall back to it.
+                pending != null ->
+                    _updateState.set(UpdateState.Downloaded(pending.info, pending.apkFile))
+                // Network failed, nothing pending.
+                else -> _updateState.set(UpdateState.Error(result.exceptionOrNull()?.message ?: "Update check failed"))
+            }
         }
+    }
+
+    /**
+     * Picks the [AppUpdateInfo] to surface for a manual check: the pending
+     * (on-disk) version, the freshly-fetched remote version, or null when the
+     * remote failed *and* nothing is pending. When both exist, prefers the
+     * newer version — ties keep the pending one so the already-downloaded APK
+     * stays the install path instead of forcing a re-download.
+     */
+    private fun pickUpdateToSurface(
+        pending: com.raulshma.jellyplay.core.model.AppUpdateInfo?,
+        remote: com.raulshma.jellyplay.core.model.AppUpdateInfo?,
+    ): com.raulshma.jellyplay.core.model.AppUpdateInfo? {
+        if (remote == null) return pending
+        if (pending == null) return remote
+        return if (com.raulshma.jellyplay.core.network.github.GitHubReleasesApiImpl
+                .compareVersions(remote.latestVersion, pending.latestVersion) > 0
+        ) remote else pending
     }
 
     /**
@@ -405,13 +454,15 @@ class MainViewModel @Inject constructor(
     }
 
     /**
-     * Begins streaming the APK for the given update, reporting progress.
+     * Begins streaming the APK for the given update, reporting progress. Wipes
+     * any previously-downloaded APK + sidecar first, so this is also the path
+     * used by [redownloadUpdate] to overwrite an existing file.
      */
     fun startUpdateDownload(info: com.raulshma.jellyplay.core.model.AppUpdateInfo) {
-        val url = info.downloadAssetUrl ?: return
+        if (info.downloadAssetUrl == null) return
         launch {
             _updateState.set(UpdateState.Downloading(info, 0f, 0L, info.releaseSize))
-            val result = appUpdateRepository.downloadApk(url) { fraction, read, total ->
+            val result = appUpdateRepository.downloadApk(info) { fraction, read, total ->
                 _updateState.set(UpdateState.Downloading(info, fraction, read, total))
             }
             result
@@ -420,21 +471,42 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Re-downloads the update whose APK is already on disk (and shown as
+     * [UpdateState.Downloaded]). Falls back to the current state's info; the
+     * repository overwrites the existing file + sidecar via the normal
+     * download path.
+     */
+    fun redownloadUpdate() {
+        val state = _updateState.value
+        val info = (state as? UpdateState.Downloaded)?.info
+            ?: (state as? UpdateState.UpdateAvailable)?.info
+            ?: return
+        startUpdateDownload(info)
+    }
+
     /** Builds and emits the system package-installer intent for the APK. */
     fun buildInstallIntent(file: java.io.File): android.content.Intent =
         appUpdateRepository.buildInstallIntent(file)
 
     /**
      * Hides the update sheet without changing download state. When dismissed
-     * from an [UpdateState.UpdateAvailable] prompt, stamps the version + time
-     * so the launch-time auto-check stays quiet for the same version for 24h.
-     * Manual checks still surface the result regardless of dismissal.
+     * from an [UpdateState.UpdateAvailable] prompt or an install-ready
+     * [UpdateState.Downloaded] sheet, stamps the version + time so the
+     * launch-time auto-check / restore stays quiet for the same version for
+     * 24h. The downloaded APK is retained on disk either way. Manual checks
+     * still surface the result regardless of dismissal.
      */
     fun dismissUpdate() {
         val state = _updateState.value
-        if (state is UpdateState.UpdateAvailable) {
+        val dismissedVersion = when (state) {
+            is UpdateState.UpdateAvailable -> state.info.latestVersion
+            is UpdateState.Downloaded -> state.info.latestVersion
+            else -> null
+        }
+        if (dismissedVersion != null) {
             launch {
-                experimentalStore.setDismissedUpdate(state.info.latestVersion)
+                experimentalStore.setDismissedUpdate(dismissedVersion)
             }
         }
         _updateState.set(UpdateState.Idle)

--- a/app/src/main/java/com/raulshma/jellyplay/MainViewModel.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/MainViewModel.kt
@@ -183,6 +183,14 @@ class MainViewModel @Inject constructor(
     private val _updateState = stateFlow<UpdateState>(UpdateState.Idle)
     val updateState = _updateState.flow
 
+    /**
+     * User's "download updates automatically" preference, mirrored from
+     * [ExperimentalStore] so the update sheet can render + toggle it while a
+     * flow is active without subscribing to the whole experimental slice.
+     */
+    private val _selfUpdateDownloadEnabled = stateFlow(false)
+    val selfUpdateDownloadEnabled = _selfUpdateDownloadEnabled.flow
+
     init {
         launch {
             coroutineScope {
@@ -298,6 +306,12 @@ class MainViewModel @Inject constructor(
         }
 
         appShortcutManager.observePlaybackForDynamicShortcuts()
+
+        launch {
+            experimentalStore.experimental.collect { prefs ->
+                _selfUpdateDownloadEnabled.set(prefs.selfUpdateDownloadEnabled)
+            }
+        }
     }
 
     fun refreshLibraryFolders() {
@@ -311,8 +325,9 @@ class MainViewModel @Inject constructor(
      * Checks GitHub Releases for a newer build, called once on launch after
      * session restore. Gated by `selfUpdateCheckEnabled`. Stays silent unless
      * an update is actually available — it never surfaces a sheet for an
-     * up-to-date result. Use [manualCheckForUpdate] when the user wants
-     * feedback regardless of outcome.
+     * up-to-date result. When the user's opted into auto-download, an available
+     * update begins streaming immediately instead of prompting. Use
+     * [manualCheckForUpdate] when the user wants feedback regardless of outcome.
      */
     fun checkForAppUpdate() {
         launch {
@@ -326,7 +341,13 @@ class MainViewModel @Inject constructor(
                 // Honor a prior dismissal: if the user dismissed this exact
                 // version less than 24h ago, stay quiet on the launch auto-check.
                 if (isUpdateRecentlyDismissed(info.latestVersion, experimental)) return@onSuccess
-                _updateState.set(UpdateState.UpdateAvailable(info))
+                // With auto-download enabled, skip the prompt and stream the APK
+                // straight away (the sheet surfaces download progress/cancel).
+                if (experimental.selfUpdateDownloadEnabled && info.downloadAssetUrl != null) {
+                    startUpdateDownload(info)
+                } else {
+                    _updateState.set(UpdateState.UpdateAvailable(info))
+                }
             }
         }
     }
@@ -349,26 +370,43 @@ class MainViewModel @Inject constructor(
      * Manual, user-initiated check (from Settings). Always surfaces the result:
      * a sheet for an available update, or a "you're up to date" sheet (with a
      * link to view the current version's release notes) when none is. Bypasses
-     * the auto-check preference.
+     * the auto-check preference, but still honors auto-download (an available
+     * update begins streaming immediately when enabled).
      */
     fun manualCheckForUpdate() {
         launch {
             _updateState.set(UpdateState.Checking)
+            val experimental = experimentalStore.experimental.first()
             val result = appUpdateRepository.checkForUpdate(
                 supportedAbis = android.os.Build.SUPPORTED_ABIS,
             )
             result
                 .onSuccess { info ->
-                    _updateState.set(
-                        if (info.isUpdateAvailable) UpdateState.UpdateAvailable(info)
-                        else UpdateState.NoUpdate(info),
-                    )
+                    when {
+                        // Always surface the "up to date" result with release notes.
+                        !info.isUpdateAvailable -> _updateState.set(UpdateState.NoUpdate(info))
+                        // Auto-download enabled → begin streaming without the prompt.
+                        experimental.selfUpdateDownloadEnabled && info.downloadAssetUrl != null ->
+                            startUpdateDownload(info)
+                        else -> _updateState.set(UpdateState.UpdateAvailable(info))
+                    }
                 }
                 .onFailure { _updateState.set(UpdateState.Error(it.message ?: "Update check failed")) }
         }
     }
 
-    /** Begins streaming the APK for the given update, reporting progress. */
+    /**
+     * Persists the "download updates automatically" preference. Also exposed
+     * from the update sheet so the toggle takes effect from either place.
+     */
+    fun setSelfUpdateDownloadEnabled(enabled: Boolean) {
+        _selfUpdateDownloadEnabled.set(enabled)
+        launch { experimentalStore.setSelfUpdateDownloadEnabled(enabled) }
+    }
+
+    /**
+     * Begins streaming the APK for the given update, reporting progress.
+     */
     fun startUpdateDownload(info: com.raulshma.jellyplay.core.model.AppUpdateInfo) {
         val url = info.downloadAssetUrl ?: return
         launch {

--- a/app/src/main/java/com/raulshma/jellyplay/di/WidgetModule.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/di/WidgetModule.kt
@@ -1,7 +1,9 @@
 package com.raulshma.jellyplay.di
 
 import com.raulshma.jellyplay.core.data.widget.ContinueWatchingBroadcaster
+import com.raulshma.jellyplay.core.data.widget.LibrarySyncHook
 import com.raulshma.jellyplay.widget.ContinueWatchingBroadcasterImpl
+import com.raulshma.jellyplay.widget.LibrarySyncHookImpl
 import com.raulshma.jellyplay.widget.WidgetWorkScheduler
 import com.raulshma.jellyplay.widget.WidgetWorkSchedulerImpl
 import dagger.Binds
@@ -21,4 +23,8 @@ abstract class WidgetModule {
     @Binds
     @Singleton
     abstract fun bindContinueWatchingBroadcaster(impl: ContinueWatchingBroadcasterImpl): ContinueWatchingBroadcaster
+
+    @Binds
+    @Singleton
+    abstract fun bindLibrarySyncHook(impl: LibrarySyncHookImpl): LibrarySyncHook
 }

--- a/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
@@ -261,10 +261,21 @@ fun JellyPlayApp(
 @Composable
 private fun UpdateSheetOverlay(viewModel: MainViewModel) {
     val state by viewModel.updateState.collectAsStateWithLifecycle()
+    val autoDownloadEnabled by viewModel.selfUpdateDownloadEnabled.collectAsStateWithLifecycle()
     if (state !is com.raulshma.jellyplay.update.UpdateState.Idle) {
         val context = LocalContext.current
         AppUpdateSheet(
             state = state,
+            autoDownloadEnabled = autoDownloadEnabled,
+            onAutoDownloadToggle = { enabled ->
+                viewModel.setSelfUpdateDownloadEnabled(enabled)
+                // Turning it ON while an update is already available should also
+                // start downloading the shown update immediately.
+                val available = state as? com.raulshma.jellyplay.update.UpdateState.UpdateAvailable
+                if (enabled && available != null) {
+                    viewModel.startUpdateDownload(available.info)
+                }
+            },
             onDownload = { info -> viewModel.startUpdateDownload(info) },
             onInstall = { intent ->
                 runCatching { context.startActivity(intent) }

--- a/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/navigation/JellyPlayApp.kt
@@ -280,6 +280,7 @@ private fun UpdateSheetOverlay(viewModel: MainViewModel) {
             onInstall = { intent ->
                 runCatching { context.startActivity(intent) }
             },
+            onRedownload = { viewModel.redownloadUpdate() },
             onCancel = { viewModel.dismissUpdate() },
             onDismiss = { viewModel.dismissUpdate() },
             buildInstallIntent = {

--- a/app/src/main/java/com/raulshma/jellyplay/update/AppUpdateSheet.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/update/AppUpdateSheet.kt
@@ -30,10 +30,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.Download
 import com.raulshma.jellyplay.core.model.AppUpdateInfo
 import com.raulshma.jellyplay.core.model.formatBytes
 import com.raulshma.jellyplay.core.ui.components.JellyPlayLinearProgressIndicator
 import com.raulshma.jellyplay.core.ui.components.MarkdownText
+import com.raulshma.jellyplay.core.ui.components.SettingToggleItem
 import com.raulshma.jellyplay.core.ui.components.TvSafeSheet
 import com.raulshma.jellyplay.R
 
@@ -49,6 +52,8 @@ import com.raulshma.jellyplay.R
 @Composable
 fun AppUpdateSheet(
     state: UpdateState,
+    autoDownloadEnabled: Boolean,
+    onAutoDownloadToggle: (Boolean) -> Unit,
     onDownload: (AppUpdateInfo) -> Unit,
     onInstall: (Intent) -> Unit,
     onCancel: () -> Unit,
@@ -89,6 +94,8 @@ fun AppUpdateSheet(
                 )
                 is UpdateState.UpdateAvailable -> UpdateAvailableContent(
                     info = state.info,
+                    autoDownloadEnabled = autoDownloadEnabled,
+                    onAutoDownloadToggle = onAutoDownloadToggle,
                     onDownload = { onDownload(state.info) },
                     onDismiss = onDismiss,
                 )
@@ -171,6 +178,8 @@ private fun ColumnScope.NoUpdateContent(
 @Composable
 private fun UpdateAvailableContent(
     info: AppUpdateInfo,
+    autoDownloadEnabled: Boolean,
+    onAutoDownloadToggle: (Boolean) -> Unit,
     onDownload: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -201,6 +210,18 @@ private fun UpdateAvailableContent(
     }
     Spacer(Modifier.height(16.dp))
     val noApk = info.downloadAssetUrl == null
+    // Lets the user flip the auto-download preference right where they're
+    // deciding what to do with the update. Disabled when there's no matching
+    // APK for this device (nothing to auto-download).
+    SettingToggleItem(
+        icon = Tabler.Outline.Download,
+        title = stringResource(R.string.update_auto_download_label),
+        subtitle = stringResource(R.string.update_auto_download_subtitle),
+        checked = autoDownloadEnabled,
+        enabled = !noApk,
+        onCheckedChange = onAutoDownloadToggle,
+    )
+    Spacer(Modifier.height(8.dp))
     ButtonsRow {
         OutlinedButton(onClick = onDismiss) { Text(stringResource(R.string.update_later)) }
         Spacer(Modifier.width(8.dp))

--- a/app/src/main/java/com/raulshma/jellyplay/update/AppUpdateSheet.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/update/AppUpdateSheet.kt
@@ -56,6 +56,7 @@ fun AppUpdateSheet(
     onAutoDownloadToggle: (Boolean) -> Unit,
     onDownload: (AppUpdateInfo) -> Unit,
     onInstall: (Intent) -> Unit,
+    onRedownload: () -> Unit,
     onCancel: () -> Unit,
     onDismiss: () -> Unit,
     buildInstallIntent: () -> Intent,
@@ -108,6 +109,7 @@ fun AppUpdateSheet(
                 is UpdateState.Downloaded -> DownloadedContent(
                     info = state.info,
                     onInstall = { onInstall(buildInstallIntent()) },
+                    onRedownload = onRedownload,
                     onDismiss = onDismiss,
                 )
                 is UpdateState.Error -> ErrorContent(
@@ -274,6 +276,7 @@ private fun DownloadingContent(
 private fun DownloadedContent(
     info: AppUpdateInfo,
     onInstall: () -> Unit,
+    onRedownload: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     Text(
@@ -290,6 +293,13 @@ private fun DownloadedContent(
     Spacer(Modifier.height(16.dp))
     ButtonsRow {
         OutlinedButton(onClick = onDismiss) { Text(stringResource(R.string.update_later)) }
+        Spacer(Modifier.width(8.dp))
+        // Re-fetch the APK even though one is already on disk (e.g. the user
+        // suspects it's corrupt, or wants the latest patch for the same
+        // version). Overwrites the existing file + sidecar.
+        OutlinedButton(onClick = onRedownload) {
+            Text(stringResource(R.string.update_download_again))
+        }
         Spacer(Modifier.width(8.dp))
         Button(onClick = onInstall) { Text(stringResource(R.string.update_install)) }
     }

--- a/app/src/main/java/com/raulshma/jellyplay/widget/ContinueWatchingWidget.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/ContinueWatchingWidget.kt
@@ -20,6 +20,30 @@ import kotlinx.coroutines.flow.first
 
 class ContinueWatchingWidget : AppWidgetProvider() {
 
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface WidgetEntryPoint {
+        fun widgetDataStore(): com.raulshma.jellyplay.core.datastore.widget.WidgetDataStore
+    }
+
+    override fun onDeleted(context: Context?, appWidgetIds: IntArray?) {
+        super.onDeleted(context, appWidgetIds)
+        if (context == null || appWidgetIds == null) return
+        val store = try {
+            EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                WidgetEntryPoint::class.java,
+            ).widgetDataStore()
+        } catch (_: Exception) {
+            return
+        }
+        kotlinx.coroutines.runBlocking {
+            for (id in appWidgetIds) {
+                store.removeWidgetConfigForId(id)
+            }
+        }
+    }
+
     override fun onUpdate(
         context: Context,
         appWidgetManager: AppWidgetManager,
@@ -53,10 +77,6 @@ class ContinueWatchingWidget : AppWidgetProvider() {
 
     override fun onDisabled(context: Context?) {
         super.onDisabled(context)
-    }
-
-    override fun onDeleted(context: Context?, appWidgetIds: IntArray?) {
-        super.onDeleted(context, appWidgetIds)
     }
 
     companion object {

--- a/app/src/main/java/com/raulshma/jellyplay/widget/ContinueWatchingWidgetService.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/ContinueWatchingWidgetService.kt
@@ -71,7 +71,8 @@ class ContinueWatchingWidgetService : RemoteViewsService() {
         override fun onCreate() = Unit
 
         override fun onDataSetChanged() {
-            items = runBlocking { store.continueWatching.first() }
+            val maxCount = store.getWidgetConfigForIdSync(appWidgetId).continueWatchingItemCount
+            items = runBlocking { store.continueWatching.first() }.take(maxCount)
             // Pre-fetch posters concurrently so each `getViewAt` is a map lookup.
             // A slow URL is bounded by `WidgetImageLoader`'s internal timeout.
             val urlById = items.associate { item ->

--- a/app/src/main/java/com/raulshma/jellyplay/widget/LibrarySyncHookImpl.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/LibrarySyncHookImpl.kt
@@ -1,0 +1,30 @@
+package com.raulshma.jellyplay.widget
+
+import com.raulshma.jellyplay.core.data.widget.LibrarySyncHook
+import com.raulshma.jellyplay.core.data.worker.AutoDownloadScheduler
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Wires the post-library-scan side effects that live in different modules:
+ * the auto-download foreground drain (core/data) and the widget refresh (app).
+ *
+ * Each call is wrapped in its own try/catch so a failure in one (e.g. widget
+ * cooldown rejected, WorkManager not yet initialised) never breaks the other or
+ * the home refresh that triggered this hook. Both targets are themselves
+ * no-op-safe when their pref is off or no widget is bound.
+ */
+@Singleton
+class LibrarySyncHookImpl @Inject constructor(
+    private val autoDownloadScheduler: AutoDownloadScheduler,
+    private val widgetWorkScheduler: WidgetWorkScheduler,
+) : LibrarySyncHook {
+
+    override suspend fun onLibraryScanComplete() {
+        runCatching { autoDownloadScheduler.enqueueNow() }
+        runCatching {
+            widgetWorkScheduler.refreshLibraryNow()
+            widgetWorkScheduler.refreshSeerrNow()
+        }
+    }
+}

--- a/app/src/main/java/com/raulshma/jellyplay/widget/NowPlayingWidget.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/NowPlayingWidget.kt
@@ -29,6 +29,7 @@ class NowPlayingWidget : AppWidgetProvider() {
     @InstallIn(SingletonComponent::class)
     interface WidgetEntryPoint {
         fun audioPlaybackManager(): AudioPlaybackManager
+        fun widgetDataStore(): com.raulshma.jellyplay.core.datastore.widget.WidgetDataStore
     }
 
     /**
@@ -53,6 +54,24 @@ class NowPlayingWidget : AppWidgetProvider() {
     override fun onDisabled(context: Context?) {
         super.onDisabled(context)
         refreshScope.cancel()
+    }
+
+    override fun onDeleted(context: Context?, appWidgetIds: IntArray?) {
+        super.onDeleted(context, appWidgetIds)
+        if (context == null || appWidgetIds == null) return
+        val store = try {
+            EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                WidgetEntryPoint::class.java,
+            ).widgetDataStore()
+        } catch (_: Exception) {
+            return
+        }
+        kotlinx.coroutines.runBlocking {
+            for (id in appWidgetIds) {
+                store.removeWidgetConfigForId(id)
+            }
+        }
     }
 
     override fun onAppWidgetOptionsChanged(
@@ -196,6 +215,14 @@ class NowPlayingWidget : AppWidgetProvider() {
         ) {
             val views = RemoteViews(context.packageName, R.layout.now_playing_widget)
             wireClickIntents(context, views)
+            val config = try {
+                EntryPointAccessors.fromApplication(
+                    context.applicationContext,
+                    WidgetEntryPoint::class.java,
+                ).widgetDataStore().getWidgetConfigForIdSync(appWidgetId)
+            } catch (_: Exception) {
+                com.raulshma.jellyplay.core.model.WidgetConfig()
+            }
             try {
                 val entryPoint = EntryPointAccessors.fromApplication(
                     context.applicationContext,
@@ -229,6 +256,15 @@ class NowPlayingWidget : AppWidgetProvider() {
                     durationMs = 0L,
                     isEmptyState = true,
                 )
+            }
+            if (!config.nowPlayingShowArtwork) {
+                views.setViewVisibility(R.id.widget_album_art, android.view.View.GONE)
+                views.setViewVisibility(R.id.widget_backdrop, android.view.View.GONE)
+            }
+            if (!config.nowPlayingShowProgress) {
+                views.setViewVisibility(R.id.widget_progress_container, android.view.View.GONE)
+                views.setViewVisibility(R.id.widget_progress, android.view.View.GONE)
+                views.setViewVisibility(R.id.widget_position, android.view.View.GONE)
             }
             applyResponsiveLayout(context, appWidgetManager, appWidgetId, views)
             appWidgetManager.updateAppWidget(appWidgetId, views)

--- a/app/src/main/java/com/raulshma/jellyplay/widget/config/WidgetConfigActivity.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/config/WidgetConfigActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -23,7 +24,9 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -40,7 +43,10 @@ import com.raulshma.jellyplay.R
 import com.raulshma.jellyplay.core.designsystem.theme.JellyPlayTheme
 import com.raulshma.jellyplay.core.model.LibraryRecommendationsSource
 import com.raulshma.jellyplay.core.model.SeerrWidgetSource
+import com.raulshma.jellyplay.core.model.WidgetConfig
+import com.raulshma.jellyplay.widget.ContinueWatchingWidget
 import com.raulshma.jellyplay.widget.LibraryRecommendationsWidget
+import com.raulshma.jellyplay.widget.NowPlayingWidget
 import com.raulshma.jellyplay.widget.SeerrRecommendationsWidget
 import com.raulshma.jellyplay.widget.WidgetWorkScheduler
 import dagger.hilt.android.AndroidEntryPoint
@@ -48,18 +54,28 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
- * Configuration activity for the Library Recommendations widget. The
- * AOSP AppWidget framework launches `android:configure` activities
- * with a fixed `APPWIDGET_CONFIGURE` action, so we keep one activity
- * per widget kind rather than a single alias-based dispatcher.
+ * Shared scaffold for the per-kind widget configuration activities. The AOSP
+ * AppWidget framework launches each `android:configure` activity with a fixed
+ * `APPWIDGET_CONFIGURE` action and an `EXTRA_APPWIDGET_ID` extra; every kind
+ * handled that identically (extract id → bail if invalid → init VM → set OK
+ * result → mount the themed [ConfigScreen]), so the base owns it once.
+ * Subclasses implement [saveAndFinish] for their kind-specific refresh side
+ * effects (push RemoteViews, notify grid, kick a scheduler, etc.).
  */
-@AndroidEntryPoint
-class LibraryWidgetConfigActivity : ComponentActivity() {
+abstract class BaseWidgetConfigActivity : ComponentActivity() {
 
-    @Inject lateinit var widgetWorkScheduler: WidgetWorkScheduler
+    protected val viewModel: WidgetConfigViewModel by viewModels()
+    protected var widgetId: Int = AppWidgetManager.INVALID_APPWIDGET_ID
+        private set
 
-    private val viewModel: WidgetConfigViewModel by viewModels()
-    private var widgetId: Int = AppWidgetManager.INVALID_APPWIDGET_ID
+    /** String resource shown as the config screen subtitle. */
+    protected abstract val titleRes: Int
+
+    /** Which options section [ConfigScreen] renders. */
+    protected abstract val kind: WidgetKind
+
+    /** Called when the user taps Save — push RemoteViews, notify grids, refresh. */
+    protected abstract suspend fun saveAndFinish()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -78,24 +94,34 @@ class LibraryWidgetConfigActivity : ComponentActivity() {
             JellyPlayTheme {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     ConfigScreen(
-                        titleRes = R.string.widget_library_recommendations_title,
+                        titleRes = titleRes,
                         viewModel = viewModel,
-                        isLibraryKind = true,
-                        onSave = { saveAndFinish() },
+                        kind = kind,
+                        onSave = { lifecycleScope.launch { saveAndFinish() } },
                     )
                 }
             }
         }
     }
+}
 
-    private fun saveAndFinish() {
-        lifecycleScope.launch {
-            val manager = AppWidgetManager.getInstance(this@LibraryWidgetConfigActivity)
-            LibraryRecommendationsWidget.updateAppWidget(this@LibraryWidgetConfigActivity, manager, widgetId)
-            manager.notifyAppWidgetViewDataChanged(widgetId, R.id.lr_widget_grid)
-            widgetWorkScheduler.refreshLibraryNow()
-            finish()
-        }
+/**
+ * Configuration activity for the Library Recommendations widget.
+ */
+@AndroidEntryPoint
+class LibraryWidgetConfigActivity : BaseWidgetConfigActivity() {
+
+    @Inject lateinit var widgetWorkScheduler: WidgetWorkScheduler
+
+    override val titleRes: Int = R.string.widget_library_recommendations_title
+    override val kind: WidgetKind = WidgetKind.LIBRARY
+
+    override suspend fun saveAndFinish() {
+        val manager = AppWidgetManager.getInstance(this)
+        LibraryRecommendationsWidget.updateAppWidget(this, manager, widgetId)
+        manager.notifyAppWidgetViewDataChanged(widgetId, R.id.lr_widget_grid)
+        widgetWorkScheduler.refreshLibraryNow()
+        finish()
     }
 }
 
@@ -103,48 +129,56 @@ class LibraryWidgetConfigActivity : ComponentActivity() {
  * Configuration activity for the Seerr Recommendations widget.
  */
 @AndroidEntryPoint
-class SeerrWidgetConfigActivity : ComponentActivity() {
+class SeerrWidgetConfigActivity : BaseWidgetConfigActivity() {
 
     @Inject lateinit var widgetWorkScheduler: WidgetWorkScheduler
 
-    private val viewModel: WidgetConfigViewModel by viewModels()
-    private var widgetId: Int = AppWidgetManager.INVALID_APPWIDGET_ID
+    override val titleRes: Int = R.string.widget_seerr_recommendations_title
+    override val kind: WidgetKind = WidgetKind.SEERR
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        widgetId = intent?.getIntExtra(
-            AppWidgetManager.EXTRA_APPWIDGET_ID,
-            AppWidgetManager.INVALID_APPWIDGET_ID,
-        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
-        if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
-            setResult(RESULT_CANCELED)
-            finish()
-            return
-        }
-        viewModel.initWidgetId(widgetId)
-        setResult(RESULT_OK, Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, widgetId))
-        setContent {
-            JellyPlayTheme {
-                Surface(modifier = Modifier.fillMaxSize()) {
-                    ConfigScreen(
-                        titleRes = R.string.widget_seerr_recommendations_title,
-                        viewModel = viewModel,
-                        isLibraryKind = false,
-                        onSave = { saveAndFinish() },
-                    )
-                }
-            }
-        }
+    override suspend fun saveAndFinish() {
+        val manager = AppWidgetManager.getInstance(this)
+        SeerrRecommendationsWidget.updateAppWidget(this, manager, widgetId)
+        manager.notifyAppWidgetViewDataChanged(widgetId, R.id.sr_widget_grid)
+        widgetWorkScheduler.refreshSeerrNow()
+        finish()
     }
+}
 
-    private fun saveAndFinish() {
-        lifecycleScope.launch {
-            val manager = AppWidgetManager.getInstance(this@SeerrWidgetConfigActivity)
-            SeerrRecommendationsWidget.updateAppWidget(this@SeerrWidgetConfigActivity, manager, widgetId)
-            manager.notifyAppWidgetViewDataChanged(widgetId, R.id.sr_widget_grid)
-            widgetWorkScheduler.refreshSeerrNow()
-            finish()
-        }
+/**
+ * Configuration activity for the Continue Watching widget. Configures the
+ * max item count; the shelf itself is fed by the playback shelf sync, so
+ * no [WidgetWorkScheduler] refresh is triggered.
+ */
+@AndroidEntryPoint
+class ContinueWatchingWidgetConfigActivity : BaseWidgetConfigActivity() {
+
+    override val titleRes: Int = R.string.widget_continue_watching_label
+    override val kind: WidgetKind = WidgetKind.CONTINUE_WATCHING
+
+    override suspend fun saveAndFinish() {
+        val manager = AppWidgetManager.getInstance(this)
+        ContinueWatchingWidget.updateWidget(this, manager, widgetId)
+        manager.notifyAppWidgetViewDataChanged(widgetId, R.id.cw_widget_list)
+        finish()
+    }
+}
+
+/**
+ * Configuration activity for the Now Playing widget. Configures artwork /
+ * progress visibility; [NowPlayingWidget.updateAppWidget] renders directly
+ * via RemoteViews, so no grid notify or scheduler refresh is needed.
+ */
+@AndroidEntryPoint
+class NowPlayingWidgetConfigActivity : BaseWidgetConfigActivity() {
+
+    override val titleRes: Int = R.string.widget_now_playing_label
+    override val kind: WidgetKind = WidgetKind.NOW_PLAYING
+
+    override suspend fun saveAndFinish() {
+        val manager = AppWidgetManager.getInstance(this)
+        NowPlayingWidget.updateAppWidget(this, manager, widgetId)
+        finish()
     }
 }
 
@@ -152,7 +186,7 @@ class SeerrWidgetConfigActivity : ComponentActivity() {
 private fun ConfigScreen(
     titleRes: Int,
     viewModel: WidgetConfigViewModel,
-    isLibraryKind: Boolean,
+    kind: WidgetKind,
     onSave: () -> Unit,
 ) {
     val state by viewModel.getWidgetConfig().collectAsStateWithLifecycle()
@@ -176,22 +210,45 @@ private fun ConfigScreen(
                 .fillMaxWidth()
                 .weight(1f),
             contentPadding = PaddingValues(vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            if (isLibraryKind) {
-                items(LibraryOptions, key = { option -> option.source.name }) { option ->
+            when (kind) {
+                WidgetKind.LIBRARY -> items(LibraryOptions, key = { option -> option.source.name }) { option ->
                     OptionRow(
                         title = stringResource(option.titleRes),
                         description = stringResource(option.descriptionRes),
                         selected = state.librarySource == option.source,
                     ) { viewModel.selectLibrarySource(option.source) }
                 }
-            } else {
-                items(SeerrOptions, key = { option -> option.source.name }) { option ->
+
+                WidgetKind.SEERR -> items(SeerrOptions, key = { option -> option.source.name }) { option ->
                     OptionRow(
                         title = stringResource(option.titleRes),
                         description = stringResource(option.descriptionRes),
                         selected = state.seerrSource == option.source,
                     ) { viewModel.selectSeerrSource(option.source) }
+                }
+
+                WidgetKind.CONTINUE_WATCHING -> item {
+                    ContinueWatchingCountRow(
+                        count = state.continueWatchingItemCount,
+                        onCountChange = { viewModel.selectContinueWatchingCount(it) },
+                    )
+                }
+
+                WidgetKind.NOW_PLAYING -> {
+                    item {
+                        SwitchRow(
+                            title = stringResource(R.string.widget_np_show_artwork),
+                            checked = state.nowPlayingShowArtwork,
+                        ) { viewModel.setNowPlayingShowArtwork(it) }
+                    }
+                    item {
+                        SwitchRow(
+                            title = stringResource(R.string.widget_np_show_progress),
+                            checked = state.nowPlayingShowProgress,
+                        ) { viewModel.setNowPlayingShowProgress(it) }
+                    }
                 }
             }
         }
@@ -201,6 +258,70 @@ private fun ConfigScreen(
         ) {
             Text(text = stringResource(R.string.widget_config_save))
         }
+    }
+}
+
+@Composable
+private fun ContinueWatchingCountRow(
+    count: Int,
+    onCountChange: (Int) -> Unit,
+) {
+    Column(modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.widget_cw_item_count),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Slider(
+            value = count.toFloat(),
+            onValueChange = { onCountChange(it.toInt()) },
+            valueRange = WidgetConfig.MIN_CONTINUE_WATCHING_ITEM_COUNT.toFloat()..
+                WidgetConfig.MAX_CONTINUE_WATCHING_ITEM_COUNT.toFloat(),
+            steps = WidgetConfig.MAX_CONTINUE_WATCHING_ITEM_COUNT -
+                WidgetConfig.MIN_CONTINUE_WATCHING_ITEM_COUNT - 1,
+        )
+    }
+}
+
+@Composable
+private fun SwitchRow(
+    title: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clip(ShapeCache.smooth12)
+            .background(
+                if (checked) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
+                else Color.Transparent,
+            )
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f),
+        )
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
     }
 }
 

--- a/app/src/main/java/com/raulshma/jellyplay/widget/config/WidgetConfigViewModel.kt
+++ b/app/src/main/java/com/raulshma/jellyplay/widget/config/WidgetConfigViewModel.kt
@@ -62,22 +62,36 @@ class WidgetConfigViewModel @Inject constructor(
         }
     }
 
-    fun selectLibrarySource(source: LibraryRecommendationsSource) {
-        viewModelScope.launch {
-            val current = getWidgetConfig().first()
-            val updated = current.copy(librarySource = source)
-            if (appWidgetId != -1) {
-                widgetDataStore.setWidgetConfigForId(appWidgetId, updated)
-            } else {
-                widgetDataStore.setWidgetConfig(updated)
-            }
-        }
+    fun selectLibrarySource(source: LibraryRecommendationsSource) =
+        update { it.copy(librarySource = source) }
+
+    fun selectSeerrSource(source: SeerrWidgetSource) =
+        update { it.copy(seerrSource = source) }
+
+    fun selectContinueWatchingCount(count: Int) = update {
+        it.copy(
+            continueWatchingItemCount = count.coerceIn(
+                WidgetConfig.MIN_CONTINUE_WATCHING_ITEM_COUNT,
+                WidgetConfig.MAX_CONTINUE_WATCHING_ITEM_COUNT,
+            ),
+        )
     }
 
-    fun selectSeerrSource(source: SeerrWidgetSource) {
+    fun setNowPlayingShowArtwork(show: Boolean) =
+        update { it.copy(nowPlayingShowArtwork = show) }
+
+    fun setNowPlayingShowProgress(show: Boolean) =
+        update { it.copy(nowPlayingShowProgress = show) }
+
+    /**
+     * One home for the read-copy-write + per-widget-or-global persist shape that
+     * every setter above used to duplicate. Routes the updated [WidgetConfig]
+     * to the per-instance store when [appWidgetId] is set, otherwise to the
+     * global default.
+     */
+    private fun update(transform: (WidgetConfig) -> WidgetConfig) {
         viewModelScope.launch {
-            val current = getWidgetConfig().first()
-            val updated = current.copy(seerrSource = source)
+            val updated = getWidgetConfig().first().let(transform)
             if (appWidgetId != -1) {
                 widgetDataStore.setWidgetConfigForId(appWidgetId, updated)
             } else {
@@ -94,5 +108,7 @@ class WidgetConfigViewModel @Inject constructor(
 enum class WidgetKind {
     LIBRARY,
     SEERR,
+    CONTINUE_WATCHING,
+    NOW_PLAYING,
     ;
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">Installationsbereit — v%1$s</string>
     <string name="update_ready_body">Das Update wurde heruntergeladen. Tippe auf Installieren, um fortzufahren.</string>
     <string name="update_install">Installieren</string>
+    <string name="update_download_again">Erneut herunterladen</string>
     <string name="update_failed_title">Update fehlgeschlagen</string>
     <string name="update_close">Schließen</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">Filme, die bald erscheinen</string>
     <string name="widget_config_source_upcoming_tv">Bevorstehende Serien</string>
     <string name="widget_config_source_upcoming_tv_description">Serien, die bald Premiere haben</string>
+    <string name="widget_cw_item_count">Anzahl Einträge</string>
+    <string name="widget_np_show_artwork">Cover anzeigen</string>
+    <string name="widget_np_show_progress">Fortschritt anzeigen</string>
+    <string name="widget_config_done">Fertig</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">Nach Updates suchen\u2026</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">Películas que se estrenan pronto</string>
     <string name="widget_config_source_upcoming_tv">Próximos estrenos de series</string>
     <string name="widget_config_source_upcoming_tv_description">Series que se estrenan pronto</string>
+    <string name="widget_cw_item_count">Elementos a mostrar</string>
+    <string name="widget_np_show_artwork">Mostrar portada</string>
+    <string name="widget_np_show_progress">Mostrar progreso</string>
+    <string name="widget_config_done">Hecho</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">Buscando actualizaciones\u2026</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">Listo para instalar — v%1$s</string>
     <string name="update_ready_body">La actualización se ha descargado. Toca Instalar para continuar.</string>
     <string name="update_install">Instalar</string>
+    <string name="update_download_again">Descargar de nuevo</string>
     <string name="update_failed_title">Error en la actualización</string>
     <string name="update_close">Cerrar</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">Films qui sortent bientôt</string>
     <string name="widget_config_source_upcoming_tv">Séries à venir</string>
     <string name="widget_config_source_upcoming_tv_description">Séries qui débutent bientôt</string>
+    <string name="widget_cw_item_count">Éléments à afficher</string>
+    <string name="widget_np_show_artwork">Afficher la pochette</string>
+    <string name="widget_np_show_progress">Afficher la progression</string>
+    <string name="widget_config_done">Terminé</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">Recherche de mises à jour\u2026</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">Prêt à installer — v%1$s</string>
     <string name="update_ready_body">La mise à jour a été téléchargée. Appuyez sur Installer pour continuer.</string>
     <string name="update_install">Installer</string>
+    <string name="update_download_again">Télécharger à nouveau</string>
     <string name="update_failed_title">Échec de la mise à jour</string>
     <string name="update_close">Fermer</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">Pronto da installare — v%1$s</string>
     <string name="update_ready_body">L\'aggiornamento è stato scaricato. Tocca Installa per continuare.</string>
     <string name="update_install">Installa</string>
+    <string name="update_download_again">Scarica di nuovo</string>
     <string name="update_failed_title">Aggiornamento non riuscito</string>
     <string name="update_close">Chiudi</string>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">Film in uscita a breve</string>
     <string name="widget_config_source_upcoming_tv">Serie TV in arrivo</string>
     <string name="widget_config_source_upcoming_tv_description">Serie TV in anteprima a breve</string>
+    <string name="widget_cw_item_count">Elementi da mostrare</string>
+    <string name="widget_np_show_artwork">Mostra copertina</string>
+    <string name="widget_np_show_progress">Mostra avanzamento</string>
+    <string name="widget_config_done">Fatto</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">Controllo aggiornamenti\u2026</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">インストール準備完了 — v%1$s</string>
     <string name="update_ready_body">更新がダウンロードされました。続行するにはインストールをタップしてください。</string>
     <string name="update_install">インストール</string>
+    <string name="update_download_again">再度ダウンロード</string>
     <string name="update_failed_title">更新に失敗しました</string>
     <string name="update_close">閉じる</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">もうすぐ公開の映画</string>
     <string name="widget_config_source_upcoming_tv">放送予定のテレビ</string>
     <string name="widget_config_source_upcoming_tv_description">もうすぐ放送開始の番組</string>
+    <string name="widget_cw_item_count">表示件数</string>
+    <string name="widget_np_show_artwork">アートワークを表示</string>
+    <string name="widget_np_show_progress">進行状況を表示</string>
+    <string name="widget_config_done">完了</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">更新を確認中\u2026</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">곧 출시되는 영화</string>
     <string name="widget_config_source_upcoming_tv">방영 예정 TV</string>
     <string name="widget_config_source_upcoming_tv_description">곧 첫 방영되는 프로그램</string>
+    <string name="widget_cw_item_count">표시할 항목 수</string>
+    <string name="widget_np_show_artwork">표지 표시</string>
+    <string name="widget_np_show_progress">진행률 표시</string>
+    <string name="widget_config_done">완료</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">업데이트 확인 중\u2026</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">설치 준비 완료 — v%1$s</string>
     <string name="update_ready_body">업데이트가 다운로드되었습니다. 계속하려면 설치를 누르세요.</string>
     <string name="update_install">설치</string>
+    <string name="update_download_again">다시 다운로드</string>
     <string name="update_failed_title">업데이트 실패</string>
     <string name="update_close">닫기</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">Pronto para instalar — v%1$s</string>
     <string name="update_ready_body">A atualização foi transferida. Toque em Instalar para continuar.</string>
     <string name="update_install">Instalar</string>
+    <string name="update_download_again">Transferir novamente</string>
     <string name="update_failed_title">Falha na atualização</string>
     <string name="update_close">Fechar</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">Filmes que estreiam em breve</string>
     <string name="widget_config_source_upcoming_tv">Próxima TV</string>
     <string name="widget_config_source_upcoming_tv_description">Séries que estreiam em breve</string>
+    <string name="widget_cw_item_count">Itens a mostrar</string>
+    <string name="widget_np_show_artwork">Mostrar capa</string>
+    <string name="widget_np_show_progress">Mostrar progresso</string>
+    <string name="widget_config_done">Concluir</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">A verificar atualizações\u2026</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -79,6 +79,10 @@
     <string name="widget_config_source_upcoming_movies_description">即将上映的电影</string>
     <string name="widget_config_source_upcoming_tv">即将播出的剧集</string>
     <string name="widget_config_source_upcoming_tv_description">即将首播的剧集</string>
+    <string name="widget_cw_item_count">显示数量</string>
+    <string name="widget_np_show_artwork">显示封面</string>
+    <string name="widget_np_show_progress">显示进度</string>
+    <string name="widget_config_done">完成</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">正在检查更新\u2026</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -99,6 +99,7 @@
     <string name="update_ready_title">已准备好安装 — v%1$s</string>
     <string name="update_ready_body">更新已下载完成。点击安装以继续。</string>
     <string name="update_install">安装</string>
+    <string name="update_download_again">重新下载</string>
     <string name="update_failed_title">更新失败</string>
     <string name="update_close">关闭</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="update_ready_title">Ready to install — v%1$s</string>
     <string name="update_ready_body">The update has been downloaded. Tap Install to continue.</string>
     <string name="update_install">Install</string>
+    <string name="update_download_again">Download again</string>
     <string name="update_failed_title">Update failed</string>
     <string name="update_close">Close</string>
     <string name="update_auto_download_label">Download updates automatically</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,8 @@
     <string name="update_install">Install</string>
     <string name="update_failed_title">Update failed</string>
     <string name="update_close">Close</string>
+    <string name="update_auto_download_label">Download updates automatically</string>
+    <string name="update_auto_download_subtitle">New updates download right away for this device</string>
 
     <!-- Shared media transport (content descriptions & labels) -->
     <string name="media_play">Play</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,10 @@
     <string name="widget_config_source_upcoming_movies_description">Movies releasing soon</string>
     <string name="widget_config_source_upcoming_tv">Upcoming TV</string>
     <string name="widget_config_source_upcoming_tv_description">Shows premiering soon</string>
+    <string name="widget_cw_item_count">Items to show</string>
+    <string name="widget_np_show_artwork">Show artwork</string>
+    <string name="widget_np_show_progress">Show progress</string>
+    <string name="widget_config_done">Done</string>
 
     <!-- In-app self-update sheet -->
     <string name="update_checking">Checking for updates\u2026</string>

--- a/app/src/main/res/xml/continue_watching_widget_info.xml
+++ b/app/src/main/res/xml/continue_watching_widget_info.xml
@@ -16,5 +16,6 @@
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen|keyguard"
     android:description="@string/widget_continue_watching_description"
+    android:configure="com.raulshma.jellyplay.widget.config.ContinueWatchingWidgetConfigActivity"
     android:widgetFeatures="configuration_optional|reconfigurable"
     tools:targetApi="31" />

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -2,6 +2,8 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <cache-path name="shared_images" path="shared_images/" />
     <cache-path name="shared_logs" path="shared_logs/" />
-    <!-- Downloaded update APKs, shared with the system package installer. -->
-    <cache-path name="updates" path="updates/" />
+    <!-- Downloaded update APKs, shared with the system package installer.
+         Lives under filesDir (not cacheDir) so the file survives the system
+         installer's round trip (backgrounding, OS cache eviction). -->
+    <files-path name="updates" path="updates/" />
 </paths>

--- a/app/src/main/res/xml/now_playing_widget_info.xml
+++ b/app/src/main/res/xml/now_playing_widget_info.xml
@@ -16,5 +16,6 @@
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen|keyguard"
     android:description="@string/widget_now_playing_description"
+    android:configure="com.raulshma.jellyplay.widget.config.NowPlayingWidgetConfigActivity"
     android:widgetFeatures="configuration_optional|reconfigurable"
     tools:targetApi="31" />

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -86,6 +87,7 @@ dependencies {
     testImplementation(libs.work.testing)
     testImplementation(libs.androidx.junit)
     testImplementation(libs.androidx.test.core)
+    testImplementation(libs.okhttp.mockwebserver)
 
     // testFixtures dependencies: the shared stubMediaSessionPlayer() helper
     // builds a mockk<Player> against media3-common. AGP's testFixtures source

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -23,6 +23,12 @@ android {
     }
     testOptions {
         unitTests {
+            isIncludeAndroidResources = true
+            // Pure-JVM tests in this module exercise code paths that touch
+            // `android.os.SystemClock` / `android.util.Log` (TtlCache TTLs,
+            // SleepTimerManager, download workers). Return default values for
+            // unmocked Android APIs instead of throwing — matches the nine
+            // other modules that already set this flag.
             isReturnDefaultValues = true
         }
     }

--- a/core/data/src/main/AndroidManifest.xml
+++ b/core/data/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
@@ -10,7 +11,8 @@
         <service
             android:name=".playback.JellyPlayPlaybackService"
             android:exported="true"
-            android:foregroundServiceType="mediaPlayback">
+            android:foregroundServiceType="mediaPlayback"
+            tools:ignore="Instantiatable">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaLibraryService" />
                 <action android:name="android.media.browse.MediaBrowserService" />

--- a/core/data/src/main/AndroidManifest.xml
+++ b/core/data/src/main/AndroidManifest.xml
@@ -8,6 +8,16 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>
+        <receiver
+            android:name=".receiver.DownloadActionReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.raulshma.jellyplay.download.PAUSE" />
+                <action android:name="com.raulshma.jellyplay.download.RESUME" />
+                <action android:name="com.raulshma.jellyplay.download.CANCEL" />
+            </intent-filter>
+        </receiver>
+
         <service
             android:name=".playback.JellyPlayPlaybackService"
             android:exported="true"

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioLibraryBrowser.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioLibraryBrowser.kt
@@ -1,8 +1,10 @@
 package com.raulshma.jellyplay.core.data.playback
 
+import android.content.Context
 import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaLibraryService.MediaLibrarySession
@@ -30,6 +32,20 @@ class AudioLibraryBrowser(
     private val streamingQualityProvider: () -> StreamingQuality,
     private val adaptiveBitrateSelector: AdaptiveBitrateSelector,
 ) {
+    /**
+     * Builds the [MediaLibrarySession] every audio path uses — the initial
+     * session and the post-crossfade rebuild. Both call sites share this one
+     * construction path so the media service host never sees a plain
+     * [MediaSession] downgrade: [JellyPlayPlaybackService.onGetSession] casts
+     * the active session with `as? MediaLibrarySession`, and a plain session
+     * makes the cast return null (now-playing notification + headset buttons
+     * die until app restart). Keep this the single source of truth for audio.
+     */
+    internal fun buildMediaSession(context: Context, player: Player, sessionId: String): MediaLibrarySession =
+        MediaLibrarySession.Builder(context, player, callback)
+            .setId(sessionId)
+            .build()
+
     val callback: MediaLibrarySession.Callback = object : MediaLibrarySession.Callback {
         override fun onGetLibraryRoot(
             session: MediaLibrarySession,

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManager.kt
@@ -16,7 +16,6 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.session.MediaSession
-import androidx.media3.session.MediaLibraryService.MediaLibrarySession
 import androidx.compose.runtime.Immutable
 import com.raulshma.jellyplay.core.data.repository.DownloadRepository
 import com.raulshma.jellyplay.core.data.repository.MediaRepository
@@ -511,9 +510,9 @@ class AudioPlaybackManager @Inject constructor(
         player.repeatMode = getExoPlayerRepeatMode(_repeatMode.value)
 
         exoPlayer = player
-        val session = MediaLibrarySession.Builder(context, player, libraryBrowser.callback)
-            .setId(playSessionId)
-            .build()
+        // Same construction path as the crossfade rebuild, via the shared
+        // audio-session builder (AudioLibraryBrowser owns the library callback).
+        val session = libraryBrowser.buildMediaSession(context, player, playSessionId)
         mediaSession = session
         sessionManager.setActiveSession(session)
 
@@ -1418,9 +1417,15 @@ class AudioPlaybackManager @Inject constructor(
         _albumArtUrl.value = nextItem.imageUrl ?: ""
 
         mediaSession?.release()
-        val newSession = MediaSession.Builder(context, secondary)
-            .setId(playSessionId)
-            .build()
+        // Rebuild via the shared audio-session builder (AudioLibraryBrowser is
+        // the single construction path for both the initial session and the
+        // crossfade rebuild). JellyPlayPlaybackService.onGetSession casts the
+        // active session to MediaLibrarySession; a plain MediaSession rebuild
+        // — the pre-fix behaviour — cast to null, so the service rejected
+        // controller connections, killing the now-playing notification and
+        // headset buttons until app restart. Mirrors the video fix
+        // (MediaSessionController).
+        val newSession = libraryBrowser.buildMediaSession(context, secondary, playSessionId)
         mediaSession = newSession
         sessionManager.setActiveSession(newSession)
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/JellyPlayPlaybackService.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/JellyPlayPlaybackService.kt
@@ -65,8 +65,14 @@ class JellyPlayPlaybackService : MediaLibraryService(), PlaybackSessionManager.L
         if (!player.isPlaying) {
             audioPlaybackManager.stopAndRelease()
             stopSelf()
+            // Let Media3 run its task-removed bookkeeping (clearing the
+            // media-button receiver / task description) before returning.
+            super.onTaskRemoved(rootIntent)
             return
         }
+        // Playing in the background: defer to Media3's default, which keeps the
+        // task alive while playing. This override exists only to stop + release
+        // when playback is actually paused.
     }
 
     override fun onDestroy() {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/PipController.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/PipController.kt
@@ -1,5 +1,6 @@
 package com.raulshma.jellyplay.core.data.playback
 
+import android.util.Rational
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -48,6 +49,34 @@ class PipController @Inject constructor() {
     @Volatile
     var pipHasNext: Boolean = false
 
+    /**
+     * The video's aspect ratio as a `Rational` (width:height), derived from the
+     * server-reported [com.raulshma.jellyplay.core.model.MediaStream] width/height.
+     * `null` until media streams are known; the Activity falls back to 16:9.
+     * Surfed as a flow so the Activity can re-apply params when it changes while
+     * already in PiP (resolution/track swap).
+     */
+    private val _pipAspectRatio = MutableStateFlow<Rational?>(null)
+    val pipAspectRatio: StateFlow<Rational?> = _pipAspectRatio.asStateFlow()
+
+    /**
+     * Source-rect hint for the PiP enter animation: the window bounds of the
+     * video surface in window coordinates. Transient (recomputed on every
+     * layout), so a plain `@Volatile` read at apply time is sufficient — no
+     * flow needed. `null` clears the hint.
+     */
+    @Volatile
+    var pipSourceRect: android.graphics.Rect? = null
+        private set
+
+    /**
+     * Set by the ViewModel when playback ends or errors in PiP so the Activity
+     * reuses the existing dismiss path (pause + navigate back) instead of
+     * leaving a dead PiP window up.
+     */
+    private val _autoExitPip = MutableStateFlow(false)
+    val autoExitPip: StateFlow<Boolean> = _autoExitPip.asStateFlow()
+
     fun setPipMode(inPip: Boolean) {
         _isInPipMode.value = inPip
     }
@@ -59,6 +88,29 @@ class PipController @Inject constructor() {
 
     fun requestAutoEnterPip(shouldEnter: Boolean) {
         _shouldAutoEnterPip.value = shouldEnter
+    }
+
+    /** Updates the PiP aspect ratio; `null` clears it (Activity falls back to 16:9). */
+    fun setPipAspectRatio(ratio: Rational?) {
+        _pipAspectRatio.value = ratio
+    }
+
+    /** Updates the source-rect hint; `null` clears it. */
+    fun updatePipSourceRect(rect: android.graphics.Rect?) {
+        pipSourceRect = rect
+    }
+
+    /**
+     * Requests an auto-exit from PiP. The Activity collector translates this
+     * into [notifyPipDismissed] so the existing dismiss machinery (pause +
+     * navigate back) handles the exit uniformly.
+     */
+    fun requestAutoExitPip() {
+        _autoExitPip.value = true
+    }
+
+    fun consumeAutoExitPip() {
+        _autoExitPip.value = false
     }
 
     fun notifyPipDismissed() {
@@ -77,6 +129,9 @@ class PipController @Inject constructor() {
         _isInPipMode.value = false
         _shouldAutoEnterPip.value = false
         _pipDismissed.value = false
+        _pipAspectRatio.value = null
+        pipSourceRect = null
+        _autoExitPip.value = false
     }
 }
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/PlaybackSessionManager.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/playback/PlaybackSessionManager.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.annotation.GuardedBy
 import androidx.media3.common.Player
 import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaLibraryService.MediaLibrarySession
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -64,6 +65,14 @@ class PlaybackSessionManager @Inject constructor(
         val currentListeners: List<Listener>
         synchronized(lock) {
             oldSession = _currentSession
+            // Log the concrete session types + play states on every call so a
+            // session-type regression (MediaLibrarySession downgraded to plain
+            // MediaSession) is immediately visible in logcat.
+            Log.d(
+                TAG,
+                "setActiveSession: challenger=${sessionKind(session)} (playing=${session.player.isPlaying}), " +
+                    "holder=${oldSession?.let { sessionKind(it) }} (playing=${oldSession?.player?.isPlaying})",
+            )
             if (oldSession != null &&
                 oldSession !== session &&
                 oldSession.player.isPlaying &&
@@ -72,6 +81,11 @@ class PlaybackSessionManager @Inject constructor(
                 // refuse the eviction. Release the rejected session to avoid a leak.
                 // Log (don't swallow silently) so a rejection-time leak is diagnosable —
                 // mirrors the logging policy used by startPlaybackService below.
+                Log.w(
+                    TAG,
+                    "Rejected idle challenger ${sessionKind(session)} (playing=${session.player.isPlaying}) " +
+                        "against playing holder ${sessionKind(oldSession)} (playing=${oldSession.player.isPlaying})",
+                )
                 try {
                     session.release()
                 } catch (e: Exception) {
@@ -153,5 +167,13 @@ class PlaybackSessionManager @Inject constructor(
 
     companion object {
         private const val TAG = "PlaybackSessionManager"
+
+        /**
+         * Classifies a session as [MediaLibrarySession] vs plain [MediaSession]
+         * — the fact that matters for [JellyPlayPlaybackService.onGetSession]'s
+         * `as? MediaLibrarySession` cast, which rejects plain sessions.
+         */
+        private fun sessionKind(session: MediaSession): String =
+            if (session is MediaLibrarySession) "MediaLibrarySession" else "MediaSession"
     }
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/receiver/DownloadActionReceiver.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/receiver/DownloadActionReceiver.kt
@@ -1,0 +1,91 @@
+package com.raulshma.jellyplay.core.data.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.raulshma.jellyplay.core.data.repository.DownloadRepository
+import com.raulshma.jellyplay.core.data.worker.DownloadNotificationHelper
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Routes the download notification actions back into the repository — the
+ * same `goAsync()` + injected-suspend pattern as the new-media
+ * NotificationActionReceiver. Each action is an explicit broadcast with the
+ * `download_id` extra; the repository methods it calls are the exact ones the
+ * Downloads screen uses, so in-shade and in-app controls stay in sync.
+ *
+ * Talks only to [DownloadRepository]: the repository owns the notification
+ * group-summary refresh on every state change, so this receiver never reaches
+ * into the DAO or posts summary updates itself.
+ */
+@AndroidEntryPoint
+class DownloadActionReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var downloadRepository: DownloadRepository
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val downloadId = intent.getStringExtra(EXTRA_DOWNLOAD_ID) ?: return
+        when (intent.action) {
+            ACTION_PAUSE -> launchPending {
+                // Cancels the worker (foreground stops promptly) and marks the
+                // row USER-paused (the repo also refreshes the group summary),
+                // then keeps a shade handle alive so the user can Resume/Cancel
+                // without reopening the app.
+                downloadRepository.pauseDownload(downloadId)
+                val name = downloadRepository.getDownloadName(downloadId)
+                if (name != null) {
+                    DownloadNotificationHelper.postPausedNotification(context, downloadId, name)
+                }
+            }
+            ACTION_RESUME -> launchPending {
+                // Same pair the in-app resume uses: mark PENDING, then enqueue
+                // so WorkManager picks it up honoring schedule/network prefs.
+                // Both refresh the summary; the paused shade handle goes away.
+                downloadRepository.resumeDownload(downloadId)
+                downloadRepository.enqueueDownload(downloadId)
+                DownloadNotificationHelper.dismissPausedNotification(context, downloadId)
+            }
+            ACTION_CANCEL -> launchPending {
+                // cancelDownload tears down the worker + files and refreshes the
+                // summary; the shade handles for both progress and paused states
+                // are dismissed here.
+                downloadRepository.cancelDownload(downloadId)
+                DownloadNotificationHelper.dismissNotification(
+                    context, DownloadNotificationHelper.notificationIdFor(downloadId),
+                )
+                DownloadNotificationHelper.dismissPausedNotification(context, downloadId)
+            }
+        }
+    }
+
+    /**
+     * Runs [block] on this receiver's coroutine scope, keeping the broadcast
+     * alive ([goAsync]) until it completes. Mirrors NotificationActionReceiver.
+     */
+    private fun launchPending(block: suspend () -> Unit) {
+        val pendingResult = goAsync()
+        scope.launch {
+            try {
+                block()
+            } finally {
+                pendingResult.finish()
+                scope.cancel()
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_PAUSE = "com.raulshma.jellyplay.download.PAUSE"
+        const val ACTION_RESUME = "com.raulshma.jellyplay.download.RESUME"
+        const val ACTION_CANCEL = "com.raulshma.jellyplay.download.CANCEL"
+        const val EXTRA_DOWNLOAD_ID = "download_id"
+    }
+}

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepository.kt
@@ -24,6 +24,13 @@ interface DownloadRepository : OfflineDownloadWriter {
 
     suspend fun getDownloadByMediaItemId(mediaItemId: String): DownloadItem?
 
+    /**
+     * The display name of a download row, or null if it no longer exists.
+     * Thin read accessor for callers (e.g. the notification action receiver)
+     * that need only the name and shouldn't depend on the DAO layer directly.
+     */
+    suspend fun getDownloadName(id: String): String?
+
     suspend fun cancelDownload(id: String): Result<Unit>
 
     suspend fun pauseDownload(id: String): Result<Unit>

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadRepositoryImpl.kt
@@ -18,6 +18,7 @@ import com.raulshma.jellyplay.core.database.dao.OfflineMediaDao
 import com.raulshma.jellyplay.core.database.entity.DownloadEntity
 import com.raulshma.jellyplay.core.database.entity.OfflineMediaEntity
 import com.raulshma.jellyplay.core.data.worker.DownloadWorker
+import com.raulshma.jellyplay.core.data.worker.DownloadNotificationHelper
 import com.raulshma.jellyplay.core.data.worker.awaitResponse
 import com.raulshma.jellyplay.core.datastore.downloads.DownloadsStore
 import com.raulshma.jellyplay.core.model.DownloadItem
@@ -112,6 +113,9 @@ class DownloadRepositoryImpl @Inject constructor(
 
     override suspend fun getDownloadByMediaItemId(mediaItemId: String): DownloadItem? =
         downloadDao.getDownloadByMediaItemId(mediaItemId)?.toDownloadItem()
+
+    override suspend fun getDownloadName(id: String): String? =
+        downloadDao.getDownloadById(id)?.name
 
     override suspend fun startDownload(
         mediaItemId: String,
@@ -220,6 +224,7 @@ class DownloadRepositoryImpl @Inject constructor(
         // its next 2-second poll tick discovers the row is gone.
         cancelWorkForDownload(id)
         cleanupDownloadFiles(entity)
+        refreshDownloadSummary()
     }
 
     override suspend fun pauseDownload(id: String): Result<Unit> = runCatching {
@@ -234,6 +239,7 @@ class DownloadRepositoryImpl @Inject constructor(
             // alone; only NETWORK interruptions auto-resume.
             downloadDao.updatePausedReason(id, DownloadPauseReason.USER.persistedValue)
         }
+        refreshDownloadSummary()
     }
 
     override suspend fun resumeDownload(id: String): Result<Unit> = runCatching {
@@ -245,12 +251,14 @@ class DownloadRepositoryImpl @Inject constructor(
             downloadDao.updatePausedReason(id, null)
             downloadDao.resetRetryCount(id)
         }
+        refreshDownloadSummary()
     }
 
     override suspend fun deleteDownload(id: String): Result<Unit> = runCatching {
         val entity = downloadDao.getDownloadById(id) ?: return@runCatching
         cancelWorkForDownload(id)
         cleanupDownloadFiles(entity)
+        refreshDownloadSummary()
     }
 
     /**
@@ -267,11 +275,24 @@ class DownloadRepositoryImpl @Inject constructor(
         }
     }
 
+    /**
+     * Keeps the download notification group summary in sync when this repository
+     * changes a row's state (pause/cancel/resume/retry/delete) — e.g. in-app
+     * controls that never cross the notification action receiver. Best-effort:
+     * a Room/notification hiccup must not fail the state change.
+     */
+    private suspend fun refreshDownloadSummary() {
+        runCatching {
+            DownloadNotificationHelper.refreshSummary(context, downloadDao.getInFlightDownloadCount())
+        }
+    }
+
     override suspend fun retryDownload(id: String): Result<Unit> = runCatching {
         downloadDao.updateProgress(id, 0L, DownloadStatus.PENDING.name)
         // A manual retry starts fresh — clear the auto-retry budget and reason.
         downloadDao.updatePausedReason(id, null)
         downloadDao.resetRetryCount(id)
+        refreshDownloadSummary()
     }
 
     override suspend fun resumeInterruptedDownloads() {
@@ -307,6 +328,7 @@ class DownloadRepositoryImpl @Inject constructor(
                 Log.w(TAG, "Failed to resume interrupted download ${row.id}", e)
             }
         }
+        refreshDownloadSummary()
     }
 
     override suspend fun getTotalDownloadedBytes(): Long =

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadStorageLayout.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/DownloadStorageLayout.kt
@@ -60,16 +60,21 @@ class DownloadStorageLayout @Inject constructor(
     ): ResolvedDownloadPath {
         val isAudioType = mediaType == MediaType.AUDIO.name || mediaType == MediaType.MUSIC.name
         val dirType = if (isAudioType) Environment.DIRECTORY_MUSIC else Environment.DIRECTORY_MOVIES
-        // "EXTERNAL" prefers the primary external storage mount (still
-        // app-private externalFilesDir, scoped to MEDIA_ROOT). "INTERNAL" falls
-        // back to filesDir which is never visible to other apps and survives
-        // media scan indexing. Both remain app-private post-uninstall.
-        val useInternalStorage = storageLocationPref.equals("INTERNAL", ignoreCase = true) &&
-            storageLocationPref != "EXTERNAL"
+        // "INTERNAL" → filesDir (app-private, never media-scanned).
+        // "EXTERNAL" / "EXTERNAL_2" / "EXTERNAL_3" / ... → the Nth app-private
+        // external root from Context.getExternalFilesDirs(dirType) (plural).
+        //   - "EXTERNAL"    == primary external (backward-compat, index 0)
+        //   - "EXTERNAL_N"  == the Nth mount (1-based: EXTERNAL_2 = 2nd root).
+        // `getExternalFilesDirs` returns every app-private external root the
+        // OS will grant — primary emulated storage PLUS any inserted SD/USB
+        // mount, already scoped to this app (no SAF needed). Real removable
+        // mounts surface to the UI without reworking the download stack onto
+        // content:// URIs.
+        val pref = StorageLocationPref(storageLocationPref)
         val baseDir = when {
-            useInternalStorage && !isAudioType -> File(context.filesDir, "downloads")
-            useInternalStorage && isAudioType -> File(context.filesDir, "downloads/music")
-            else -> context.getExternalFilesDir(dirType)
+            pref.isInternal && !isAudioType -> File(context.filesDir, "downloads")
+            pref.isInternal && isAudioType -> File(context.filesDir, "downloads/music")
+            else -> externalRootForPref(pref, dirType)
                 ?: File(context.filesDir, if (isAudioType) "downloads/music" else "downloads")
         }
         if (!baseDir.exists()) baseDir.mkdirs()
@@ -87,6 +92,82 @@ class DownloadStorageLayout @Inject constructor(
             filePath = file.absolutePath,
         )
     }
+
+    /**
+     * Resolves the app-private external root selected by [pref]
+     * under [dirType]. Returns null when the requested index is out of range
+     * (e.g. the SD card was unmounted) — callers fall back to filesDir.
+     *
+     * `Context.getExternalFilesDirs` is the cleanest API for
+     * surfacing real removable mounts under app-private scoping — no SAF, no
+     * `content://`, no MediaStore. Each returned entry is a real directory the
+     * OS will let this app write into for the lifetime of the mount.
+     */
+    private fun externalRootForPref(pref: StorageLocationPref, dirType: String): File? {
+        val roots = context.getExternalFilesDirs(dirType)
+            ?.filterNotNull()
+            ?.filter { it.absolutePath.isNotBlank() }
+            ?: return null
+        if (roots.isEmpty()) return null
+        val index = pref.externalIndex.coerceIn(0, roots.lastIndex)
+        return roots[index]
+    }
+
+    /**
+     * Enumerates the storage mounts the user can pick for downloads, in a
+     * stable order: INTERNAL first, then each app-private external root from
+     * [Context.getExternalFilesDirs] (primary emulated storage, then any
+     * inserted SD / USB mount). Each entry carries the [prefValue] to persist
+     * and a [kind] the UI maps to a localized label.
+     *
+     * This is what makes "Storage location" show the *real*
+     * available mounts instead of a hardcoded INTERNAL/EXTERNAL pair — when an
+     * SD card or USB stick is inserted, it appears here as an extra
+     * [StorageMountKind.REMOVABLE] option. Stays within app-private scoped
+     * storage (no SAF rework).
+     */
+    fun availableMounts(): List<StorageMount> {
+        val options = mutableListOf<StorageMount>()
+        options.add(
+            StorageMount(
+                prefValue = "INTERNAL",
+                kind = StorageMountKind.INTERNAL,
+                availableBytes = freeBytes(context.filesDir),
+                rootPath = context.filesDir.absolutePath,
+            )
+        )
+        val externalRoots = context.getExternalFilesDirs(null)
+            ?.filterNotNull()
+            ?.filter { it.absolutePath.isNotBlank() }
+            ?: return options
+        externalRoots.forEachIndexed { index, root ->
+            val prefValue = if (index == 0) "EXTERNAL" else "EXTERNAL_${index + 1}"
+            val removable = try { Environment.isExternalStorageRemovable(root) } catch (_: Throwable) { false }
+            val kind = if (index == 0) {
+                // Primary external is emulated (built-in flash); only secondary
+                // entries are real removable mounts.
+                StorageMountKind.PRIMARY_EXTERNAL
+            } else if (removable) {
+                StorageMountKind.REMOVABLE
+            } else {
+                StorageMountKind.EXTERNAL
+            }
+            options.add(
+                StorageMount(
+                    prefValue = prefValue,
+                    kind = kind,
+                    availableBytes = freeBytes(root),
+                    rootPath = root.absolutePath,
+                )
+            )
+        }
+        return options
+    }
+
+    private fun freeBytes(dir: File): Long = try {
+        val statFs = StatFs(dir.absolutePath)
+        statFs.availableBlocksLong * statFs.blockSizeLong
+    } catch (_: Throwable) { 0L }
 
     /**
      * The download display name with characters that are unsafe on the local
@@ -139,3 +220,78 @@ data class ResolvedDownloadPath(
     val fileName: String,
     val filePath: String,
 )
+
+/**
+ * One selectable download destination surfaced by
+ * [DownloadStorageLayout.availableMounts].
+ *
+ * @property prefValue the value to persist as `downloadStorageLocation`
+ *   ("INTERNAL" / "EXTERNAL" / "EXTERNAL_N").
+ * @property kind coarse label class the UI maps to a localized string.
+ * @property availableBytes free bytes on the mount, or 0 if unavailable.
+ * @property rootPath absolute path of the app-private root (for display).
+ */
+data class StorageMount(
+    val prefValue: String,
+    val kind: StorageMountKind,
+    val availableBytes: Long,
+    val rootPath: String,
+)
+
+/**
+ * Coarse classification of a [StorageMount] for UI labeling. The settings
+ * screen maps each to a localized string (`storage_internal`, etc.).
+ */
+enum class StorageMountKind {
+    /** App-private `filesDir` (built-in flash, never media-scanned). */
+    INTERNAL,
+
+    /** Primary emulated external storage (built-in flash, app-private). */
+    PRIMARY_EXTERNAL,
+
+    /** A real removable mount (SD card / USB) reported by the OS. */
+    REMOVABLE,
+
+    /** Secondary non-removable external mount (e.g. adopted storage). */
+    EXTERNAL,
+}
+
+/**
+ * Value class around the raw `download_storage_location` preference string,
+ * so the "is this INTERNAL?" / "which external index?" parsing lives in one
+ * place instead of being re-derived at every call site.
+ *
+ * **Persistence stays `String`.** The slice is `@Serializable` and crosses the
+ * backup/restore boundary as a plain string, so this class is a parse/label
+ * helper — construct it from the stored value at the point of use.
+ *
+ * Accepted forms (case-insensitive):
+ *  - `"INTERNAL"` → app-private filesDir.
+ *  - `"EXTERNAL"` → primary external root (index 0, backward-compat).
+ *  - `"EXTERNAL_N"` → the Nth external mount (1-based: `EXTERNAL_2` = index 1).
+ *  - anything else → treated as primary external (legacy fallback).
+ *
+ * @param raw the stored preference value.
+ */
+@JvmInline
+value class StorageLocationPref(val raw: String) {
+
+    /** True iff this selects app-private internal storage (`filesDir`). */
+    val isInternal: Boolean
+        get() = raw.trim().equals("INTERNAL", ignoreCase = true) &&
+            !raw.trim().startsWith("EXTERNAL", ignoreCase = true)
+
+    /**
+     * 0-based index into `Context.getExternalFilesDirs`: `"EXTERNAL"` → 0,
+     * `"EXTERNAL_N"` → N-1. Anything unparseable → 0 (backward-compat with
+     * the legacy binary INTERNAL/EXTERNAL toggle).
+     */
+    val externalIndex: Int
+        get() {
+            val upper = raw.trim()
+            if (upper.equals("EXTERNAL", ignoreCase = true)) return 0
+            val match = Regex("^EXTERNAL_(\\d+)$", RegexOption.IGNORE_CASE).matchEntire(upper)
+                ?: return 0
+            return ((match.groupValues[1].toIntOrNull() ?: 1) - 1).coerceAtLeast(0)
+        }
+}

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/LiveTvRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/LiveTvRepository.kt
@@ -50,6 +50,9 @@ interface LiveTvRepository {
         isInProgress: Boolean? = null,
     ): Result<List<LiveTvRecording>>
 
+    /** Permanently deletes a recorded item by its Jellyfin item id. */
+    suspend fun deleteRecording(recordingId: String): Result<Unit>
+
     suspend fun getTimers(
         isActive: Boolean? = null,
         isScheduled: Boolean? = null,

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/MediaRepositoryImpl.kt
@@ -992,6 +992,9 @@ class MediaRepositoryImpl @Inject constructor(
     override suspend fun getRecordings(limit: Int?, isInProgress: Boolean?): Result<List<LiveTvRecording>> =
         apiClient.getRecordings(limit, isInProgress)
 
+    override suspend fun deleteRecording(recordingId: String): Result<Unit> =
+        apiClient.deleteItem(recordingId)
+
     override suspend fun getTimers(isActive: Boolean?, isScheduled: Boolean?): Result<List<DvrTimer>> =
         apiClient.getTimers(isActive, isScheduled)
 
@@ -1091,6 +1094,12 @@ class MediaRepositoryImpl @Inject constructor(
 
     override suspend fun getNewsletterData(sinceDate: String, limit: Int): Result<NewsletterData> =
         apiClient.getNewsletterData(sinceDate, limit)
+
+    override suspend fun sendNewsletter(): Result<Unit> =
+        apiClient.sendNewsletter()
+
+    override suspend fun sendTestNewsletter(): Result<Unit> =
+        apiClient.sendTestNewsletter()
 
     companion object {
         private const val PAGE_SIZE = 50

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/NewsletterRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/NewsletterRepository.kt
@@ -5,4 +5,10 @@ import com.raulshma.jellyplay.core.model.NewsletterData
 interface NewsletterRepository {
 
     suspend fun getNewsletterData(sinceDate: String, limit: Int = 20): Result<NewsletterData>
+
+    // NOTE: backend route `POST /newsletter/send` not yet implemented; 404s until added.
+    suspend fun sendNewsletter(): Result<Unit>
+
+    // NOTE: backend route `POST /newsletter/test` not yet implemented; 404s until added.
+    suspend fun sendTestNewsletter(): Result<Unit>
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/PlayedStateSync.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/PlayedStateSync.kt
@@ -2,9 +2,13 @@ package com.raulshma.jellyplay.core.data.repository
 
 import com.raulshma.jellyplay.core.data.offline.OfflineModeManager
 import com.raulshma.jellyplay.core.data.repository.PlayedStateSync.ComputeResult
+import com.raulshma.jellyplay.core.datastore.downloads.DownloadsStore
+import com.raulshma.jellyplay.core.model.DownloadStatus
 import com.raulshma.jellyplay.core.network.JellyfinApiClient
+import kotlinx.coroutines.flow.first
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import android.util.Log
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -91,6 +95,19 @@ class PlayedStateSyncImpl @Inject constructor(
     private val playbackOutboxRepository: PlaybackOutboxRepository,
     private val offlineModeManager: OfflineModeManager,
     private val mediaRepository: dagger.Lazy<MediaRepository>,
+    /**
+     * Auto-delete-after-watch: reads the download-lifetime pref.
+     * Injected (not constructed) and lazy-deferred so the download stack
+     * cannot form a construction cycle with this module.
+     */
+    private val downloadsStore: dagger.Lazy<DownloadsStore>,
+    /**
+     * Same concern as [downloadsStore]: looks up + deletes a finished download
+     * row when a watched flip lands. Lazy for the same cycle-safety reason
+     * (`DownloadRepositoryImpl` references only the [PlayedStateSync] companion
+     * helper, never the impl, so this edge is acyclic — Lazy keeps it defensive).
+     */
+    private val downloadRepository: dagger.Lazy<DownloadRepository>,
 ) : PlayedStateSync {
 
     override suspend fun flip(itemId: String, played: Boolean): Result<Unit> {
@@ -99,6 +116,10 @@ class PlayedStateSyncImpl @Inject constructor(
         if (offlineModeManager.isOffline) {
             runCatching { offlineRepository.applyPlayedState(itemId, isPlayed = played) }
             runCatching { playbackOutboxRepository.enqueuePlayedState(itemId, isPlayed = played) }
+            // Auto-delete-after-watch: even offline, a watched flip removes the
+            // download (cleanup is local-only; nothing to sync). Guarded so a
+            // failure never surfaces or crashes playback.
+            if (played) maybeAutoDeleteAfterWatch(itemId)
             return Result.success(Unit)
         }
         val result = if (played) apiClient.markPlayed(itemId) else apiClient.markUnplayed(itemId)
@@ -108,14 +129,47 @@ class PlayedStateSyncImpl @Inject constructor(
             // a failure here must not surface — the server mutation already
             // succeeded and reconciliation will correct any drift.
             runCatching { offlineRepository.applyPlayedState(itemId, isPlayed = played) }
+            // Auto-delete-after-watch: item was just marked played — if the
+            // user opted in and a finished download exists for it, remove it
+            // now. The flip already succeeded, so a cleanup failure must never
+            // bubble up to the caller.
+            if (played) maybeAutoDeleteAfterWatch(itemId)
         } else {
             // Online but the call failed (transient 5xx, auth drop). Don't lose
             // the user's intent: apply locally and enqueue for retry.
             runCatching { offlineRepository.applyPlayedState(itemId, isPlayed = played) }
             runCatching { playbackOutboxRepository.enqueuePlayedState(itemId, isPlayed = played) }
+            // The played state wasn't confirmed server-side, so don't delete
+            // the download yet — wait for a confirmed played flip.
             return Result.success(Unit)
         }
         return result
+    }
+
+    /**
+     * Auto-deleting a finished download on a watched flip is an unrequested,
+     * destructive product decision — it is off by default. Kept behind its own
+     * pref (`auto_delete_after_watch`) so it only runs when the user opts in.
+     * If the behaviour is unwanted it should be removed (pref + this call site
+     * + the store key).
+     *
+     * Behaviour: when the pref is ON and the just-flipped-played [itemId] has a
+     * completed download, delete that download (file + DB row + offline
+     * metadata). Everything is wrapped so a cleanup error is logged and
+     * swallowed — playback must never crash because we couldn't reclaim disk.
+     * Only COMPLETED downloads are removed so an in-flight/partial download is
+     * never destroyed mid-transfer.
+     */
+    private suspend fun maybeAutoDeleteAfterWatch(itemId: String) {
+        try {
+            if (!downloadsStore.get().downloads.first().autoDeleteAfterWatch) return
+            val download = downloadRepository.get().getDownloadByMediaItemId(itemId) ?: return
+            if (download.status != DownloadStatus.COMPLETED) return
+            runCatching { downloadRepository.get().deleteDownload(download.id) }
+                .onFailure { Log.w(TAG, "Auto-delete-after-watch failed for $itemId", it) }
+        } catch (e: Exception) {
+            Log.w(TAG, "Auto-delete-after-watch lookup failed for $itemId", e)
+        }
     }
 
     override suspend fun reconcileOfflineRow(itemId: String): ComputeResult? {
@@ -178,6 +232,7 @@ class PlayedStateSyncImpl @Inject constructor(
     }
 
     companion object {
+        private const val TAG = "PlayedStateSync"
         private val ISO_OFFSET_PARSER: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
         private val ISO_PARSER: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeerrRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeerrRepository.kt
@@ -85,6 +85,7 @@ interface SeerrRepository {
         sortDirection: String = "desc",
         requestedBy: Int? = null,
         mediaType: String? = null,
+        search: String? = null,
     ): Result<SeerrRequestListResponse>
 
     suspend fun getRequest(id: Int): Result<SeerrRequestItem>

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeerrRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/repository/SeerrRepositoryImpl.kt
@@ -327,10 +327,11 @@ class SeerrRepositoryImpl @Inject constructor(
         sortDirection: String,
         requestedBy: Int?,
         mediaType: String?,
+        search: String?,
     ): Result<SeerrRequestListResponse> {
         val url = serverUrl() ?: return Result.failure(Exception("Seerr not configured"))
         val credentials = getCredentials() ?: return Result.failure(Exception("Seerr not configured"))
-        return seerrApiClient.getRequests(url, credentials, take, skip, filter, sort, sortDirection, requestedBy, mediaType)
+        return seerrApiClient.getRequests(url, credentials, take, skip, filter, sort, sortDirection, requestedBy, mediaType, search)
     }
 
     override suspend fun getRequest(id: Int): Result<SeerrRequestItem> {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepository.kt
@@ -8,6 +8,13 @@ import java.io.File
  * Checks for app updates against GitHub Releases and manages the in-app
  * download/install flow. Shared between the launch-time auto-check
  * ([com.raulshma.jellyplay.MainViewModel]) and the manual Settings check.
+ *
+ * Downloaded APKs are persisted (under `filesDir`, not `cacheDir`) together
+ * with a sidecar metadata file until they are installed: a successful install
+ * restarts the process in the new version, and the launch-time
+ * [cleanupDownloadedApk] then sees the sidecar version is no longer newer than
+ * the installed one and deletes it. This lets the user install (or re-download)
+ * a previously-fetched update across app restarts.
  */
 interface AppUpdateRepository {
 
@@ -22,21 +29,40 @@ interface AppUpdateRepository {
     suspend fun checkForUpdate(supportedAbis: Array<String>): Result<AppUpdateInfo>
 
     /**
-     * Streams the APK at [url] into the app's files directory, reporting
+     * Streams the APK for [info] into the app's files directory, reporting
      * progress. Stored under filesDir (not cacheDir) so it survives the
      * system installer's round trip — backgrounding, screen lock, or the user
      * leaving to grant unknown-sources permission must not delete the file.
      *
-     * @param url `browser_download_url` of the chosen asset.
+     * A sidecar `.meta.json` is written next to the APK recording the update's
+     * version + asset metadata so [getPendingUpdate] can restore an
+     * install-ready state across restarts and [cleanupDownloadedApk] can tell a
+     * genuinely pending update from an orphan. Any prior APK + sidecar in the
+     * updates directory is wiped first, so calling this again re-downloads
+     * cleanly over an existing file.
+     *
+     * @param info The release being downloaded; its version / asset URL / size
+     *   are persisted to the sidecar.
      * @param onProgress Called with (fraction 0..1, bytesRead, totalBytes) on
      *   a background dispatcher; safe to update UI state from here via the
      *   caller's coroutine context.
      * @return The downloaded [File], or failure.
      */
     suspend fun downloadApk(
-        url: String,
+        info: AppUpdateInfo,
         onProgress: (Float, Long, Long) -> Unit = { _, _, _ -> },
     ): Result<File>
+
+    /**
+     * Returns the previously-downloaded update APK that is still pending
+     * install, if any. Reads the on-disk sidecar and only returns a non-null
+     * result when the APK file exists **and** its recorded version is newer
+     * than the currently-installed build — so a completed install (process
+     * restarted in the new version), a stale/older APK, or a missing sidecar
+     * all yield `null`. Lets the caller rebuild a `Downloaded` state with no
+     * network call.
+     */
+    suspend fun getPendingUpdate(): PendingAppUpdate?
 
     /**
      * Builds a launchable [Intent] that asks the system package installer to
@@ -46,12 +72,14 @@ interface AppUpdateRepository {
     fun buildInstallIntent(apkFile: File): Intent
 
     /**
-     * Deletes any previously-downloaded update APK. The system installer is
-     * launched in a separate process and returns no result for `ACTION_VIEW`,
-     * so this is best invoked on app startup ([Application.onCreate]): a
-     * successful self-update restarts the process, leaving the prior APK
-     * orphaned — the next launch sweeps it. Safe to call before any download
-     * has started.
+     * Sweeps the updates directory on app startup. **Keeps** any APK whose
+     * sidecar records a version newer than the currently-installed build (a
+     * genuinely pending update the user hasn't installed yet); **deletes**
+     * everything else — an orphan left by a completed self-update (process
+     * restarted in the new version), a stale/older APK, a partial download, or
+     * a sidecar whose APK is gone. The system installer returns no result for
+     * `ACTION_VIEW`, so this is the reliable place to reclaim space. Safe to
+     * call before any download has started.
      */
     fun cleanupDownloadedApk()
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepository.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepository.kt
@@ -22,7 +22,10 @@ interface AppUpdateRepository {
     suspend fun checkForUpdate(supportedAbis: Array<String>): Result<AppUpdateInfo>
 
     /**
-     * Streams the APK at [url] into the cache directory, reporting progress.
+     * Streams the APK at [url] into the app's files directory, reporting
+     * progress. Stored under filesDir (not cacheDir) so it survives the
+     * system installer's round trip — backgrounding, screen lock, or the user
+     * leaving to grant unknown-sources permission must not delete the file.
      *
      * @param url `browser_download_url` of the chosen asset.
      * @param onProgress Called with (fraction 0..1, bytesRead, totalBytes) on
@@ -41,4 +44,14 @@ interface AppUpdateRepository {
      * `startActivity`s it.
      */
     fun buildInstallIntent(apkFile: File): Intent
+
+    /**
+     * Deletes any previously-downloaded update APK. The system installer is
+     * launched in a separate process and returns no result for `ACTION_VIEW`,
+     * so this is best invoked on app startup ([Application.onCreate]): a
+     * successful self-update restarts the process, leaving the prior APK
+     * orphaned — the next launch sweeps it. Safe to call before any download
+     * has started.
+     */
+    fun cleanupDownloadedApk()
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepositoryImpl.kt
@@ -8,11 +8,14 @@ import androidx.core.content.FileProvider
 import androidx.core.content.pm.PackageInfoCompat
 import com.raulshma.jellyplay.core.model.AppUpdateInfo
 import com.raulshma.jellyplay.core.network.github.GitHubReleasesApi
+import com.raulshma.jellyplay.core.network.github.GitHubReleasesApiImpl
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
@@ -29,6 +32,11 @@ class AppUpdateRepositoryImpl @Inject constructor(
     // cache — mirroring how the image client is built in JellyPlayApplication.
     @Named("download") private val downloadClient: OkHttpClient,
 ) : AppUpdateRepository {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
 
     override suspend fun checkForUpdate(supportedAbis: Array<String>): Result<AppUpdateInfo> {
         val current = currentVersionName()
@@ -51,9 +59,11 @@ class AppUpdateRepositoryImpl @Inject constructor(
     }
 
     override suspend fun downloadApk(
-        url: String,
+        info: AppUpdateInfo,
         onProgress: (Float, Long, Long) -> Unit,
     ): Result<File> {
+        val url = info.downloadAssetUrl
+            ?: return Result.failure(java.io.IOException("Download failed: no asset URL"))
         // Clone once with no cache. A binary APK must not pollute the shared
         // JSON/asset cache, and we want a clean connection for streaming.
         val client = downloadClient.newBuilder()
@@ -88,14 +98,17 @@ class AppUpdateRepositoryImpl @Inject constructor(
                 // be evicted by the OS at any time — both delete the APK mid
                 // install, producing "There was a problem parsing the package".
                 val updatesDir = File(context.filesDir, UPDATES_DIR).apply { mkdirs() }
-                // Clean up any previously downloaded APK so a stale/partial file
-                // never masquerades as the new build.
-                updatesDir.listFiles()?.forEach { runCatching { it.delete() } }
-                val outFile = File(updatesDir, OUTPUT_APK_NAME)
+                val finalFile = File(updatesDir, OUTPUT_APK_NAME)
+                // Stream into a .part file so a failed/cancelled re-download
+                // leaves the previously-installed APK + sidecar untouched. The
+                // swap to the final name only happens once the transfer is
+                // complete — that's what keeps the "keep until install" promise
+                // across re-downloads.
+                val partFile = File(updatesDir, OUTPUT_PART_NAME)
 
                 try {
                     body.byteStream().buffered().use { input ->
-                        outFile.outputStream().buffered().use { output ->
+                        partFile.outputStream().buffered().use { output ->
                             val buffer = ByteArray(BUFFER_SIZE)
                             var bytesRead: Int
                             var downloaded = 0L
@@ -117,10 +130,29 @@ class AppUpdateRepositoryImpl @Inject constructor(
                         }
                     }
                     response.close()
-                    Result.success(outFile)
+                    // Atomically promote the complete .part to the final name,
+                    // removing the old APK + sidecar first so the rename lands
+                    // cleanly (Windows refuses rename onto an existing file).
+                    finalFile.delete()
+                    if (!partFile.renameTo(finalFile)) {
+                        partFile.copyTo(finalFile, overwrite = true)
+                        partFile.delete()
+                    }
+                    // Write the sidecar last, only after a fully-successful
+                    // transfer, so a partial download can never be mistaken for
+                    // a pending install on the next launch. A sidecar write
+                    // failure must not undo a completed download: the APK is
+                    // already in place and still installable; the worst case is
+                    // the next launch's sweep can't identify it (treats it as an
+                    // orphan) — preferable to deleting a usable APK.
+                    runCatching { writeSidecar(info, updatesDir) }
+                    Result.success(finalFile)
                 } catch (e: Throwable) {
                     response.close()
-                    runCatching { outFile.delete() }
+                    // Only the in-flight .part is discarded; the prior APK +
+                    // sidecar (if any) survive so the user can still install what
+                    // they had before the failed re-download.
+                    runCatching { partFile.delete() }
                     throw e
                 }
             }
@@ -129,6 +161,30 @@ class AppUpdateRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Result.failure(e)
         }
+    }
+
+    override suspend fun getPendingUpdate(): PendingAppUpdate? = withContext(Dispatchers.IO) {
+        val updatesDir = File(context.filesDir, UPDATES_DIR)
+        val apkFile = File(updatesDir, OUTPUT_APK_NAME)
+        if (!apkFile.exists()) return@withContext null
+        val meta = readSidecar(updatesDir) ?: return@withContext null
+        // Only treat the on-disk APK as pending when its version is genuinely
+        // newer than the installed build. A completed install restarts the
+        // process in the new version, so equality/older means it's an orphan
+        // that the sweep will reclaim — don't surface a stale "ready" state.
+        if (!isNewerThanInstalled(meta.version)) {
+            return@withContext null
+        }
+        val info = AppUpdateInfo(
+            latestVersion = meta.version,
+            htmlUrl = "",
+            releaseNotes = "",
+            isUpdateAvailable = true,
+            downloadAssetUrl = meta.downloadUrl,
+            downloadAssetName = meta.assetName,
+            releaseSize = meta.releaseSize,
+        )
+        PendingAppUpdate(info = info, apkFile = apkFile)
     }
 
     override fun buildInstallIntent(apkFile: File): Intent {
@@ -148,16 +204,72 @@ class AppUpdateRepositoryImpl @Inject constructor(
         // The system installer is launched in a separate process; we get no
         // result callback for ACTION_VIEW. But a successful package replace
         // kills and restarts our process, so onCreate runs again in the newly
-        // installed version — at which point any previously-downloaded APK is
-        // orphaned. Sweeping it here on startup removes those leftovers without
-        // racing an in-flight download (onCreate precedes any user action).
+        // installed version — at which point the sidecar's version is no longer
+        // newer than the installed one and the APK is an orphan. Keep only a
+        // genuinely pending update; sweep everything else (orphan APK, stale
+        // sidecar, and any abandoned .part from a failed download). Safe at
+        // startup: onCreate precedes any new download.
         val updatesDir = File(context.filesDir, UPDATES_DIR)
+        val apkFile = File(updatesDir, OUTPUT_APK_NAME)
         runCatching {
-            updatesDir.listFiles()?.forEach { it.delete() }
-            if (updatesDir.exists() && updatesDir.listFiles()?.isEmpty() == true) {
-                updatesDir.delete()
+            val meta = readSidecar(updatesDir)
+            val keep = apkFile.exists() && meta != null &&
+                isNewerThanInstalled(meta.version)
+            if (!keep) {
+                updatesDir.listFiles()?.forEach { it.delete() }
+                if (updatesDir.exists() && updatesDir.listFiles()?.isEmpty() == true) {
+                    updatesDir.delete()
+                }
+            } else {
+                // Even when keeping a pending APK, drop any abandoned .part left
+                // by a failed/cancelled re-download so it can't linger forever.
+                runCatching { File(updatesDir, OUTPUT_PART_NAME).delete() }
             }
         }
+    }
+
+    /**
+     * True when [version] (from the sidecar) is strictly newer than the
+     * currently-installed build — i.e. the on-disk APK is a genuinely pending
+     * update the user hasn't installed yet. Centralised so [getPendingUpdate]
+     * and [cleanupDownloadedApk] share one definition of "pending".
+     */
+    private fun isNewerThanInstalled(version: String): Boolean =
+        GitHubReleasesApiImpl.compareVersions(version, currentVersionName()) > 0
+
+    /**
+     * Writes [PendingUpdateMeta] derived from [info] into the sidecar file in
+     * [updatesDir], atomically (write to a temp file then rename) so a crash
+     * mid-write can't leave a half-written sidecar that looks valid.
+     */
+    private fun writeSidecar(info: AppUpdateInfo, updatesDir: File?) {
+        if (updatesDir == null) return
+        val meta = PendingUpdateMeta(
+            version = info.latestVersion,
+            downloadUrl = info.downloadAssetUrl,
+            assetName = info.downloadAssetName,
+            releaseSize = info.releaseSize,
+            downloadedAtMs = System.currentTimeMillis(),
+        )
+        val target = File(updatesDir, META_NAME)
+        val tmp = File(updatesDir, "$META_NAME.tmp")
+        tmp.writeText(json.encodeToString(meta))
+        // renameTo overwrites an existing target on both ART and the JVM's
+        // File.renameTo for same-directory names; atomic on the same volume. If
+        // it fails (some Windows filesystems refuse rename when the target
+        // exists), fall back to a copy + delete.
+        if (!tmp.renameTo(target)) {
+            tmp.copyTo(target, overwrite = true)
+            tmp.delete()
+        }
+    }
+
+    /** Reads + decodes the sidecar in [updatesDir], or null if absent/corrupt. */
+    private fun readSidecar(updatesDir: File): PendingUpdateMeta? {
+        val file = File(updatesDir, META_NAME)
+        if (!file.exists()) return null
+        return runCatching { json.decodeFromString<PendingUpdateMeta>(file.readText()) }
+            .getOrNull()
     }
 
     private fun currentVersionName(): String {
@@ -181,6 +293,8 @@ class AppUpdateRepositoryImpl @Inject constructor(
     companion object {
         private const val UPDATES_DIR = "updates"
         private const val OUTPUT_APK_NAME = "jellyplay-update.apk"
+        private const val OUTPUT_PART_NAME = "jellyplay-update.apk.part"
+        private const val META_NAME = "jellyplay-update.meta.json"
         private const val BUFFER_SIZE = 65536
         private const val PROGRESS_INTERVAL_MS = 500L
         private const val MIME_APK = "application/vnd.android.package-archive"

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepositoryImpl.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepositoryImpl.kt
@@ -82,7 +82,12 @@ class AppUpdateRepositoryImpl @Inject constructor(
                     )
                 }
 
-                val updatesDir = File(context.cacheDir, UPDATES_DIR).apply { mkdirs() }
+                // Persist under filesDir (NOT cacheDir): the APK must survive
+                // backgrounding during the system-installer round trip. cacheDir
+                // is swept by CacheManager on ON_STOP (autoDeleteCache) and can
+                // be evicted by the OS at any time — both delete the APK mid
+                // install, producing "There was a problem parsing the package".
+                val updatesDir = File(context.filesDir, UPDATES_DIR).apply { mkdirs() }
                 // Clean up any previously downloaded APK so a stale/partial file
                 // never masquerades as the new build.
                 updatesDir.listFiles()?.forEach { runCatching { it.delete() } }
@@ -136,6 +141,22 @@ class AppUpdateRepositoryImpl @Inject constructor(
             setDataAndType(uri, MIME_APK)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    override fun cleanupDownloadedApk() {
+        // The system installer is launched in a separate process; we get no
+        // result callback for ACTION_VIEW. But a successful package replace
+        // kills and restarts our process, so onCreate runs again in the newly
+        // installed version — at which point any previously-downloaded APK is
+        // orphaned. Sweeping it here on startup removes those leftovers without
+        // racing an in-flight download (onCreate precedes any user action).
+        val updatesDir = File(context.filesDir, UPDATES_DIR)
+        runCatching {
+            updatesDir.listFiles()?.forEach { it.delete() }
+            if (updatesDir.exists() && updatesDir.listFiles()?.isEmpty() == true) {
+                updatesDir.delete()
+            }
         }
     }
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/PendingAppUpdate.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/update/PendingAppUpdate.kt
@@ -1,0 +1,37 @@
+package com.raulshma.jellyplay.core.data.update
+
+import com.raulshma.jellyplay.core.model.AppUpdateInfo
+import kotlinx.serialization.Serializable
+import java.io.File
+
+/**
+ * A downloaded update APK that is waiting for the user to install it. Returned
+ * by [AppUpdateRepository.getPendingUpdate] so the caller can rebuild an
+ * install-ready state with no network round-trip (the release notes / asset
+ * name come straight from the on-disk sidecar, see [PendingUpdateMeta]).
+ *
+ * @property info The reconstructed [AppUpdateInfo] (version + asset metadata
+ *   persisted in the sidecar). `isUpdateAvailable` is true and the download URL
+ *   is restored so a re-download can overwrite the file.
+ * @property apkFile The downloaded APK under `<filesDir>/updates/`.
+ */
+data class PendingAppUpdate(
+    val info: AppUpdateInfo,
+    val apkFile: File,
+)
+
+/**
+ * Sidecar metadata written next to the downloaded APK so the file's identity
+ * survives process death and the launch-time cleanup can tell a genuinely
+ * pending update (version newer than installed) from an orphan left by a
+ * completed/cancelled install. Plain JSON, co-located with the APK at
+ * `<filesDir>/updates/jellyplay-update.meta.json`.
+ */
+@Serializable
+internal data class PendingUpdateMeta(
+    val version: String,
+    val downloadUrl: String?,
+    val assetName: String?,
+    val releaseSize: Long,
+    val downloadedAtMs: Long,
+)

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/widget/LibrarySyncHook.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/widget/LibrarySyncHook.kt
@@ -1,0 +1,16 @@
+package com.raulshma.jellyplay.core.data.widget
+
+/**
+ * Fired after a successful foreground library scan / home refresh so downstream
+ * one-shot triggers can piggy-back on the same signal:
+ *   - the auto-download foreground drain ([com.raulshma.jellyplay.core.data.worker.AutoDownloadScheduler.enqueueNow])
+ *   - the widget recommendations refresh ([com.raulshma.jellyplay.widget.WidgetWorkScheduler])
+ *
+ * Mirrors the `ContinueWatchingBroadcaster` DI-clean pattern: the interface
+ * lives in `core/data` (reachable from `feature/home`), the wiring lives in
+ * `app` where both schedulers are available.
+ */
+interface LibrarySyncHook {
+    /** Best-effort; implementations must swallow their own failures. */
+    suspend fun onLibraryScanComplete()
+}

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/AutoDownloadScheduler.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/AutoDownloadScheduler.kt
@@ -3,7 +3,9 @@ package com.raulshma.jellyplay.core.data.worker
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.raulshma.jellyplay.core.datastore.di.ApplicationScope
@@ -51,6 +53,40 @@ class AutoDownloadScheduler @Inject constructor(
             } else {
                 cancel()
             }
+        }
+    }
+
+    /**
+     * Immediate one-shot trigger fired when the app returns to the foreground
+     * or after a successful library scan. Mirrors [PlaybackSyncScheduler.enqueueNow]:
+     * a [OneTimeWorkRequestBuilder] with [ExistingWorkPolicy.KEEP] under a
+     * distinct unique name so the foreground trigger never duplicates an
+     * already-queued run.
+     *
+     * Gated on the preference here (not just inside the worker) so a disabled
+     * periodic schedule isn't resurrected by the foreground path — if the
+     * periodic was cancelled because the pref is off, this is a no-op.
+     */
+    fun enqueueNow() {
+        applicationScope.launch {
+            val enabled = downloadsStore.downloads.first().autoDownloadNewEpisodes
+            if (!enabled) return@launch
+
+            val constraints = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresBatteryNotLow(true)
+                .build()
+
+            val request = OneTimeWorkRequestBuilder<AutoDownloadWorker>()
+                .setConstraints(constraints)
+                .addTag(AutoDownloadWorker.WORK_TAG)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                AutoDownloadWorker.UNIQUE_NOW_NAME,
+                ExistingWorkPolicy.KEEP,
+                request,
+            )
         }
     }
 

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/AutoDownloadWorker.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/AutoDownloadWorker.kt
@@ -95,6 +95,7 @@ class AutoDownloadWorker @AssistedInject constructor(
 
     companion object {
         const val UNIQUE_PERIODIC_NAME = "com.raulshma.jellyplay.work.auto_download"
+        const val UNIQUE_NOW_NAME = "com.raulshma.jellyplay.work.auto_download_now"
         const val WORK_TAG = "auto_download"
         private const val TAG = "AutoDownloadWorker"
         private const val MAX_RETRIES = 3

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelper.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelper.kt
@@ -79,6 +79,27 @@ internal object DownloadNotificationHelper {
         }
     }
 
+    /**
+     * Queued-state foreground notification — shown while a transfer waits for a
+     * concurrency slot. Distinct from [createForegroundInfo] so the shade shows
+     * "Queued…" with an indeterminate bar instead of the misleading "0 B / …"
+     * that the byte-formatted progress text renders at zero downloaded bytes.
+     */
+    fun createQueuedForegroundInfo(
+        context: Context,
+        downloadId: String,
+        notificationId: Int,
+        name: String,
+    ): ForegroundInfo {
+        createNotificationChannel(context)
+        val notification = buildQueuedNotification(context, downloadId, name)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(notificationId, notification)
+        }
+    }
+
     fun updateNotification(
         context: Context,
         downloadId: String,
@@ -192,6 +213,39 @@ internal object DownloadNotificationHelper {
             .setOnlyAlertOnce(true)
             .setProgress(100, progress, false)
             .setSubText(speedBytesPerSec.formatSpeed())
+            .setContentIntent(openDownloadsPendingIntent(context))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setGroup(GROUP_KEY)
+            .addAction(
+                R.drawable.ic_notification_pause,
+                context.getString(R.string.data_download_action_pause),
+                actionPendingIntent(context, downloadId, DownloadActionReceiver.ACTION_PAUSE, ACTION_PAUSE_OFFSET),
+            )
+            .addAction(
+                R.drawable.ic_notification_stop,
+                context.getString(R.string.data_download_action_cancel),
+                actionPendingIntent(context, downloadId, DownloadActionReceiver.ACTION_CANCEL, ACTION_CANCEL_OFFSET),
+            )
+            .build()
+    }
+
+    /**
+     * Queued variant: indeterminate progress bar and a "Queued…" body, with the
+     * same Pause/Cancel actions so the user can still hold or cancel while
+     * waiting for a slot.
+     */
+    private fun buildQueuedNotification(
+        context: Context,
+        downloadId: String,
+        name: String,
+    ): Notification {
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle(name)
+            .setContentText(context.getString(R.string.data_download_queued))
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setProgress(0, 0, true)
             .setContentIntent(openDownloadsPendingIntent(context))
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setGroup(GROUP_KEY)

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelper.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelper.kt
@@ -14,15 +14,24 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.work.ForegroundInfo
+import com.raulshma.jellyplay.core.data.R
+import com.raulshma.jellyplay.core.data.receiver.DownloadActionReceiver
 import com.raulshma.jellyplay.core.model.formatBytes
 import com.raulshma.jellyplay.core.model.formatEta
 import com.raulshma.jellyplay.core.model.formatSpeed
 
 /**
- * Builds and manages the download progress foreground notification (channel
- * creation, foreground info, progress/speed/ETA formatting). Extracted out of
- * [DownloadWorker] so the worker orchestrates transfer instead of owning
- * presentation.
+ * Builds and manages the download notifications: the per-transfer progress
+ * foreground notification (with Pause/Cancel actions), the paused-state
+ * notification (Resume/Cancel) shown once a transfer stops at the user's
+ * request, and the "downloads" group **summary** that collapses N concurrent
+ * transfers into one shade item.
+ *
+ * Channel creation, foreground info, and progress/speed/ETA formatting live
+ * here; the workers orchestrate the transfer and call back in. Notification
+ * ids flow through [notificationIdFor] / [pausedNotificationIdFor] — the
+ * single home for the derivation so the worker, the action receiver
+ * ([DownloadActionReceiver]) and the summary never drift.
  *
  * The channel is deduplicated solely via [NotificationManager.getNotificationChannel]
  * — the previous process-global `channelCreated` flag was redundant
@@ -31,9 +40,27 @@ import com.raulshma.jellyplay.core.model.formatSpeed
 internal object DownloadNotificationHelper {
 
     const val CHANNEL_ID = "downloads"
+    const val GROUP_KEY = "downloads"
+
+    /**
+     * Per-download progress notification id. Must match the worker's
+     * ForegroundInfo. The id is masked to [ID_MASK] so the paused and summary
+     * id ranges (which set the bits above it) can never alias a progress id.
+     */
+    fun notificationIdFor(downloadId: String): Int = downloadId.hashCode() and ID_MASK
+
+    /**
+     * Paused-state notification id — [notificationIdFor] with [PAUSED_ID_FLAG]
+     * OR'd in, landing in a range strictly above every progress id and below
+     * [SUMMARY_NOTIFICATION_ID], so the three spaces can never alias each other
+     * (unlike an `xor`, which can fold a paused id back into the progress range).
+     */
+    fun pausedNotificationIdFor(downloadId: String): Int =
+        notificationIdFor(downloadId) or PAUSED_ID_FLAG
 
     fun createForegroundInfo(
         context: Context,
+        downloadId: String,
         notificationId: Int,
         name: String,
         progress: Int,
@@ -43,7 +70,7 @@ internal object DownloadNotificationHelper {
     ): ForegroundInfo {
         createNotificationChannel(context)
         val notification = buildNotification(
-            context, notificationId, name, progress, downloadedBytes, totalBytes, speedBytesPerSec,
+            context, downloadId, name, progress, downloadedBytes, totalBytes, speedBytesPerSec,
         )
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             ForegroundInfo(notificationId, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
@@ -54,6 +81,7 @@ internal object DownloadNotificationHelper {
 
     fun updateNotification(
         context: Context,
+        downloadId: String,
         notificationId: Int,
         name: String,
         progress: Int,
@@ -61,20 +89,78 @@ internal object DownloadNotificationHelper {
         totalBytes: Long,
         speedBytesPerSec: Long,
     ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            if (ContextCompat.checkSelfPermission(
-                    context, Manifest.permission.POST_NOTIFICATIONS,
-                ) != PackageManager.PERMISSION_GRANTED
-            ) return
-        }
+        if (!canPostNotifications(context)) return
         val notification = buildNotification(
-            context, notificationId, name, progress, downloadedBytes, totalBytes, speedBytesPerSec,
+            context, downloadId, name, progress, downloadedBytes, totalBytes, speedBytesPerSec,
         )
         NotificationManagerCompat.from(context).notify(notificationId, notification)
     }
 
     fun dismissNotification(context: Context, notificationId: Int) {
         NotificationManagerCompat.from(context).cancel(notificationId)
+    }
+
+    /**
+     * Posts the paused-state notification for a download stopped by the user,
+     * so the shade keeps a Resume/Cancel handle after the worker is gone.
+     * Best-effort: silently skipped when notification permission was revoked.
+     */
+    fun postPausedNotification(context: Context, downloadId: String, name: String) {
+        if (!canPostNotifications(context)) return
+        createNotificationChannel(context)
+        val notificationId = pausedNotificationIdFor(downloadId)
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle(name)
+            .setContentText(context.getString(R.string.data_download_paused))
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentIntent(openDownloadsPendingIntent(context))
+            .setGroup(GROUP_KEY)
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .addAction(
+                R.drawable.ic_notification_play,
+                context.getString(R.string.data_download_action_resume),
+                actionPendingIntent(context, downloadId, DownloadActionReceiver.ACTION_RESUME, ACTION_RESUME_OFFSET),
+            )
+            .addAction(
+                R.drawable.ic_notification_stop,
+                context.getString(R.string.data_download_action_cancel),
+                actionPendingIntent(context, downloadId, DownloadActionReceiver.ACTION_CANCEL, ACTION_CANCEL_OFFSET),
+            )
+            .build()
+        NotificationManagerCompat.from(context).notify(notificationId, notification)
+    }
+
+    fun dismissPausedNotification(context: Context, downloadId: String) {
+        NotificationManagerCompat.from(context).cancel(pausedNotificationIdFor(downloadId))
+    }
+
+    /**
+     * Posts (or dismisses when [inFlightCount] == 0) the group summary. Called
+     * from every download lifecycle transition so the shade collapses the active
+     * transfers into a single row and clears itself when the last one ends.
+     */
+    fun refreshSummary(context: Context, inFlightCount: Int) {
+        if (inFlightCount <= 0) {
+            NotificationManagerCompat.from(context).cancel(SUMMARY_NOTIFICATION_ID)
+            return
+        }
+        if (!canPostNotifications(context)) return
+        createNotificationChannel(context)
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_download)
+            .setContentTitle(
+                context.resources.getQuantityString(R.plurals.data_download_summary_active, inFlightCount, inFlightCount)
+            )
+            .setContentIntent(openDownloadsPendingIntent(context))
+            .setGroup(GROUP_KEY)
+            .setGroupSummary(true)
+            .setOnlyAlertOnce(true)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+        NotificationManagerCompat.from(context).notify(SUMMARY_NOTIFICATION_ID, notification)
     }
 
     fun formatProgressText(
@@ -91,27 +177,13 @@ internal object DownloadNotificationHelper {
 
     private fun buildNotification(
         context: Context,
-        notificationId: Int,
+        downloadId: String,
         name: String,
         progress: Int,
         downloadedBytes: Long,
         totalBytes: Long,
         speedBytesPerSec: Long,
     ): Notification {
-        // Explicit target: MainActivity in our own package with the DOWNLOADS action.
-        // `setClassName` is applied on the intent directly (not inside an
-        // `Intent().apply { }` block) so CodeQL recognizes the intent as explicit
-        // and the PendingIntent is not flagged as implicit.
-        val intent = Intent()
-            .setClassName(context.packageName, "com.raulshma.jellyplay.MainActivity")
-            .setAction("com.raulshma.jellyplay.action.DOWNLOADS")
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        val pendingIntent = PendingIntent.getActivity(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-        )
         return NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle(name)
             .setContentText(formatProgressText(downloadedBytes, totalBytes, speedBytesPerSec))
@@ -120,10 +192,73 @@ internal object DownloadNotificationHelper {
             .setOnlyAlertOnce(true)
             .setProgress(100, progress, false)
             .setSubText(speedBytesPerSec.formatSpeed())
-            .setContentIntent(pendingIntent)
+            .setContentIntent(openDownloadsPendingIntent(context))
             .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setGroup(GROUP_KEY)
+            .addAction(
+                R.drawable.ic_notification_pause,
+                context.getString(R.string.data_download_action_pause),
+                actionPendingIntent(context, downloadId, DownloadActionReceiver.ACTION_PAUSE, ACTION_PAUSE_OFFSET),
+            )
+            .addAction(
+                R.drawable.ic_notification_stop,
+                context.getString(R.string.data_download_action_cancel),
+                actionPendingIntent(context, downloadId, DownloadActionReceiver.ACTION_CANCEL, ACTION_CANCEL_OFFSET),
+            )
             .build()
     }
+
+    // ── Intents ──────────────────────────────────────────────────────────
+
+    /**
+     * Explicit PendingIntent targeting [DownloadActionReceiver]. The request
+     * code incorporates the per-download notification id so PendingIntent
+     * matching never collapses two distinct downloads into one broadcast — the
+     * extras are not part of PendingIntent's identity.
+     */
+    private fun actionPendingIntent(
+        context: Context,
+        downloadId: String,
+        action: String,
+        offset: Int,
+    ): PendingIntent {
+        val intent = Intent()
+            .setClassName(context.packageName, DownloadActionReceiver::class.java.name)
+            .setAction(action)
+            .putExtra(DownloadActionReceiver.EXTRA_DOWNLOAD_ID, downloadId)
+        return PendingIntent.getBroadcast(
+            context,
+            notificationIdFor(downloadId) + offset,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    /**
+     * Explicit target: MainActivity in our own package with the DOWNLOADS action.
+     * `setClassName` is applied on the intent directly (not inside an
+     * `Intent().apply { }` block) so CodeQL recognizes the intent as explicit
+     * and the PendingIntent is not flagged as implicit.
+     */
+    private fun openDownloadsPendingIntent(context: Context): PendingIntent {
+        val intent = Intent()
+            .setClassName(context.packageName, "com.raulshma.jellyplay.MainActivity")
+            .setAction("com.raulshma.jellyplay.action.DOWNLOADS")
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        return PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    // ── Channel / permissions ────────────────────────────────────────────
+
+    private fun canPostNotifications(context: Context): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
 
     private fun createNotificationChannel(context: Context) {
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -139,4 +274,26 @@ internal object DownloadNotificationHelper {
             manager.createNotificationChannel(channel)
         }
     }
+
+    // Every broadcast action above must resolve to a distinct PendingIntent
+    // identity (request code + component + action), so give each action its own
+    // offset on top of the per-download notification id.
+    private const val ACTION_PAUSE_OFFSET = 0
+    private const val ACTION_RESUME_OFFSET = 1
+    private const val ACTION_CANCEL_OFFSET = 2
+
+    // The three notification-id spaces are kept disjoint by bit partitioning:
+    //   progress ids:   bits 0..26  (ID_MASK)
+    //   paused ids:     bit 27 set  (PAUSED_ID_FLAG)  — always > any progress id
+    //   summary id:     bit 28 set  (SUMMARY_BIT)     — always > any paused id
+    // A plain `xor` flag is unsafe here: it can fold a paused id back into the
+    // progress range for a different download, so we OR the flags instead and
+    // mask the base id so it can never reach them.
+    private const val ID_MASK = 0x07FFFFFF
+    private const val PAUSED_ID_FLAG = 0x08000000
+    private const val SUMMARY_BIT = 0x10000000
+
+    // Fixed summary id — strictly greater than every possible progress and
+    // paused id by construction (only the SUMMARY bit is set).
+    const val SUMMARY_NOTIFICATION_ID = SUMMARY_BIT
 }

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadTransferRunner.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadTransferRunner.kt
@@ -59,7 +59,7 @@ internal class DownloadTransferRunner(
      */
     private val updateForeground: suspend (name: String, progress: Int, downloaded: Long, total: Long, speed: Long, notificationId: Int) -> Unit,
     /** Cancels the progress notification on completion; best-effort, swallowed by the caller. */
-    private val dismissForeground: (notificationId: Int) -> Unit,
+    private val dismissForeground: suspend (notificationId: Int) -> Unit,
 ) {
 
     /**

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
@@ -76,10 +76,14 @@ class DownloadWorker @AssistedInject constructor(
         concurrencyLimiter.configure(maxConcurrent)
 
         val notificationId = DownloadNotificationHelper.notificationIdFor(downloadId)
+        val existingBytes = entity.downloadedBytes
+        // Mark the row QUEUED while it waits for a concurrency slot so the UI
+        // can show a distinct indicator instead of a stalled DOWNLOADING row.
+        dao.updateProgress(downloadId, existingBytes, DownloadStatus.QUEUED.name)
         try {
             setForeground(
-                DownloadNotificationHelper.createForegroundInfo(
-                    applicationContext, downloadId, notificationId, entity.name, 0, 0L, entity.totalSizeBytes, 0L,
+                DownloadNotificationHelper.createQueuedForegroundInfo(
+                    applicationContext, downloadId, notificationId, entity.name,
                 )
             )
             DownloadNotificationHelper.dismissPausedNotification(applicationContext, downloadId)
@@ -101,11 +105,6 @@ class DownloadWorker @AssistedInject constructor(
             // OEMs): fall through and attempt the download as a background
             // worker — best-effort.
         }
-
-        val existingBytes = entity.downloadedBytes
-        // Mark the row QUEUED while it waits for a concurrency slot so the UI
-        // can show a distinct indicator instead of a stalled DOWNLOADING row.
-        dao.updateProgress(downloadId, existingBytes, DownloadStatus.QUEUED.name)
 
         val activeUserId = serverIdentityStore.activeUserId.firstOrNull()
         val accessToken = activeUserId?.let { uid ->

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/DownloadWorker.kt
@@ -75,12 +75,16 @@ class DownloadWorker @AssistedInject constructor(
         val maxConcurrent = downloadsStore.downloads.value.maxConcurrentDownloads
         concurrencyLimiter.configure(maxConcurrent)
 
-        val notificationId = downloadId.hashCode() and 0x7FFFFFFF
+        val notificationId = DownloadNotificationHelper.notificationIdFor(downloadId)
         try {
             setForeground(
                 DownloadNotificationHelper.createForegroundInfo(
-                    applicationContext, notificationId, entity.name, 0, 0L, entity.totalSizeBytes, 0L,
+                    applicationContext, downloadId, notificationId, entity.name, 0, 0L, entity.totalSizeBytes, 0L,
                 )
+            )
+            DownloadNotificationHelper.dismissPausedNotification(applicationContext, downloadId)
+            DownloadNotificationHelper.refreshSummary(
+                applicationContext, dao.getInFlightDownloadCount(),
             )
         } catch (e: Exception) {
             // On Android 12+ a background-launched worker cannot promote itself
@@ -130,12 +134,18 @@ class DownloadWorker @AssistedInject constructor(
                     updateForeground = { name, progress, downloaded, total, speed, notifId ->
                         setForeground(
                             DownloadNotificationHelper.createForegroundInfo(
-                                applicationContext, notifId, name, progress, downloaded, total, speed,
+                                applicationContext, downloadId, notifId, name, progress, downloaded, total, speed,
                             )
+                        )
+                        DownloadNotificationHelper.refreshSummary(
+                            applicationContext, dao.getInFlightDownloadCount(),
                         )
                     },
                     dismissForeground = { notifId ->
                         DownloadNotificationHelper.dismissNotification(applicationContext, notifId)
+                        DownloadNotificationHelper.refreshSummary(
+                            applicationContext, dao.getInFlightDownloadCount(),
+                        )
                     },
                 )
                 if (existingBytes > 0L) {

--- a/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/MultiConnectionDownloadStrategy.kt
+++ b/core/data/src/main/java/com/raulshma/jellyplay/core/data/worker/MultiConnectionDownloadStrategy.kt
@@ -74,9 +74,10 @@ internal object MultiConnectionDownloadStrategy {
         try {
             setForegroundInfo(
                 DownloadNotificationHelper.createForegroundInfo(
-                    context, notificationId, entity.name, 0, 0L, totalSize, 0L,
+                    context, downloadId, notificationId, entity.name, 0, 0L, totalSize, 0L,
                 )
             )
+            DownloadNotificationHelper.refreshSummary(context, dao.getInFlightDownloadCount())
         } catch (_: Exception) {
         }
 
@@ -110,9 +111,10 @@ internal object MultiConnectionDownloadStrategy {
                             (currentDownloaded * 100 / totalSize).toInt()
                         } else 0
                         DownloadNotificationHelper.updateNotification(
-                            context, notificationId, entity.name, progress,
+                            context, downloadId, notificationId, entity.name, progress,
                             currentDownloaded, totalSize, speedBytesPerSec,
                         )
+                        DownloadNotificationHelper.refreshSummary(context, dao.getInFlightDownloadCount())
 
                         delay(PROGRESS_UPDATE_INTERVAL_MS)
                     }
@@ -170,6 +172,7 @@ internal object MultiConnectionDownloadStrategy {
             // A successful download clears the auto-retry budget.
             dao.resetRetryCount(downloadId)
             DownloadNotificationHelper.dismissNotification(context, notificationId)
+            DownloadNotificationHelper.refreshSummary(context, dao.getInFlightDownloadCount())
             Result.success()
         } catch (e: CancellationException) {
             throw e

--- a/core/data/src/main/res/values-de/strings.xml
+++ b/core/data/src/main/res/values-de/strings.xml
@@ -20,6 +20,16 @@
     <string name="data_channel_downloads">Downloads</string>
     <string name="data_channel_downloads_desc">Benachrichtigungen zum Download-Fortschritt</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">Pause</string>
+    <string name="data_download_action_resume">Fortsetzen</string>
+    <string name="data_download_action_cancel">Abbrechen</string>
+    <string name="data_download_paused">Download pausiert</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="one">%1$d Download wird ausgeführt</item>
+        <item quantity="other">%1$d Downloads werden ausgeführt</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">Filme</string>
     <string name="data_label_episodes">Episoden</string>

--- a/core/data/src/main/res/values-de/strings.xml
+++ b/core/data/src/main/res/values-de/strings.xml
@@ -25,6 +25,7 @@
     <string name="data_download_action_resume">Fortsetzen</string>
     <string name="data_download_action_cancel">Abbrechen</string>
     <string name="data_download_paused">Download pausiert</string>
+    <string name="data_download_queued">In der Warteschlange\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="one">%1$d Download wird ausgeführt</item>
         <item quantity="other">%1$d Downloads werden ausgeführt</item>

--- a/core/data/src/main/res/values-es/strings.xml
+++ b/core/data/src/main/res/values-es/strings.xml
@@ -25,6 +25,7 @@
     <string name="data_download_action_resume">Reanudar</string>
     <string name="data_download_action_cancel">Cancelar</string>
     <string name="data_download_paused">Descarga en pausa</string>
+    <string name="data_download_queued">En cola\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="one">%1$d descarga en curso</item>
         <item quantity="other">%1$d descargas en curso</item>

--- a/core/data/src/main/res/values-es/strings.xml
+++ b/core/data/src/main/res/values-es/strings.xml
@@ -20,6 +20,16 @@
     <string name="data_channel_downloads">Descargas</string>
     <string name="data_channel_downloads_desc">Notificaciones del progreso de descarga</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">Pausar</string>
+    <string name="data_download_action_resume">Reanudar</string>
+    <string name="data_download_action_cancel">Cancelar</string>
+    <string name="data_download_paused">Descarga en pausa</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="one">%1$d descarga en curso</item>
+        <item quantity="other">%1$d descargas en curso</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">Películas</string>
     <string name="data_label_episodes">Episodios</string>

--- a/core/data/src/main/res/values-fr/strings.xml
+++ b/core/data/src/main/res/values-fr/strings.xml
@@ -25,6 +25,7 @@
     <string name="data_download_action_resume">Reprendre</string>
     <string name="data_download_action_cancel">Annuler</string>
     <string name="data_download_paused">Téléchargement en pause</string>
+    <string name="data_download_queued">En file d\'attente\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="one">%1$d téléchargement en cours</item>
         <item quantity="other">%1$d téléchargements en cours</item>

--- a/core/data/src/main/res/values-fr/strings.xml
+++ b/core/data/src/main/res/values-fr/strings.xml
@@ -20,6 +20,16 @@
     <string name="data_channel_downloads">Téléchargements</string>
     <string name="data_channel_downloads_desc">Notifications de progression des téléchargements</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">Pause</string>
+    <string name="data_download_action_resume">Reprendre</string>
+    <string name="data_download_action_cancel">Annuler</string>
+    <string name="data_download_paused">Téléchargement en pause</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="one">%1$d téléchargement en cours</item>
+        <item quantity="other">%1$d téléchargements en cours</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">Films</string>
     <string name="data_label_episodes">Épisodes</string>

--- a/core/data/src/main/res/values-it/strings.xml
+++ b/core/data/src/main/res/values-it/strings.xml
@@ -25,6 +25,7 @@
     <string name="data_download_action_resume">Riprendi</string>
     <string name="data_download_action_cancel">Annulla</string>
     <string name="data_download_paused">Download in pausa</string>
+    <string name="data_download_queued">In coda\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="one">%1$d download in corso</item>
         <item quantity="other">%1$d download in corso</item>

--- a/core/data/src/main/res/values-it/strings.xml
+++ b/core/data/src/main/res/values-it/strings.xml
@@ -20,6 +20,16 @@
     <string name="data_channel_downloads">Download</string>
     <string name="data_channel_downloads_desc">Notifiche sull\'avanzamento dei download</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">Pausa</string>
+    <string name="data_download_action_resume">Riprendi</string>
+    <string name="data_download_action_cancel">Annulla</string>
+    <string name="data_download_paused">Download in pausa</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="one">%1$d download in corso</item>
+        <item quantity="other">%1$d download in corso</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">Film</string>
     <string name="data_label_episodes">Episodi</string>

--- a/core/data/src/main/res/values-ja/strings.xml
+++ b/core/data/src/main/res/values-ja/strings.xml
@@ -24,6 +24,7 @@
     <string name="data_download_action_resume">再開</string>
     <string name="data_download_action_cancel">キャンセル</string>
     <string name="data_download_paused">ダウンロードを一時停止しました</string>
+    <string name="data_download_queued">待機中\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="other">%1$d 件のダウンロードが進行中</item>
     </plurals>

--- a/core/data/src/main/res/values-ja/strings.xml
+++ b/core/data/src/main/res/values-ja/strings.xml
@@ -19,6 +19,15 @@
     <string name="data_channel_downloads">ダウンロード</string>
     <string name="data_channel_downloads_desc">ダウンロードの進行状況通知</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">一時停止</string>
+    <string name="data_download_action_resume">再開</string>
+    <string name="data_download_action_cancel">キャンセル</string>
+    <string name="data_download_paused">ダウンロードを一時停止しました</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="other">%1$d 件のダウンロードが進行中</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">映画</string>
     <string name="data_label_episodes">エピソード</string>

--- a/core/data/src/main/res/values-ko/strings.xml
+++ b/core/data/src/main/res/values-ko/strings.xml
@@ -19,6 +19,15 @@
     <string name="data_channel_downloads">다운로드</string>
     <string name="data_channel_downloads_desc">다운로드 진행 상황 알림</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">일시 정지</string>
+    <string name="data_download_action_resume">재개</string>
+    <string name="data_download_action_cancel">취소</string>
+    <string name="data_download_paused">다운로드 일시 정지됨</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="other">%1$d개 다운로드 진행 중</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">영화</string>
     <string name="data_label_episodes">에피소드</string>

--- a/core/data/src/main/res/values-ko/strings.xml
+++ b/core/data/src/main/res/values-ko/strings.xml
@@ -24,6 +24,7 @@
     <string name="data_download_action_resume">재개</string>
     <string name="data_download_action_cancel">취소</string>
     <string name="data_download_paused">다운로드 일시 정지됨</string>
+    <string name="data_download_queued">대기 중\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="other">%1$d개 다운로드 진행 중</item>
     </plurals>

--- a/core/data/src/main/res/values-pt/strings.xml
+++ b/core/data/src/main/res/values-pt/strings.xml
@@ -25,6 +25,7 @@
     <string name="data_download_action_resume">Retomar</string>
     <string name="data_download_action_cancel">Cancelar</string>
     <string name="data_download_paused">Download em pausa</string>
+    <string name="data_download_queued">Na fila\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="one">%1$d download em curso</item>
         <item quantity="other">%1$d downloads em curso</item>

--- a/core/data/src/main/res/values-pt/strings.xml
+++ b/core/data/src/main/res/values-pt/strings.xml
@@ -20,6 +20,16 @@
     <string name="data_channel_downloads">Downloads</string>
     <string name="data_channel_downloads_desc">Notificações de progresso de download</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">Pausar</string>
+    <string name="data_download_action_resume">Retomar</string>
+    <string name="data_download_action_cancel">Cancelar</string>
+    <string name="data_download_paused">Download em pausa</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="one">%1$d download em curso</item>
+        <item quantity="other">%1$d downloads em curso</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">Filmes</string>
     <string name="data_label_episodes">Episódios</string>

--- a/core/data/src/main/res/values-zh/strings.xml
+++ b/core/data/src/main/res/values-zh/strings.xml
@@ -24,6 +24,7 @@
     <string name="data_download_action_resume">继续</string>
     <string name="data_download_action_cancel">取消</string>
     <string name="data_download_paused">下载已暂停</string>
+    <string name="data_download_queued">排队中\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="other">%1$d 个下载正在进行</item>
     </plurals>

--- a/core/data/src/main/res/values-zh/strings.xml
+++ b/core/data/src/main/res/values-zh/strings.xml
@@ -19,6 +19,15 @@
     <string name="data_channel_downloads">下载</string>
     <string name="data_channel_downloads_desc">下载进度通知</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">暂停</string>
+    <string name="data_download_action_resume">继续</string>
+    <string name="data_download_action_cancel">取消</string>
+    <string name="data_download_paused">下载已暂停</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="other">%1$d 个下载正在进行</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">电影</string>
     <string name="data_label_episodes">剧集</string>

--- a/core/data/src/main/res/values/strings.xml
+++ b/core/data/src/main/res/values/strings.xml
@@ -20,6 +20,16 @@
     <string name="data_channel_downloads">Downloads</string>
     <string name="data_channel_downloads_desc">Download progress notifications</string>
 
+    <!-- Downloads notification actions -->
+    <string name="data_download_action_pause">Pause</string>
+    <string name="data_download_action_resume">Resume</string>
+    <string name="data_download_action_cancel">Cancel</string>
+    <string name="data_download_paused">Download paused</string>
+    <plurals name="data_download_summary_active">
+        <item quantity="one">%1$d download in progress</item>
+        <item quantity="other">%1$d downloads in progress</item>
+    </plurals>
+
     <!-- Admin statistics: content-type breakdown labels -->
     <string name="data_label_movies">Movies</string>
     <string name="data_label_episodes">Episodes</string>

--- a/core/data/src/main/res/values/strings.xml
+++ b/core/data/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="data_download_action_resume">Resume</string>
     <string name="data_download_action_cancel">Cancel</string>
     <string name="data_download_paused">Download paused</string>
+    <string name="data_download_queued">Queued\u2026</string>
     <plurals name="data_download_summary_active">
         <item quantity="one">%1$d download in progress</item>
         <item quantity="other">%1$d downloads in progress</item>

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManagerCrossfadeTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/AudioPlaybackManagerCrossfadeTest.kt
@@ -1,0 +1,127 @@
+package com.raulshma.jellyplay.core.data.playback
+
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaLibraryService.MediaLibrarySession
+import androidx.media3.session.MediaSession
+import androidx.test.core.app.ApplicationProvider
+import com.raulshma.jellyplay.core.data.repository.DownloadRepository
+import com.raulshma.jellyplay.core.data.repository.MediaRepository
+import com.raulshma.jellyplay.core.data.repository.PlaybackRepository
+import com.raulshma.jellyplay.core.data.streaming.AdaptiveBitrateSelector
+import com.raulshma.jellyplay.core.model.StreamingQuality
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.junit.After
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Regression guard for the audio-crossfade session rebuild in
+ * [AudioPlaybackManager.onCrossfadeTransition].
+ *
+ * `AudioPlaybackManager` is not unit-testable in isolation (its Hilt-injected
+ * constructor pulls in ~20 repositories/processors), so the rebuild is verified
+ * here at the [PlaybackSessionManager] level using the **exact production
+ * construction path**: [AudioLibraryBrowser.buildMediaSession]. Both the
+ * initial audio session and the post-crossfade rebuild go through that shared
+ * builder (the extraction that fixed the downgrade), so this test exercises the
+ * real code the service depends on, not a test-local copy.
+ *
+ * The host service ([JellyPlayPlaybackService.onGetSession]) casts the active
+ * session with `as? MediaLibrarySession`. Pre-fix, the crossfade rebuilt a plain
+ * [MediaSession], the cast returned null, the service rejected controller
+ * connections, and the now-playing notification + headset buttons stayed dead
+ * until app restart — the same bug class already fixed for video in
+ * MediaSessionController and pinned by
+ * [PlaybackSessionManagerPriorityTest].
+ *
+ * Uses real [MediaSession] instances (Robolectric context) wrapping mockk
+ * [Player]s via the shared [stubMediaSessionPlayer] testFixture.
+ */
+@OptIn(UnstableApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class AudioPlaybackManagerCrossfadeTest {
+
+    private lateinit var manager: PlaybackSessionManager
+    private lateinit var browser: AudioLibraryBrowser
+    private val createdSessions = mutableListOf<MediaSession>()
+    private var idCounter = 0
+
+    @Before
+    fun setUp() {
+        manager = PlaybackSessionManager(ApplicationProvider.getApplicationContext())
+        // A real browser with mocked collaborators: the crossfade fix lives in
+        // its buildMediaSession(), so the constructor only needs to succeed.
+        browser = AudioLibraryBrowser(
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            mediaRepository = mockk<MediaRepository>(relaxed = true),
+            downloadRepository = mockk<DownloadRepository>(relaxed = true),
+            playbackRepository = mockk<PlaybackRepository>(relaxed = true),
+            playbackSourceResolver = mockk<PlaybackSourceResolver>(relaxed = true),
+            streamingQualityProvider = { StreamingQuality.AUTO },
+            adaptiveBitrateSelector = mockk<AdaptiveBitrateSelector>(relaxed = true),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        createdSessions.forEach { runCatching { it.release() } }
+        createdSessions.clear()
+    }
+
+    @Test
+    fun crossfadeRebuild_producesSessionThatSurvives_theServiceCast() {
+        // The rebuild must remain a MediaLibrarySession so
+        // JellyPlayPlaybackService.onGetSession's `as? MediaLibrarySession`
+        // returns it (notification + headset buttons stay alive past crossfade).
+        val rebuilt = crossfadeRebuild(isPlaying = true)
+
+        assertTrue(manager.currentSession === rebuilt)
+        assertTrue(manager.currentSession is MediaLibrarySession)
+    }
+
+    @Test
+    fun crossfadeRebuild_displacesPreviousSession_whileStillPlaying() {
+        // The guard in setActiveSession rejects idle challengers, but a
+        // crossfade swaps playing -> playing: the rebuild must displace the
+        // previous audio session, not be blocked or release it wrongly.
+        val first = crossfadeRebuild(isPlaying = true)
+        val second = crossfadeRebuild(isPlaying = true)
+
+        assertSame(second, manager.currentSession)
+        assertTrue(second is MediaLibrarySession)
+    }
+
+    /**
+     * Mirrors the fixed [AudioPlaybackManager.onCrossfadeTransition] rebuild:
+     * release the old session, build a new [MediaLibrarySession] around the
+     * swapped-in player via the shared production builder, and activate it
+     * through the session manager.
+     */
+    private fun crossfadeRebuild(isPlaying: Boolean): MediaLibrarySession {
+        val player = stubMediaSessionPlayer(isPlaying)
+        // Media3's MediaLibrarySession construction requires its context to be a
+        // MediaLibraryService; pass the Robolectric-built JellyPlayPlaybackService
+        // so the exact production construction path runs (a plain Application
+        // context throws ClassCastException under Robolectric SDK 35).
+        val service = Robolectric.buildService(JellyPlayPlaybackService::class.java).get()
+        val session = browser.buildMediaSession(
+            context = service,
+            player = player,
+            sessionId = "crossfade_${idCounter++}",
+        )
+        createdSessions.add(session)
+        manager.setActiveSession(session)
+        return session
+    }
+}

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/MediaStreamVolumeTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/MediaStreamVolumeTest.kt
@@ -8,8 +8,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class MediaStreamVolumeTest {
 
     private lateinit var context: Context

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/PlaybackSessionManagerPriorityTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/playback/PlaybackSessionManagerPriorityTest.kt
@@ -1,14 +1,18 @@
 package com.raulshma.jellyplay.core.data.playback
 
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaLibraryService.MediaLibrarySession
 import androidx.media3.session.MediaSession
 import androidx.test.core.app.ApplicationProvider
 import org.junit.After
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -24,6 +28,7 @@ import org.robolectric.annotation.Config
  * `isPlaying`, `playbackState`, and `applicationLooper` (the latter is probed by
  * `MediaSession`'s constructor).
  */
+@OptIn(UnstableApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
 class PlaybackSessionManagerPriorityTest {
@@ -104,6 +109,72 @@ class PlaybackSessionManagerPriorityTest {
         assertNotNull(manager.currentSession)
     }
 
+    @Test
+    fun playingLibraryHolder_isNotDisplacedBy_idleLibraryChallenger() {
+        // Same guard with the real production types: the audio/initial + rebuilt
+        // crossfade sessions are MediaLibrarySessions, not plain MediaSessions.
+        val playing = newLibrarySession(isPlaying = true)
+        val idle = newLibrarySession(isPlaying = false)
+
+        manager.setActiveSession(playing)
+        manager.setActiveSession(idle)
+
+        assertSame(playing, manager.currentSession)
+    }
+
+    @Test
+    fun playingLibraryHolder_isDisplacedBy_playingLibraryChallenger() {
+        // Crossfade-style swap with production types: playing -> playing must
+        // still displace, so audio crossfade rebuilds are not blocked.
+        val first = newLibrarySession(isPlaying = true)
+        val second = newLibrarySession(isPlaying = true)
+
+        manager.setActiveSession(first)
+        manager.setActiveSession(second)
+
+        assertSame(second, manager.currentSession)
+    }
+
+    @Test
+    fun libraryChallenger_survives_theServiceCast() {
+        // JellyPlayPlaybackService.onGetSession casts the current session to
+        // MediaLibrarySession. A MediaLibrarySession must never be rejected.
+        val library = newLibrarySession(isPlaying = true)
+        manager.setActiveSession(library)
+
+        assertTrue(manager.currentSession is MediaLibrarySession)
+    }
+
+    @Test
+    fun plainMediaSessionChallenger_isTheKnownRegression_forTheServiceCast() {
+        // Regression guard: the pre-fix audio crossfade path rebuilt a plain
+        // MediaSession; it fails the `as? MediaLibrarySession` cast in
+        // JellyPlayPlaybackService.onGetSession, which breaks the now-playing
+        // notification + headset buttons until app restart. A re-introduction of
+        // a plain-session challenger must fail this test.
+        val plain = newSession(isPlaying = true)
+        manager.setActiveSession(plain)
+
+        assertTrue(manager.currentSession as? MediaLibrarySession == null)
+    }
+
+    private fun newLibrarySession(isPlaying: Boolean): MediaLibrarySession {
+        val player = stubMediaSessionPlayer(isPlaying)
+        // Media3's MediaLibrarySession construction requires its context to be a
+        // MediaLibraryService (it hooks the session to the host service). Passing
+        // the Robolectric-built JellyPlayPlaybackService as the context boots the
+        // exact production construction path; a plain Application context throws
+        // ClassCastException on Robolectric SDK 35.
+        val service = Robolectric.buildService(JellyPlayPlaybackService::class.java).get()
+        val session = MediaLibrarySession.Builder(
+            service,
+            player,
+            NO_OP_LIBRARY_CALLBACK,
+        ).setId("${this.javaClass.simpleName}_lib_${idCounter++}").build()
+        createdSessions.add(session)
+        return session
+    }
+
     private fun newSession(isPlaying: Boolean): MediaSession {
         val player = stubMediaSessionPlayer(isPlaying)
         val session = MediaSession.Builder(
@@ -112,5 +183,15 @@ class PlaybackSessionManagerPriorityTest {
         ).setId("${this.javaClass.simpleName}_${idCounter++}").build()
         createdSessions.add(session)
         return session
+    }
+
+    private companion object {
+        /**
+         * Satisfies [MediaLibrarySession]'s constructor so the manager tests can
+         * exercise the real production session type. The base callback's
+         * defaults reject every library method, which is correct here — the
+         * guard only reads the player.
+         */
+        val NO_OP_LIBRARY_CALLBACK = object : MediaLibrarySession.Callback {}
     }
 }

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/repository/PlayedStateSyncImplTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/repository/PlayedStateSyncImplTest.kt
@@ -1,6 +1,8 @@
 package com.raulshma.jellyplay.core.data.repository
 
 import com.raulshma.jellyplay.core.data.offline.OfflineModeManager
+import com.raulshma.jellyplay.core.datastore.downloads.DownloadsSlice
+import com.raulshma.jellyplay.core.datastore.downloads.DownloadsStore
 import com.raulshma.jellyplay.core.model.MediaDetail
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
@@ -11,6 +13,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -31,6 +34,8 @@ class PlayedStateSyncImplTest {
     private val playbackOutboxRepository: PlaybackOutboxRepository = mockk(relaxed = true)
     private val offlineModeManager: OfflineModeManager = mockk()
     private val mediaRepository: MediaRepository = mockk(relaxed = true)
+    private val downloadsStore: DownloadsStore = mockk()
+    private val downloadRepository: DownloadRepository = mockk(relaxed = true)
 
     private lateinit var sync: PlayedStateSyncImpl
 
@@ -39,12 +44,21 @@ class PlayedStateSyncImplTest {
         // dagger.Lazy is trivially faked — PlayedStateSyncImpl only calls get().
         val lazyMedia: Lazy<MediaRepository> = mockk()
         every { lazyMedia.get() } returns mediaRepository
+        val lazyStore: Lazy<DownloadsStore> = mockk()
+        every { lazyStore.get() } returns downloadsStore
+        val lazyDownloads: Lazy<DownloadRepository> = mockk()
+        every { lazyDownloads.get() } returns downloadRepository
+        // Auto-delete-after-watch defaults OFF, so existing flip tests stay
+        // unaffected: getDownloadByMediaItemId is never reached.
+        every { downloadsStore.downloads } returns kotlinx.coroutines.flow.MutableStateFlow(DownloadsSlice())
         sync = PlayedStateSyncImpl(
             apiClient,
             offlineRepository,
             playbackOutboxRepository,
             offlineModeManager,
             lazyMedia,
+            lazyStore,
+            lazyDownloads,
         )
     }
 

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepositoryImplTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/update/AppUpdateRepositoryImplTest.kt
@@ -1,0 +1,196 @@
+package com.raulshma.jellyplay.core.data.update
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.raulshma.jellyplay.core.model.AppUpdateInfo
+import com.raulshma.jellyplay.core.network.github.GitHubReleasesApi
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Robolectric tests for the sidecar + version-aware-sweep behaviour backing the
+ * "keep downloaded APK until install, allow re-download" feature. Uses a real
+ * filesDir (via ApplicationProvider) and a MockWebServer to exercise the actual
+ * download path end-to-end. The installed version is faked by stubbing the
+ * package manager's PackageInfo (Robolectric returns versionName="1.0" by
+ * default for the test application).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class AppUpdateRepositoryImplTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var repo: AppUpdateRepositoryImpl
+    private lateinit var updatesDir: File
+
+    // Under Robolectric the test app has no explicit versionName/versionCode, so
+    // currentVersionName() falls back to longVersionCode = "0". Any sidecar
+    // version strictly greater than 0 (e.g. "2.0") reads as "pending"; an equal
+    // version ("0") reads as "installed/orphan" — simulating a completed install
+    // where the process restarted in the new build.
+    private val orphanVersion = "0"
+
+    private fun updateInfo(version: String, url: String? = null) = AppUpdateInfo(
+        latestVersion = version,
+        htmlUrl = "https://example.com/release",
+        releaseNotes = "notes",
+        isUpdateAvailable = true,
+        downloadAssetUrl = url,
+        downloadAssetName = "jellyplay-v$version-phone-arm64-v8a.apk",
+        releaseSize = 0L,
+    )
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        updatesDir = File(context.filesDir, "updates")
+        // Start clean so tests don't see leftovers from one another.
+        updatesDir.deleteRecursively()
+        repo = AppUpdateRepositoryImpl(
+            context = context,
+            gitHubReleasesApi = mockk<GitHubReleasesApi>(),
+            downloadClient = OkHttpClient(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        updatesDir.deleteRecursively()
+    }
+
+    @Test
+    fun `download writes apk and sidecar`() = runBlocking {
+        server.enqueue(MockResponse().setBody("fake-apk-bytes"))
+        val info = updateInfo("2.0", server.url("/apk").toString())
+
+        val result = repo.downloadApk(info)
+
+        assertTrue(result.isSuccess)
+        val apk = File(updatesDir, "jellyplay-update.apk")
+        assertTrue(apk.exists())
+        assertEquals("fake-apk-bytes", apk.readText())
+        // Sidecar present with the recorded version.
+        val sidecar = File(updatesDir, "jellyplay-update.meta.json")
+        assertTrue(sidecar.exists())
+        assertTrue(sidecar.readText().contains("\"version\":\"2.0\""))
+    }
+
+    @Test
+    fun `getPendingUpdate returns pending when sidecar newer than installed`() = runBlocking {
+        server.enqueue(MockResponse().setBody("apk"))
+        val info = updateInfo("2.0", server.url("/apk").toString())
+        repo.downloadApk(info)
+
+        val pending = repo.getPendingUpdate()
+
+        assertNotNull(pending)
+        assertEquals("2.0", pending!!.info.latestVersion)
+        assertTrue(pending.apkFile.exists())
+        assertTrue(pending.info.isUpdateAvailable)
+    }
+
+    @Test
+    fun `getPendingUpdate returns null when sidecar version not newer`() = runBlocking {
+        server.enqueue(MockResponse().setBody("apk"))
+        // Older than installed: simulates a completed install where the process
+        // restarted in the new build (sidecar version now <= installed).
+        val info = updateInfo(orphanVersion, server.url("/apk").toString())
+        repo.downloadApk(info)
+
+        val pending = repo.getPendingUpdate()
+
+        assertNull(pending)
+    }
+
+    @Test
+    fun `getPendingUpdate returns null when apk missing`() = runBlocking {
+        server.enqueue(MockResponse().setBody("apk"))
+        repo.downloadApk(updateInfo("2.0", server.url("/apk").toString()))
+        // Delete the APK but leave the sidecar — must not surface a ghost state.
+        File(updatesDir, "jellyplay-update.apk").delete()
+
+        assertNull(repo.getPendingUpdate())
+    }
+
+    @Test
+    fun `cleanup keeps genuinely pending apk`() = runBlocking {
+        server.enqueue(MockResponse().setBody("apk"))
+        repo.downloadApk(updateInfo("2.0", server.url("/apk").toString()))
+
+        repo.cleanupDownloadedApk()
+
+        assertTrue(File(updatesDir, "jellyplay-update.apk").exists())
+        assertTrue(File(updatesDir, "jellyplay-update.meta.json").exists())
+    }
+
+    @Test
+    fun `cleanup deletes orphan when version is not newer`() = runBlocking {
+        server.enqueue(MockResponse().setBody("apk"))
+        repo.downloadApk(updateInfo(orphanVersion, server.url("/apk").toString()))
+
+        repo.cleanupDownloadedApk()
+
+        assertFalse(File(updatesDir, "jellyplay-update.apk").exists())
+        assertFalse(File(updatesDir, "jellyplay-update.meta.json").exists())
+    }
+
+    @Test
+    fun `cleanup deletes orphan apk without sidecar`() = runBlocking {
+        // A leftover APK with no sidecar (e.g. from an older app version that
+        // didn't write one) must be swept, not retained forever.
+        updatesDir.mkdirs()
+        File(updatesDir, "jellyplay-update.apk").writeText("stale")
+
+        repo.cleanupDownloadedApk()
+
+        assertFalse(File(updatesDir, "jellyplay-update.apk").exists())
+    }
+
+    @Test
+    fun `redownload overwrites prior apk and sidecar`() = runBlocking {
+        // First download: version 2.0.
+        server.enqueue(MockResponse().setBody("apk-v2"))
+        repo.downloadApk(updateInfo("2.0", server.url("/apk").toString()))
+        // Second download: version 3.0, reusing the same output path.
+        server.enqueue(MockResponse().setBody("apk-v3"))
+        repo.downloadApk(updateInfo("3.0", server.url("/apk").toString()))
+
+        val apk = File(updatesDir, "jellyplay-update.apk")
+        assertEquals("apk-v3", apk.readText())
+        val sidecar = File(updatesDir, "jellyplay-update.meta.json")
+        assertTrue(sidecar.readText().contains("\"version\":\"3.0\""))
+        // Only one APK + one sidecar in the dir — no leftovers.
+        assertEquals(2, updatesDir.listFiles()?.size)
+    }
+
+    @Test
+    fun `failed download deletes apk and leaves no sidecar`() = runBlocking {
+        server.enqueue(MockResponse().setResponseCode(500))
+        val info = updateInfo("2.0", server.url("/apk").toString())
+
+        val result = repo.downloadApk(info)
+
+        assertTrue(result.isFailure)
+        // No APK, no sidecar — nothing for the next launch to mistake as pending.
+        assertFalse(File(updatesDir, "jellyplay-update.apk").exists())
+        assertFalse(File(updatesDir, "jellyplay-update.meta.json").exists())
+    }
+}

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelperTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelperTest.kt
@@ -1,0 +1,114 @@
+package com.raulshma.jellyplay.core.data.worker
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.raulshma.jellyplay.core.data.R
+import com.raulshma.jellyplay.core.data.receiver.DownloadActionReceiver
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the shape of the download notifications the user sees in the shade:
+ * the per-transfer progress notification grouped + Pause/Cancel actions routed
+ * to [DownloadActionReceiver], the paused-state notification carrying
+ * Resume/Cancel, and the collapsible group summary that self-dismisses when the
+ * last in-flight transfer ends.
+ *
+ * Real framework inflation (PendingIntents, the system NotificationManager,
+ * module resources for the action labels) runs against Robolectric's shadows so
+ * the assertion covers the notification shape and intent routing end to end.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = android.app.Application::class)
+class DownloadNotificationHelperTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        // postPausedNotification / refreshSummary skip posting when notification
+        // permission is denied; Robolectric grants it by default, but pin it so
+        // the assertion is about the notification shape, not permission state.
+        shadowOf(context as Application).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    @Test
+    fun `progress notification groups under downloads and exposes pause + cancel actions`() {
+        val downloadId = "dl-1"
+        val notificationId = DownloadNotificationHelper.notificationIdFor(downloadId)
+        val foregroundInfo = DownloadNotificationHelper.createForegroundInfo(
+            context, downloadId, notificationId, "Test Movie", 42, 1_000L, 2_000L, 500L,
+        )
+
+        assertEquals(notificationId, foregroundInfo.notificationId)
+        val notification = foregroundInfo.notification
+        assertEquals("Test Movie", notification.extras.getCharSequence(Notification.EXTRA_TITLE).toString())
+        assertEquals(DownloadNotificationHelper.GROUP_KEY, notification.group)
+        assertEquals(2, notification.actions.size)
+
+        val pauseIntent = shadowOf(notification.actions[0].actionIntent).savedIntent
+        assertEquals(DownloadActionReceiver.ACTION_PAUSE, pauseIntent.action)
+        assertEquals(downloadId, pauseIntent.getStringExtra(DownloadActionReceiver.EXTRA_DOWNLOAD_ID))
+
+        val cancelIntent = shadowOf(notification.actions[1].actionIntent).savedIntent
+        assertEquals(DownloadActionReceiver.ACTION_CANCEL, cancelIntent.action)
+        assertEquals(downloadId, cancelIntent.getStringExtra(DownloadActionReceiver.EXTRA_DOWNLOAD_ID))
+    }
+
+    @Test
+    fun `paused notification keeps the row resumable from the shade`() {
+        val downloadId = "dl-2"
+        DownloadNotificationHelper.postPausedNotification(context, downloadId, "Movie")
+
+        val notification = shadowOf(notificationManager())
+            .getNotification(DownloadNotificationHelper.pausedNotificationIdFor(downloadId))
+        assertNotNull(notification)
+        assertEquals("Movie", notification.extras.getCharSequence(Notification.EXTRA_TITLE).toString())
+        assertEquals(DownloadNotificationHelper.GROUP_KEY, notification.group)
+        assertEquals(2, notification.actions.size)
+        assertEquals(
+            DownloadActionReceiver.ACTION_RESUME,
+            shadowOf(notification.actions[0].actionIntent).savedIntent.action,
+        )
+        assertEquals(
+            DownloadActionReceiver.ACTION_CANCEL,
+            shadowOf(notification.actions[1].actionIntent).savedIntent.action,
+        )
+    }
+
+    @Test
+    fun `summary collapses active downloads and dismisses when the last one finishes`() {
+        DownloadNotificationHelper.refreshSummary(context, 2)
+
+        val posted = shadowOf(notificationManager())
+            .getNotification(DownloadNotificationHelper.SUMMARY_NOTIFICATION_ID)
+        assertNotNull(posted)
+        assertEquals(DownloadNotificationHelper.GROUP_KEY, posted.group)
+        assertEquals(
+            context.resources.getQuantityString(R.plurals.data_download_summary_active, 2, 2),
+            posted.extras.getCharSequence(Notification.EXTRA_TITLE).toString(),
+        )
+
+        DownloadNotificationHelper.refreshSummary(context, 0)
+
+        assertNull(
+            shadowOf(notificationManager())
+                .getNotification(DownloadNotificationHelper.SUMMARY_NOTIFICATION_ID)
+        )
+    }
+
+    private fun notificationManager() =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+}

--- a/core/data/src/test/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelperTest.kt
+++ b/core/data/src/test/java/com/raulshma/jellyplay/core/data/worker/DownloadNotificationHelperTest.kt
@@ -89,6 +89,35 @@ class DownloadNotificationHelperTest {
     }
 
     @Test
+    fun `queued notification shows queued text with indeterminate progress and pause + cancel`() {
+        val downloadId = "dl-q"
+        val notificationId = DownloadNotificationHelper.notificationIdFor(downloadId)
+        val foregroundInfo = DownloadNotificationHelper.createQueuedForegroundInfo(
+            context, downloadId, notificationId, "Queued Episode",
+        )
+
+        assertEquals(notificationId, foregroundInfo.notificationId)
+        val notification = foregroundInfo.notification
+        assertEquals("Queued Episode", notification.extras.getCharSequence(Notification.EXTRA_TITLE).toString())
+        assertEquals(
+            context.getString(R.string.data_download_queued),
+            notification.extras.getCharSequence(Notification.EXTRA_TEXT).toString(),
+        )
+        assertEquals(DownloadNotificationHelper.GROUP_KEY, notification.group)
+        // Indeterminate progress: the progress extras flag is set but the
+        // concrete values aren't meaningful — assert the body text only.
+        assertEquals(2, notification.actions.size)
+        assertEquals(
+            DownloadActionReceiver.ACTION_PAUSE,
+            shadowOf(notification.actions[0].actionIntent).savedIntent.action,
+        )
+        assertEquals(
+            DownloadActionReceiver.ACTION_CANCEL,
+            shadowOf(notification.actions[1].actionIntent).savedIntent.action,
+        )
+    }
+
+    @Test
     fun `summary collapses active downloads and dismisses when the last one finishes`() {
         DownloadNotificationHelper.refreshSummary(context, 2)
 

--- a/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
+++ b/core/database/src/main/java/com/raulshma/jellyplay/core/database/dao/DownloadDao.kt
@@ -36,6 +36,15 @@ interface DownloadDao {
     @Query("SELECT COUNT(*) FROM downloads WHERE status IN ('PENDING', 'QUEUED', 'DOWNLOADING', 'PAUSED')")
     fun getActiveDownloadCount(): Flow<Int>
 
+    /**
+     * Count of downloads actively in flight — `PENDING`/`QUEUED`/`DOWNLOADING`
+     * only (excludes `PAUSED`, which the summary counts as resolved). Used by the
+     * download notification group summary so it collapses to one shade item and
+     * dismisses itself when the last transfer finishes.
+     */
+    @Query("SELECT COUNT(*) FROM downloads WHERE status IN ('PENDING', 'QUEUED', 'DOWNLOADING')")
+    suspend fun getInFlightDownloadCount(): Int
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertDownload(download: DownloadEntity)
 

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/downloads/DownloadsStore.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/downloads/DownloadsStore.kt
@@ -56,6 +56,13 @@ class DownloadsStore @Inject constructor(
         val AUTO_DOWNLOAD_NEW_EPISODES = booleanPreferencesKey("auto_download_new_episodes")
         val MAX_DOWNLOAD_STORAGE_GB = intPreferencesKey("max_download_storage_gb")
         val DOWNLOAD_STORAGE_LOCATION = stringPreferencesKey("download_storage_location")
+        /**
+         * Auto-delete-after-watch: when ON, a downloaded item is removed from
+         * disk once it reaches 100% played. This is an unrequested,
+         * destructive, opt-in behaviour; see
+         * `PlayedStateSync.maybeAutoDeleteAfterWatch`. Default OFF.
+         */
+        val AUTO_DELETE_AFTER_WATCH = booleanPreferencesKey("auto_delete_after_watch")
         val CELLULAR_DOWNLOAD_SIZE_WARNING_MB = intPreferencesKey("cellular_download_size_warning_mb")
         val DOWNLOAD_SCHEDULE_ENABLED = booleanPreferencesKey("download_schedule_enabled")
         val DOWNLOAD_SCHEDULE_START = intPreferencesKey("download_schedule_start")
@@ -81,6 +88,7 @@ class DownloadsStore @Inject constructor(
         autoDownloadNewEpisodes = PreferenceCodec.readBool(prefs, Keys.AUTO_DOWNLOAD_NEW_EPISODES, "auto_download_new_episodes", false),
         maxDownloadStorageGb = PreferenceCodec.readInt(prefs, Keys.MAX_DOWNLOAD_STORAGE_GB, "max_download_storage_gb", 0),
         downloadStorageLocation = prefs[Keys.DOWNLOAD_STORAGE_LOCATION] ?: "INTERNAL",
+        autoDeleteAfterWatch = prefs[Keys.AUTO_DELETE_AFTER_WATCH] ?: false,
         cellularDownloadSizeWarningMb = PreferenceCodec.readInt(prefs, Keys.CELLULAR_DOWNLOAD_SIZE_WARNING_MB, "cellular_download_size_warning_mb", 0),
         downloadScheduleEnabled = prefs[Keys.DOWNLOAD_SCHEDULE_ENABLED] ?: false,
         downloadScheduleWindow = DownloadScheduleWindow(
@@ -130,6 +138,10 @@ class DownloadsStore @Inject constructor(
         dataStore.edit { it[Keys.DOWNLOAD_STORAGE_LOCATION] = location }
     }
 
+    suspend fun setAutoDeleteAfterWatch(enabled: Boolean) {
+        dataStore.edit { it[Keys.AUTO_DELETE_AFTER_WATCH] = enabled }
+    }
+
     suspend fun setCellularDownloadSizeWarningMb(sizeMb: Int) {
         dataStore.edit { it[Keys.CELLULAR_DOWNLOAD_SIZE_WARNING_MB] = sizeMb }
     }
@@ -156,6 +168,7 @@ class DownloadsStore @Inject constructor(
         Keys.WIFI_ONLY_DOWNLOADS, Keys.DOWNLOAD_CONNECTIONS, Keys.MAX_CONCURRENT_DOWNLOADS,
         Keys.DOWNLOAD_QUALITY, Keys.SMART_DOWNLOADS_ENABLED, Keys.AUTO_DOWNLOAD_NEW_EPISODES,
         Keys.MAX_DOWNLOAD_STORAGE_GB, Keys.DOWNLOAD_STORAGE_LOCATION,
+        Keys.AUTO_DELETE_AFTER_WATCH,
         Keys.CELLULAR_DOWNLOAD_SIZE_WARNING_MB,
         Keys.DOWNLOAD_SCHEDULE_ENABLED, Keys.DOWNLOAD_SCHEDULE_START,
         Keys.DOWNLOAD_SCHEDULE_END, Keys.DOWNLOAD_SCHEDULE_WIFI_ONLY,
@@ -176,6 +189,7 @@ class DownloadsStore @Inject constructor(
             Keys.AUTO_DOWNLOAD_NEW_EPISODES,
             Keys.MAX_DOWNLOAD_STORAGE_GB,
             Keys.DOWNLOAD_STORAGE_LOCATION,
+            Keys.AUTO_DELETE_AFTER_WATCH,
             Keys.CELLULAR_DOWNLOAD_SIZE_WARNING_MB,
             Keys.DOWNLOAD_SCHEDULE_ENABLED,
             Keys.DOWNLOAD_SCHEDULE_START,
@@ -227,6 +241,7 @@ class DownloadsStore @Inject constructor(
             it[Keys.AUTO_DOWNLOAD_NEW_EPISODES] = slice.autoDownloadNewEpisodes
             it[Keys.MAX_DOWNLOAD_STORAGE_GB] = slice.maxDownloadStorageGb
             it[Keys.DOWNLOAD_STORAGE_LOCATION] = slice.downloadStorageLocation
+            it[Keys.AUTO_DELETE_AFTER_WATCH] = slice.autoDeleteAfterWatch
             it[Keys.CELLULAR_DOWNLOAD_SIZE_WARNING_MB] = slice.cellularDownloadSizeWarningMb
             it[Keys.DOWNLOAD_SCHEDULE_ENABLED] = slice.downloadScheduleEnabled
             it[Keys.DOWNLOAD_SCHEDULE_START] = slice.downloadScheduleWindow.startHour
@@ -251,6 +266,7 @@ data class DownloadsSlice(
     val autoDownloadNewEpisodes: Boolean = false,
     val maxDownloadStorageGb: Int = 0,
     val downloadStorageLocation: String = "INTERNAL",
+    val autoDeleteAfterWatch: Boolean = false,
     val cellularDownloadSizeWarningMb: Int = 0,
     val downloadScheduleEnabled: Boolean = false,
     val downloadScheduleWindow: DownloadScheduleWindow = DownloadScheduleWindow(),

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/experimental/ExperimentalStore.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/experimental/ExperimentalStore.kt
@@ -31,8 +31,9 @@ import javax.inject.Singleton
 /**
  * Deep module owning the **experimental features + misc app / update** preference
  * domain: the opt-in experimental feature set (JSON), the self-update check
- * toggle, the app language override, the share-media / search-history /
- * audio-description toggles, and the dismissed-update one-time state.
+ * + auto-download toggles, the app language override, the share-media /
+ * search-history / audio-description toggles, and the dismissed-update
+ * one-time state.
  *
  * Extracted from the `UserPreferencesStore` god object so this concern owns its
  * keys, setters, read projection, JSON memoisation, and reset list end-to-end.
@@ -56,8 +57,9 @@ import javax.inject.Singleton
  * legacy `UserPreferencesStore.Keys` names — no migration file.
  *
  * **Codec note:** none of the booleans owned here
- * (`self_update_check_enabled`, `show_share_media_option`,
- * `hide_search_history`, `prefer_audio_description`) appear in the legacy-string
+ * (`self_update_check_enabled`, `self_update_download_enabled`,
+ * `show_share_media_option`, `hide_search_history`,
+ * `prefer_audio_description`) appear in the legacy-string
  * → typed-key migration lists, so they are read with plain `prefs[key] ?: default`.
  */
 @Singleton
@@ -72,6 +74,7 @@ class ExperimentalStore @Inject constructor(
     internal object Keys {
         val ENABLED_EXPERIMENTAL_FEATURES = stringPreferencesKey("enabled_experimental_features")
         val SELF_UPDATE_CHECK_ENABLED = booleanPreferencesKey("self_update_check_enabled")
+        val SELF_UPDATE_DOWNLOAD_ENABLED = booleanPreferencesKey("self_update_download_enabled")
         val APP_LANGUAGE = stringPreferencesKey("app_language")
         val SHOW_SHARE_MEDIA_OPTION = booleanPreferencesKey("show_share_media_option")
         val HIDE_SEARCH_HISTORY = booleanPreferencesKey("hide_search_history")
@@ -100,6 +103,7 @@ class ExperimentalStore @Inject constructor(
     internal fun read(prefs: Preferences): ExperimentalSlice = ExperimentalSlice(
         enabledExperimentalFeatures = readEnabledExperimentalFeatures(prefs),
         selfUpdateCheckEnabled = prefs[Keys.SELF_UPDATE_CHECK_ENABLED] ?: true,
+        selfUpdateDownloadEnabled = prefs[Keys.SELF_UPDATE_DOWNLOAD_ENABLED] ?: false,
         appLanguage = prefs[Keys.APP_LANGUAGE],
         showShareMediaOption = prefs[Keys.SHOW_SHARE_MEDIA_OPTION] ?: true,
         hideSearchHistory = prefs[Keys.HIDE_SEARCH_HISTORY] ?: false,
@@ -136,6 +140,15 @@ class ExperimentalStore @Inject constructor(
 
     suspend fun setSelfUpdateCheckEnabled(enabled: Boolean) {
         dataStore.edit { it[Keys.SELF_UPDATE_CHECK_ENABLED] = enabled }
+    }
+
+    /**
+     * When enabled, an available update's APK begins downloading immediately
+     * after a check instead of waiting for the user to tap Download. Defaults
+     * to off; can be toggled from Settings (About) or from the update sheet.
+     */
+    suspend fun setSelfUpdateDownloadEnabled(enabled: Boolean) {
+        dataStore.edit { it[Keys.SELF_UPDATE_DOWNLOAD_ENABLED] = enabled }
     }
 
     suspend fun setAppLanguage(language: String?) {
@@ -200,6 +213,7 @@ class ExperimentalStore @Inject constructor(
         )
         PreferenceResetCategory.MISC_APP -> listOf(
             Keys.SELF_UPDATE_CHECK_ENABLED,
+            Keys.SELF_UPDATE_DOWNLOAD_ENABLED,
             Keys.SHOW_SHARE_MEDIA_OPTION,
             Keys.HIDE_SEARCH_HISTORY,
         )
@@ -220,6 +234,7 @@ class ExperimentalStore @Inject constructor(
         dataStore.edit { it ->
             it[Keys.ENABLED_EXPERIMENTAL_FEATURES] = json.encodeToString(userPreferences.enabledExperimentalFeatures.map { feature -> feature.name }.toSet())
             it[Keys.SELF_UPDATE_CHECK_ENABLED] = userPreferences.selfUpdateCheckEnabled
+            it[Keys.SELF_UPDATE_DOWNLOAD_ENABLED] = userPreferences.selfUpdateDownloadEnabled
             userPreferences.appLanguage?.let { language -> it[Keys.APP_LANGUAGE] = language }
             it[Keys.SHOW_SHARE_MEDIA_OPTION] = userPreferences.showShareMediaOption
             it[Keys.HIDE_SEARCH_HISTORY] = userPreferences.hideSearchHistory
@@ -241,6 +256,7 @@ class ExperimentalStore @Inject constructor(
         dataStore.edit { it ->
             it[Keys.ENABLED_EXPERIMENTAL_FEATURES] = json.encodeToString(slice.enabledExperimentalFeatures.map { feature -> feature.name }.toSet())
             it[Keys.SELF_UPDATE_CHECK_ENABLED] = slice.selfUpdateCheckEnabled
+            it[Keys.SELF_UPDATE_DOWNLOAD_ENABLED] = slice.selfUpdateDownloadEnabled
             slice.appLanguage?.let { language -> it[Keys.APP_LANGUAGE] = language }
             it[Keys.SHOW_SHARE_MEDIA_OPTION] = slice.showShareMediaOption
             it[Keys.HIDE_SEARCH_HISTORY] = slice.hideSearchHistory
@@ -264,6 +280,7 @@ class ExperimentalStore @Inject constructor(
 data class ExperimentalSlice(
     val enabledExperimentalFeatures: Set<ExperimentalFeature> = emptySet(),
     val selfUpdateCheckEnabled: Boolean = true,
+    val selfUpdateDownloadEnabled: Boolean = false,
     val appLanguage: String? = null,
     val showShareMediaOption: Boolean = true,
     val hideSearchHistory: Boolean = false,

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/library/LibraryStore.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/library/LibraryStore.kt
@@ -60,6 +60,7 @@ class LibraryStore @Inject constructor(
         val COMPACT_EPISODE_LIST = booleanPreferencesKey("compact_episode_list")
         val LIBRARY_POSTER_SIZE = floatPreferencesKey("library_poster_size")
         val LIBRARY_GROUP_BY = stringPreferencesKey("library_group_by")
+        val CONFIRM_LIBRARY_RESET = booleanPreferencesKey("confirm_library_reset")
     }
 
     private var cachedDefaultLibrarySortOrders = ParsedCache<Map<String, String>>(null, emptyMap())
@@ -85,7 +86,10 @@ class LibraryStore @Inject constructor(
         compactEpisodeList = PreferenceCodec.readBool(prefs, Keys.COMPACT_EPISODE_LIST, "compact_episode_list", false),
         libraryPosterSize = prefs[Keys.LIBRARY_POSTER_SIZE] ?: DEFAULT_POSTER_SIZE,
         libraryGroupBy = readGroupBy(prefs),
+        confirmLibraryReset = readConfirmLibraryReset(prefs),
     )
+
+    private fun readConfirmLibraryReset(prefs: Preferences): Boolean = prefs[Keys.CONFIRM_LIBRARY_RESET] ?: true
 
     private fun readLibraryViewMode(prefs: Preferences): LibraryViewMode = try {
         LibraryViewMode.valueOf(prefs[Keys.LIBRARY_VIEW_MODE] ?: LibraryViewMode.GRID.name)
@@ -187,6 +191,10 @@ class LibraryStore @Inject constructor(
         dataStore.edit { it[Keys.LIBRARY_GROUP_BY] = groupBy.name }
     }
 
+    suspend fun setConfirmLibraryReset(enabled: Boolean) {
+        dataStore.edit { it[Keys.CONFIRM_LIBRARY_RESET] = enabled }
+    }
+
     /**
      * Keys owned by this store, for factory-reset participation. These are the
      * library-view/sort/filter + episode keys split out of the legacy
@@ -198,6 +206,7 @@ class LibraryStore @Inject constructor(
         Keys.HIDE_EPISODE_THUMBNAILS, Keys.EPISODES_DESCENDING, Keys.SKIP_SPECIALS,
         Keys.COMPACT_EPISODE_LIST,
         Keys.LIBRARY_POSTER_SIZE, Keys.LIBRARY_GROUP_BY,
+        Keys.CONFIRM_LIBRARY_RESET,
     )
 
     /**
@@ -212,6 +221,7 @@ class LibraryStore @Inject constructor(
             Keys.HIDE_EPISODE_THUMBNAILS, Keys.EPISODES_DESCENDING, Keys.SKIP_SPECIALS,
             Keys.COMPACT_EPISODE_LIST,
             Keys.LIBRARY_POSTER_SIZE, Keys.LIBRARY_GROUP_BY,
+            Keys.CONFIRM_LIBRARY_RESET,
         )
         else -> emptyList()
     }
@@ -233,6 +243,7 @@ class LibraryStore @Inject constructor(
             it[Keys.EPISODES_DESCENDING] = userPreferences.episodesDescending
             it[Keys.SKIP_SPECIALS] = userPreferences.skipSpecials
             it[Keys.COMPACT_EPISODE_LIST] = userPreferences.compactEpisodeList
+            it[Keys.CONFIRM_LIBRARY_RESET] = true
         }
     }
 
@@ -253,6 +264,7 @@ class LibraryStore @Inject constructor(
             it[Keys.COMPACT_EPISODE_LIST] = slice.compactEpisodeList
             it[Keys.LIBRARY_POSTER_SIZE] = slice.libraryPosterSize
             it[Keys.LIBRARY_GROUP_BY] = slice.libraryGroupBy.name
+            it[Keys.CONFIRM_LIBRARY_RESET] = slice.confirmLibraryReset
         }
     }
 }
@@ -283,4 +295,5 @@ data class LibrarySlice(
     val compactEpisodeList: Boolean = false,
     val libraryPosterSize: Float = DEFAULT_POSTER_SIZE,
     val libraryGroupBy: GroupBy = GroupBy.NONE,
+    val confirmLibraryReset: Boolean = true,
 )

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/settings/PreferenceProjections.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/settings/PreferenceProjections.kt
@@ -363,6 +363,7 @@ class PreferenceProjections @Inject constructor(
                 autoDownloadNewEpisodes = downloads.autoDownloadNewEpisodes,
                 maxDownloadStorageGb = downloads.maxDownloadStorageGb,
                 downloadStorageLocation = downloads.downloadStorageLocation,
+                autoDeleteAfterWatch = downloads.autoDeleteAfterWatch,
                 manualOfflineEnabled = network.manualOfflineEnabled,
                 autoOfflineEnabled = network.autoOfflineEnabled,
                 maxCacheSizeMb = network.maxCacheSizeMb,

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/settings/PreferenceProjections.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/settings/PreferenceProjections.kt
@@ -484,6 +484,7 @@ class PreferenceProjections @Inject constructor(
             hideEpisodeThumbnails = g1.library.hideEpisodeThumbnails,
             skipSpecials = g1.library.skipSpecials,
             compactEpisodeList = g1.library.compactEpisodeList,
+            confirmLibraryReset = g1.library.confirmLibraryReset,
             showExternalRatings = g1.home.showExternalRatings,
             showShareMediaOption = g1.experimental.showShareMediaOption,
             hideSearchHistory = g1.experimental.hideSearchHistory,

--- a/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/settings/UserPreferencesSnapshotBuilder.kt
+++ b/core/datastore/src/main/java/com/raulshma/jellyplay/core/datastore/settings/UserPreferencesSnapshotBuilder.kt
@@ -259,6 +259,7 @@ fun buildUserPreferencesSnapshot(
     hiddenNavItems = navigation.hiddenNavItems,
     navItemOrder = navigation.navItemOrder,
     selfUpdateCheckEnabled = experimental.selfUpdateCheckEnabled,
+    selfUpdateDownloadEnabled = experimental.selfUpdateDownloadEnabled,
     dismissedUpdateVersion = experimental.dismissedUpdateVersion,
     dismissedUpdateAtMs = experimental.dismissedUpdateAtMs,
     watchLaterPlaylistId = runtime.watchLaterPlaylistId,

--- a/core/datastore/src/test/java/com/raulshma/jellyplay/core/datastore/experimental/ExperimentalStoreTest.kt
+++ b/core/datastore/src/test/java/com/raulshma/jellyplay/core/datastore/experimental/ExperimentalStoreTest.kt
@@ -54,6 +54,7 @@ class ExperimentalStoreTest {
         val slice = store.experimental.first()
         assertTrue(slice.enabledExperimentalFeatures.isEmpty())
         assertTrue(slice.selfUpdateCheckEnabled)
+        assertFalse(slice.selfUpdateDownloadEnabled)
         assertNull(slice.appLanguage)
         assertTrue(slice.showShareMediaOption)
         assertFalse(slice.hideSearchHistory)
@@ -85,6 +86,12 @@ class ExperimentalStoreTest {
     fun `setSelfUpdateCheckEnabled round-trips`() = runTest {
         store.setSelfUpdateCheckEnabled(false)
         assertFalse(store.experimental.first().selfUpdateCheckEnabled)
+    }
+
+    @Test
+    fun `setSelfUpdateDownloadEnabled round-trips`() = runTest {
+        store.setSelfUpdateDownloadEnabled(true)
+        assertTrue(store.experimental.first().selfUpdateDownloadEnabled)
     }
 
     @Test

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/ItemKindFilter.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/ItemKindFilter.kt
@@ -6,11 +6,8 @@ import androidx.compose.runtime.Immutable
  * Which nested media kinds a library item query excludes by default.
  *
  * Library browsing shows top-level items (movies, shows) — seasons and
- * episodes are both excluded. Section mode ("See All" from a home Latest row)
- * must reproduce what the home `/Items/Latest` row showed, which is leaf
- * items: episodes included, seasons still excluded. The two exclusions travel
- * together for every caller, so they're bundled here instead of being two
- * loose booleans.
+ * episodes are both excluded. The two exclusions travel together for every
+ * caller, so they're bundled here instead of being two loose booleans.
  */
 @Immutable
 data class ItemKindFilter(
@@ -24,8 +21,5 @@ data class ItemKindFilter(
     companion object {
         /** Top-level library browsing: seasons and episodes both excluded. */
         val TOP_LEVEL = ItemKindFilter()
-
-        /** Leaf items: episodes included, seasons still excluded. */
-        val LEAF_ITEMS = ItemKindFilter(includeEpisodes = true)
     }
 }

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryBrowserReducer.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryBrowserReducer.kt
@@ -1,0 +1,149 @@
+package com.raulshma.jellyplay.core.model
+
+/**
+ * Pure transitions for [LibraryBrowserState]. No Android, no DataStore, no
+ * coroutines — the deep module: one interface, one place to test the invariants.
+ *
+ * Each `reduceX` returns a new immutable state; it does **not** write to disk.
+ * Persistence is a side effect the VM performs *after* a transition, gated by
+ * [shouldPersistPerFolder] — a single boolean derived from state, not a
+ * hand-written guard at each site.
+ *
+ * The precedence rule ([resolveViewMode]) is computed in **one** place. This
+ * replaces the two divergent derivation paths the old VM had:
+ *  - the async collector (`loadViewMode()`) — full 3-tier rule;
+ *  - the sync `selectFolder()` — only per-folder or global, **omitting**
+ *    `defaultViewMode()`.
+ * `selectFolder` here applies the full 3-tier rule, making the old divergence
+ * an asserted invariant (see `LibraryBrowserReducerTest`).
+ */
+object LibraryBrowserReducer {
+
+    /**
+     * Resolve view-mode precedence: per-folder override > collectionType default
+     * (via [LibraryFolder.defaultViewMode]) > global.
+     *
+     * Per-folder overrides are ignored while a section (See-All deep-link) is
+     * active: the synthetic section folder's id must never be read as a real
+     * library's saved view mode.
+     */
+    fun resolveViewMode(
+        current: LibraryBrowserState,
+        perFolderOverride: LibraryViewMode?,
+        globalDefault: LibraryViewMode,
+    ): LibraryViewMode = when {
+        perFolderOverride != null && !current.isSection -> perFolderOverride
+        current.folder?.defaultViewMode() != null -> current.folder.defaultViewMode()!!
+        else -> globalDefault
+    }
+
+    /**
+     * Select a (real or synthetic) folder. Decoding saved filters/sort from the
+     * persisted blob is the caller's job (it owns the store + Json) — pass the
+     * decoded [filters] in. View mode is recomputed via [resolveViewMode] so a
+     * folder with a collectionType default (e.g. music → LIST) is honoured even
+     * with no explicit saved override — the divergence the old `selectFolder()`
+     * had is fixed here.
+     */
+    fun selectFolder(
+        current: LibraryBrowserState,
+        folder: LibraryFolder?,
+        filters: LibraryFilters,
+        perFolderOverride: LibraryViewMode?,
+        globalDefault: LibraryViewMode,
+    ): LibraryBrowserState {
+        val next = current.copy(folder = folder, filters = filters, sectionContext = null, title = null)
+        return next.copy(viewMode = resolveViewMode(next, perFolderOverride, globalDefault))
+    }
+
+    /**
+     * Enter a home-section "See-All" deep-link. Scopes to the section's synthetic
+     * folder + pre-applied sort/media-type filter, and marks the state as a
+     * section so per-folder persistence is gated off.
+     */
+    fun configureSection(current: LibraryBrowserState, ctx: LibrarySectionContext): LibraryBrowserState {
+        val folder = ctx.parentId?.let {
+            LibraryFolder(id = it, name = ctx.title, collectionType = ctx.collectionType)
+        }
+        val sectionSort = ctx.sortBy?.let { api ->
+            SortOption.entries.firstOrNull { it.apiValue == api || it.name == api }
+        } ?: SortOption.DATE_ADDED
+        // "See All" from a home Latest row mirrors the default library tab view
+        // (top-level items) and differs only in sort order (latest first).
+        // Explicit ctx.mediaTypes (if passed) still win.
+        val filters = LibraryFilters(sortBy = sectionSort, mediaTypes = ctx.mediaTypes)
+        return current.copy(
+            folder = folder,
+            title = ctx.title,
+            filters = filters,
+            sectionContext = ctx,
+        )
+    }
+
+    /**
+     * Tear down section mode and return to the default browsing view. Idempotent
+     * (a no-op when [LibraryBrowserState.isSection] is already false).
+     */
+    fun clearSectionMode(current: LibraryBrowserState): LibraryBrowserState {
+        if (!current.isSection) return current
+        return current.copy(
+            sectionContext = null,
+            title = null,
+            folder = null,
+            filters = LibraryFilters(),
+        )
+    }
+
+    /** Explicit user view-mode tap. Does not touch persistence. */
+    fun setViewMode(current: LibraryBrowserState, mode: LibraryViewMode): LibraryBrowserState =
+        current.copy(viewMode = mode)
+
+    /** Replace the active filters (e.g. from the filter sheet). Does not persist. */
+    fun updateFilters(current: LibraryBrowserState, filters: LibraryFilters): LibraryBrowserState =
+        current.copy(filters = filters)
+
+    /** Change the client-side grouping dimension. Does not persist. */
+    fun setGroupBy(current: LibraryBrowserState, groupBy: GroupBy): LibraryBrowserState =
+        current.copy(groupBy = groupBy)
+
+    /** Change the poster-size multiplier. Does not persist. */
+    fun setPosterSize(current: LibraryBrowserState, size: Float): LibraryBrowserState =
+        current.copy(posterSize = size)
+
+    /**
+     * Reset the whole browser to defaults: clear filters, drop the folder + title,
+     * restore poster size / grouping, and recompute the view mode from the global
+     * default. Any active section is torn down. Returns whether the reset touched
+     * a real (non-section) folder so the caller can persist a clean slate for it.
+     */
+    fun resetToDefault(
+        current: LibraryBrowserState,
+        globalDefault: LibraryViewMode,
+    ): ResetResult {
+        val wasInSection = current.isSection
+        val realFolderBeforeReset = current.folder
+        val next = LibraryBrowserState(
+            viewMode = globalDefault,
+            posterSize = DEFAULT_POSTER_SIZE,
+            groupBy = GroupBy.NONE,
+        )
+        // Persist a clean slate for the real folder the user was viewing (never a
+        // synthetic section parentId — that must never be written as a library key).
+        val folderToClean = if (!wasInSection) realFolderBeforeReset?.id else null
+        return ResetResult(state = next, realFolderIdToClean = folderToClean)
+    }
+
+    data class ResetResult(
+        val state: LibraryBrowserState,
+        /** Non-null only when the reset cleared a real (non-section) folder. */
+        val realFolderIdToClean: String?,
+    )
+
+    /**
+     * Does this transition deserve a per-folder write? False for synthetic section
+     * folders and when no folder is selected. Replaces the hand-written
+     * `_sectionContext.value == null` guard at each persist site.
+     */
+    fun shouldPersistPerFolder(state: LibraryBrowserState): Boolean =
+        !state.isSection && state.folder != null
+}

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryBrowserState.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryBrowserState.kt
@@ -1,0 +1,46 @@
+package com.raulshma.jellyplay.core.model
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Factory-default poster-size multiplier (matches the toolbar slider's 1.0 center).
+ *
+ * Promoted to core/model from a private VM const so [LibraryBrowserState] and
+ * [LibraryBrowserReducer] can reference the canonical default. A separate
+ * same-named const in [com.raulshma.jellyplay.core.datastore.library.LibraryStore]
+ * predates this one and remains the store's own default; they intentionally agree.
+ */
+const val DEFAULT_POSTER_SIZE: Float = 1.0f
+
+/**
+ * One immutable value type owning the entire library *browser* view-state as a
+ * consistent unit: which folder, which filters, which view mode, grouping,
+ * poster size, the active section context, and the toolbar title.
+ *
+ * This collapses the swarm of individual StateFlows that previously lived in
+ * `LibraryViewModel` (the 18-flow "swarm"). The invariants the VM used to enforce
+ * by hand-scattered guards now live as properties/derivation rules:
+ *
+ * - "is the user in a See-All deep-link section?" → [isSection] (derived from
+ *   [sectionContext]), replacing the hand-written `_sectionContext.value == null`
+ *   guards at three persistence sites.
+ * - view-mode precedence ("per-folder override > collectionType default > global")
+ *   → a single rule in [LibraryBrowserReducer.resolveViewMode], replacing the two
+ *   divergent derivation paths in the old VM.
+ *
+ * "Synthetic folder" — a section-mode `parentId` that must never be written as a
+ * per-library key — becomes [isSection], not a guard at every persist site.
+ */
+@Immutable
+data class LibraryBrowserState(
+    val folder: LibraryFolder? = null,
+    val filters: LibraryFilters = LibraryFilters(),
+    val viewMode: LibraryViewMode = LibraryViewMode.GRID,
+    val posterSize: Float = DEFAULT_POSTER_SIZE,
+    val groupBy: GroupBy = GroupBy.NONE,
+    val sectionContext: LibrarySectionContext? = null,
+    val title: String? = null,
+) {
+    /** True while a section (See-All deep link) is active — gates per-folder persistence. */
+    val isSection: Boolean get() = sectionContext != null
+}

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryFilters.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryFilters.kt
@@ -1,0 +1,31 @@
+package com.raulshma.jellyplay.core.model
+
+import androidx.compose.runtime.Immutable
+import kotlinx.serialization.Serializable
+
+/**
+ * The active filter/sort state for a library browsing session.
+ *
+ * Promoted to core/model from the feature module so [LibraryBrowserState] and
+ * [LibraryBrowserReducer] can live here too and be unit-tested without the
+ * feature classpath. Its dependencies ([SortOption], [MediaType], [PlayedStatus])
+ * already lived in core/model; this only sat in the feature module by accident.
+ *
+ * Serialised by name (kotlinx.serialization encodes enums as their `.name`) so
+ * the on-disk wire format is unchanged from the legacy `SavedLibraryFilters`
+ * mirror — see [LibraryFiltersSerializationTest].
+ */
+@Immutable
+@Serializable
+data class LibraryFilters(
+    val mediaTypes: List<MediaType> = emptyList(),
+    val genres: List<String> = emptyList(),
+    val years: List<Int> = emptyList(),
+    // Newest (highest production year first) is the most useful landing sort for
+    // a media library — a user opening the tab wants to see fresh content, not an
+    // alphabetical list. Overridden per-folder by the persisted filter blob.
+    val sortBy: SortOption = SortOption.YEAR_DESC,
+    val playedStatus: PlayedStatus = PlayedStatus.ALL,
+    val tags: List<String> = emptyList(),
+    val minRating: Float = 0f,
+)

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryGrouper.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/LibraryGrouper.kt
@@ -1,0 +1,38 @@
+package com.raulshma.jellyplay.core.model
+
+/**
+ * Pure grouping logic for the library grid, lifted out of `GroupedLibraryContent`
+ * so it can be unit-tested. This was the site of two #113 crashes (duplicate
+ * lazy keys from scattered group labels, and a throw on [GroupBy.NONE] while a
+ * grouped view was transiently mounted) — both pinned by `LibraryGrouperTest`.
+ */
+object LibraryGrouper {
+
+    /**
+     * A group key derived from a [MediaItem] for the active [GroupBy] dimension.
+     *
+     * Returns an empty string for [GroupBy.NONE] instead of throwing: although the
+     * caller only mounts grouped rendering when grouping is active, the persisted
+     * [GroupBy] value flows in asynchronously and can transiently resolve to NONE
+     * while a grouped view is still mounted. Throwing here crashed the app on
+     * every library open once a non-NONE value had been persisted (issue #113).
+     */
+    fun groupKey(item: MediaItem, groupBy: GroupBy): String = when (groupBy) {
+        GroupBy.NONE -> ""
+        GroupBy.NAME -> (item.name.firstOrNull()?.uppercaseChar()?.takeIf { it in 'A'..'Z' } ?: '#').toString()
+        GroupBy.TYPE -> item.mediaType.name
+        GroupBy.GENRE -> item.genres.firstOrNull() ?: "Unknown"
+        GroupBy.YEAR -> item.year?.toString() ?: "Unknown"
+    }
+
+    /**
+     * Sort comparator that orders items to match the active [GroupBy] dimension,
+     * so groups come out contiguous when building header/item rows. Without this,
+     * grouping a snapshot that is server-sorted by a different dimension (e.g.
+     * Name) scatters the same group key across the list, which produced duplicate
+     * `"header_${key}"` lazy keys and crashed the app (issue #113). Within a group,
+     * the server's existing order is preserved (stable sort).
+     */
+    fun groupComparator(groupBy: GroupBy): Comparator<MediaItem> =
+        Comparator { a, b -> groupKey(a, groupBy).compareTo(groupKey(b, groupBy)) }
+}

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/PreferenceGroups.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/PreferenceGroups.kt
@@ -291,6 +291,7 @@ data class StoragePreferences(
     val autoDownloadNewEpisodes: Boolean = false,
     val maxDownloadStorageGb: Int = 0,
     val downloadStorageLocation: String = "INTERNAL",
+    val autoDeleteAfterWatch: Boolean = false,
     val manualOfflineEnabled: Boolean = false,
     val autoOfflineEnabled: Boolean = true,
     val maxCacheSizeMb: Int = 0,

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/PreferenceGroups.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/PreferenceGroups.kt
@@ -399,6 +399,8 @@ data class AppearanceScreenPreferences(
     val hideEpisodeThumbnails: Boolean = false,
     val skipSpecials: Boolean = false,
     val compactEpisodeList: Boolean = false,
+    /** Whether the library "Reset" pill shows a confirmation dialog before clearing. */
+    val confirmLibraryReset: Boolean = true,
     val showExternalRatings: Boolean = true,
     val showShareMediaOption: Boolean = true,
     val hideSearchHistory: Boolean = false,

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/SubtitleRenderDefaults.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/SubtitleRenderDefaults.kt
@@ -1,0 +1,132 @@
+package com.raulshma.jellyplay.core.model
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * The canonical "effective subtitle defaults" — a single immutable record of the
+ * rendering defaults every engine / the Compose overlay / the onboarding preview
+ * should consume, independent of any engine's native format.
+ *
+ * These values match [SubtitleStyle]'s own model defaults, making "defaults" mean
+ * one thing. Where an engine historically diverged (mpv's libass border = 3.0 /
+ * shadow = 0.0; ExoPlayer's 18sp + DROP_SHADOW), the engine keeps a **documented
+ * override** — never a silent inline literal — so the divergence is a conscious
+ * choice, not drift.
+ *
+ * Promoted to core/model (from feature/player/video's `SubtitleDefaults`, which
+ * only held two size constants) so [ResolvedSubtitleStyle] and the Compose
+ * `toCompose()` mapping in core/ui can live without depending on the feature
+ * module. The feature module's `SubtitleDefaults` remains the source of the
+ * mpv-specific [MPV_LIBASS_REFERENCE_FONT_SIZE] (a libass canvas concern).
+ */
+@Immutable
+data class SubtitleRenderDefaults(
+    val fontSizeSp: Int = REFERENCE_FONT_SIZE,   // 24
+    val fontColor: Int = SubtitleColor.WHITE.value,
+    val backgroundColor: Int = SubtitleColor.BLACK.value,
+    val backgroundAlpha: Float = 0f,
+    val edgeColor: Int = SubtitleColor.BLACK.value,
+    val edgeType: SubtitleEdgeType = SubtitleEdgeType.OUTLINE,
+    val borderWidth: Float = 2.0f,
+    val shadowOffset: Float = 1.0f,
+    val bold: Boolean = false,
+    val italic: Boolean = false,
+) {
+    companion object {
+        /** The reference subtitle font size (sp) every engine scales relative to. */
+        const val REFERENCE_FONT_SIZE: Int = 24
+
+        /** Canonical defaults matching [SubtitleStyle]'s zero-arg constructor. */
+        val DEFAULT: SubtitleRenderDefaults = SubtitleRenderDefaults()
+
+        /**
+         * ExoPlayer's **documented** divergence from [DEFAULT]: uncustomized
+         * captions render at 18sp + DROP_SHADOW (vs the 24sp + OUTLINE every other
+         * path uses). This is intentional — Media3's embedded-style path sizes
+         * captions against the view height, and the smaller size keeps them stable
+         * across orientation changes. Promoted from a silent inline literal in
+         * `ExoPlayerEngine.applySubtitleStyleToView` to a named override so the
+         * divergence is a conscious, discoverable choice rather than drift.
+         *
+         * To align ExoPlayer with the other engines, repoint the engine's default
+         * branch at [DEFAULT] instead.
+         */
+        val EXOPLAYER_OVERRIDE: SubtitleRenderDefaults = SubtitleRenderDefaults(
+            fontSizeSp = 18,
+            edgeType = SubtitleEdgeType.DROP_SHADOW,
+        )
+    }
+}
+
+/**
+ * Engine-neutral resolved subtitle magnitudes: ARGB ints + plain floats, no mpv
+ * property strings, no Compose `Color`. Engines map from this record to their
+ * native format; the Compose overlay and the onboarding preview map from this
+ * record to Compose `Color`/`TextStyle` via a `toCompose()` extension in core/ui.
+ *
+ * Generalizes feature/player/video's mpv-named `ResolvedMpvStyle` — same shape,
+ * no longer named after one engine.
+ */
+@Immutable
+data class ResolvedSubtitleStyle(
+    val fontColorArgb: Int,
+    val backgroundColorArgb: Int,
+    val backgroundAlpha: Float,
+    val edgeColorArgb: Int,
+    val edgeType: SubtitleEdgeType,
+    val borderWidth: Float,
+    val shadowOffset: Float,
+    val fontSizeSp: Int,
+    val bold: Boolean,
+    val italic: Boolean,
+    val verticalPosition: Float,
+    val offsetMs: Long,
+)
+
+/**
+ * Resolve a [SubtitleStyle] against [defaults] into an engine-neutral record.
+ *
+ * - When [SubtitleStyle.applyCustomStyle] is false, the [defaults] table wins
+ *   (only `verticalPosition` / `offsetMs` carry over, since they're layout not
+ *   styling).
+ * - When true, the user's free-form ARGB fields win over the enum colors
+ *   (`fontColorArgb ?: fontColor.value`), folding in what
+ *   feature/player/video's `SubtitleColorResolver` used to do module-locally.
+ *
+ * This is the single resolution entry point; engines and the Compose overlay
+ * read from the returned [ResolvedSubtitleStyle] instead of re-deriving.
+ */
+fun SubtitleStyle.resolveAgainst(
+    defaults: SubtitleRenderDefaults = SubtitleRenderDefaults.DEFAULT,
+): ResolvedSubtitleStyle =
+    if (!applyCustomStyle) {
+        ResolvedSubtitleStyle(
+            fontColorArgb = defaults.fontColor,
+            backgroundColorArgb = defaults.backgroundColor,
+            backgroundAlpha = defaults.backgroundAlpha,
+            edgeColorArgb = defaults.edgeColor,
+            edgeType = defaults.edgeType,
+            borderWidth = defaults.borderWidth,
+            shadowOffset = defaults.shadowOffset,
+            fontSizeSp = defaults.fontSizeSp,
+            bold = defaults.bold,
+            italic = defaults.italic,
+            verticalPosition = verticalPosition,
+            offsetMs = offsetMs,
+        )
+    } else {
+        ResolvedSubtitleStyle(
+            fontColorArgb = fontColorArgb ?: fontColor.value,
+            backgroundColorArgb = backgroundColorArgb ?: backgroundColor.value,
+            backgroundAlpha = backgroundOpacity,
+            edgeColorArgb = edgeColorArgb ?: edgeColor.value,
+            edgeType = edgeType,
+            borderWidth = borderWidth,
+            shadowOffset = shadowOffset,
+            fontSizeSp = fontSize,
+            bold = bold,
+            italic = italic,
+            verticalPosition = verticalPosition,
+            offsetMs = offsetMs,
+        )
+    }

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/WidgetConfig.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/WidgetConfig.kt
@@ -17,7 +17,16 @@ import kotlinx.serialization.Serializable
 data class WidgetConfig(
     val librarySource: LibraryRecommendationsSource = LibraryRecommendationsSource.LATEST,
     val seerrSource: SeerrWidgetSource = SeerrWidgetSource.TRENDING,
-)
+    val continueWatchingItemCount: Int = DEFAULT_CONTINUE_WATCHING_ITEM_COUNT,
+    val nowPlayingShowArtwork: Boolean = true,
+    val nowPlayingShowProgress: Boolean = true,
+) {
+    companion object {
+        const val DEFAULT_CONTINUE_WATCHING_ITEM_COUNT = 10
+        const val MIN_CONTINUE_WATCHING_ITEM_COUNT = 3
+        const val MAX_CONTINUE_WATCHING_ITEM_COUNT = 20
+    }
+}
 
 @Immutable
 @Serializable

--- a/core/model/src/main/java/com/raulshma/jellyplay/core/model/legacy/UserPreferences.kt
+++ b/core/model/src/main/java/com/raulshma/jellyplay/core/model/legacy/UserPreferences.kt
@@ -263,6 +263,11 @@ data class UserPreferences(
     val navItemOrder: List<String> = emptyList(),
     val selfUpdateCheckEnabled: Boolean = true,
     /**
+     * When enabled, an available update's APK downloads immediately after a
+     * check instead of waiting for the user to tap Download on the prompt.
+     */
+    val selfUpdateDownloadEnabled: Boolean = false,
+    /**
      * Version of the last update the user dismissed via "Later"/"Close", plus
      * the wall-clock millis at which it was dismissed. Used to suppress the
      * launch-time auto-prompt for the same version for 24 hours. Manual checks

--- a/core/model/src/test/java/com/raulshma/jellyplay/core/model/LibraryBrowserReducerTest.kt
+++ b/core/model/src/test/java/com/raulshma/jellyplay/core/model/LibraryBrowserReducerTest.kt
@@ -1,0 +1,214 @@
+package com.raulshma.jellyplay.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM tests for the pure [LibraryBrowserReducer]. No Compose, no Robolectric,
+ * no MockK — the reducer's invariants are the single source of truth for the
+ * old hand-scattered guards in `LibraryViewModel`.
+ *
+ * The view-mode precedence test pins the divergence fix: the old `selectFolder()`
+ * omitted `defaultViewMode()`, so a music folder with no saved override rendered
+ * as a grid instead of a list. Here that's an asserted invariant.
+ */
+class LibraryBrowserReducerTest {
+
+    private val globalDefault = LibraryViewMode.GRID
+
+    // ---- resolveViewMode precedence (the single rule) ----
+
+    @Test
+    fun `resolveViewMode uses per-folder override when present`() {
+        val state = LibraryBrowserState(folder = LibraryFolder(id = "lib-1", name = "Movies"))
+        assertEquals(
+            LibraryViewMode.LIST,
+            LibraryBrowserReducer.resolveViewMode(state, perFolderOverride = LibraryViewMode.LIST, globalDefault),
+        )
+    }
+
+    @Test
+    fun `resolveViewMode ignores per-folder override in section mode`() {
+        // The section's synthetic parentId must never be read as a real library's
+        // saved view mode — so a per-folder override is discarded while in section.
+        val state = LibraryBrowserState(
+            folder = LibraryFolder(id = "lib-tv", name = "Latest Shows"),
+            sectionContext = LibrarySectionContext(title = "Latest Shows", parentId = "lib-tv"),
+        )
+        assertEquals(
+            globalDefault,
+            LibraryBrowserReducer.resolveViewMode(state, perFolderOverride = LibraryViewMode.LIST, globalDefault),
+        )
+    }
+
+    @Test
+    fun `resolveViewMode falls back to collectionType default`() {
+        // music → LIST. This is the divergence the old selectFolder() missed.
+        val state = LibraryBrowserState(folder = LibraryFolder(id = "lib-music", name = "Music", collectionType = "music"))
+        assertEquals(
+            LibraryViewMode.LIST,
+            LibraryBrowserReducer.resolveViewMode(state, perFolderOverride = null, globalDefault),
+        )
+    }
+
+    @Test
+    fun `resolveViewMode falls back to global default`() {
+        val state = LibraryBrowserState(folder = LibraryFolder(id = "lib-1", name = "Movies"))
+        assertEquals(
+            globalDefault,
+            LibraryBrowserReducer.resolveViewMode(state, perFolderOverride = null, globalDefault),
+        )
+    }
+
+    @Test
+    fun `resolveViewMode per-folder override beats collectionType default`() {
+        val state = LibraryBrowserState(folder = LibraryFolder(id = "lib-music", name = "Music", collectionType = "music"))
+        assertEquals(
+            LibraryViewMode.GRID,
+            LibraryBrowserReducer.resolveViewMode(state, perFolderOverride = LibraryViewMode.GRID, globalDefault),
+        )
+    }
+
+    // ---- selectFolder applies the full 3-tier rule (the divergence fix) ----
+
+    @Test
+    fun `selectFolder applies collectionType default with no saved override`() {
+        // The regression: a music folder with no saved view-mode override should
+        // land on LIST, not the global GRID. The old sync path omitted this tier.
+        val next = LibraryBrowserReducer.selectFolder(
+            current = LibraryBrowserState(),
+            folder = LibraryFolder(id = "lib-music", name = "Music", collectionType = "music"),
+            filters = LibraryFilters(),
+            perFolderOverride = null,
+            globalDefault = globalDefault,
+        )
+        assertEquals(LibraryViewMode.LIST, next.viewMode)
+    }
+
+    @Test
+    fun `selectFolder applies saved override`() {
+        val next = LibraryBrowserReducer.selectFolder(
+            current = LibraryBrowserState(),
+            folder = LibraryFolder(id = "lib-1", name = "Movies"),
+            filters = LibraryFilters(sortBy = SortOption.RATING),
+            perFolderOverride = LibraryViewMode.THUMB,
+            globalDefault = globalDefault,
+        )
+        assertEquals(LibraryViewMode.THUMB, next.viewMode)
+        assertEquals(SortOption.RATING, next.filters.sortBy)
+    }
+
+    @Test
+    fun `selectFolder with null folder clears folder and section`() {
+        val next = LibraryBrowserReducer.selectFolder(
+            current = LibraryBrowserState(
+                folder = LibraryFolder("lib-1", "Movies"),
+                sectionContext = LibrarySectionContext("x", parentId = "lib-1"),
+            ),
+            folder = null,
+            filters = LibraryFilters(),
+            perFolderOverride = null,
+            globalDefault = globalDefault,
+        )
+        assertNull(next.folder)
+        assertFalse(next.isSection)
+    }
+
+    // ---- configureSection / clearSectionMode round-trip ----
+
+    @Test
+    fun `configureSection scopes to synthetic folder and marks isSection`() {
+        val next = LibraryBrowserReducer.configureSection(
+            LibraryBrowserState(),
+            LibrarySectionContext(title = "Latest Movies", parentId = "lib-movies", collectionType = "movies", sortBy = SortOption.DATE_ADDED.apiValue),
+        )
+        assertEquals("lib-movies", next.folder?.id)
+        assertEquals("Latest Movies", next.title)
+        assertTrue(next.isSection)
+        assertEquals(SortOption.DATE_ADDED, next.filters.sortBy)
+    }
+
+    @Test
+    fun `clearSectionMode is a no-op when not in section`() {
+        val state = LibraryBrowserState(folder = LibraryFolder("lib-1", "Movies"))
+        val next = LibraryBrowserReducer.clearSectionMode(state)
+        assertEquals(state, next)
+    }
+
+    @Test
+    fun `configureSection then clearSectionMode round-trips to default browsing`() {
+        val sectioned = LibraryBrowserReducer.configureSection(
+            LibraryBrowserState(),
+            LibrarySectionContext(title = "Latest Shows", parentId = "lib-tv", collectionType = "tvshows", sortBy = SortOption.DATE_ADDED.apiValue),
+        )
+        val cleared = LibraryBrowserReducer.clearSectionMode(sectioned)
+        assertFalse(cleared.isSection)
+        assertNull(cleared.folder)
+        assertNull(cleared.title)
+        assertEquals(LibraryFilters(), cleared.filters)
+    }
+
+    // ---- shouldPersistPerFolder ----
+
+    @Test
+    fun `shouldPersistPerFolder is false for every section state`() {
+        val sectioned = LibraryBrowserReducer.configureSection(
+            LibraryBrowserState(),
+            LibrarySectionContext(title = "S", parentId = "lib-1"),
+        )
+        assertFalse(LibraryBrowserReducer.shouldPersistPerFolder(sectioned))
+    }
+
+    @Test
+    fun `shouldPersistPerFolder is true for a real folder`() {
+        val state = LibraryBrowserState(folder = LibraryFolder("lib-1", "Movies"))
+        assertTrue(LibraryBrowserReducer.shouldPersistPerFolder(state))
+    }
+
+    @Test
+    fun `shouldPersistPerFolder is false with no folder`() {
+        assertFalse(LibraryBrowserReducer.shouldPersistPerFolder(LibraryBrowserState()))
+    }
+
+    // ---- resetToDefault ----
+
+    @Test
+    fun `resetToDefault does not preserve a synthetic folder id`() {
+        val sectioned = LibraryBrowserReducer.configureSection(
+            LibraryBrowserState(),
+            LibrarySectionContext(title = "Latest", parentId = "lib-tv"),
+        )
+        val result = LibraryBrowserReducer.resetToDefault(sectioned, globalDefault)
+        assertNull(result.realFolderIdToClean)
+        assertNull(result.state.folder)
+        assertFalse(result.state.isSection)
+    }
+
+    @Test
+    fun `resetToDefault cleans a real folder id`() {
+        val state = LibraryBrowserState(folder = LibraryFolder("lib-1", "Movies"))
+        val result = LibraryBrowserReducer.resetToDefault(state, globalDefault)
+        assertEquals("lib-1", result.realFolderIdToClean)
+        assertEquals(DEFAULT_POSTER_SIZE, result.state.posterSize, 0.0001f)
+        assertEquals(GroupBy.NONE, result.state.groupBy)
+        assertEquals(globalDefault, result.state.viewMode)
+    }
+
+    // ---- simple setters ----
+
+    @Test
+    fun `setViewMode updateFilters setGroupBy setPosterSize only touch their field`() {
+        val s0 = LibraryBrowserState()
+        val s1 = LibraryBrowserReducer.setViewMode(s0, LibraryViewMode.LIST)
+        assertEquals(LibraryViewMode.LIST, s1.viewMode)
+        val s2 = LibraryBrowserReducer.updateFilters(s1, LibraryFilters(sortBy = SortOption.RATING))
+        assertEquals(SortOption.RATING, s2.filters.sortBy)
+        val s3 = LibraryBrowserReducer.setGroupBy(s2, GroupBy.GENRE)
+        assertEquals(GroupBy.GENRE, s3.groupBy)
+        val s4 = LibraryBrowserReducer.setPosterSize(s3, 1.5f)
+        assertEquals(1.5f, s4.posterSize, 0.0001f)
+    }
+}

--- a/core/model/src/test/java/com/raulshma/jellyplay/core/model/LibraryFiltersSerializationTest.kt
+++ b/core/model/src/test/java/com/raulshma/jellyplay/core/model/LibraryFiltersSerializationTest.kt
@@ -1,25 +1,21 @@
-package com.raulshma.jellyplay.feature.library
+package com.raulshma.jellyplay.core.model
 
-import com.raulshma.jellyplay.core.model.MediaType
-import com.raulshma.jellyplay.core.model.PlayedStatus
-import com.raulshma.jellyplay.core.model.SortOption
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Round-trip + legacy-format tests for the now-directly-serializable
- * [LibraryFilters]. These pin two things:
+ * Round-trip + legacy-format tests for [LibraryFilters].
  *
- * 1. The on-disk wire format is unchanged after deleting `SavedLibraryFilters`
- *    (enums serialise by Kotlin `.name`, exactly what the String mirror stored).
- * 2. The decode resilience boundary (unknown enum → fallback) holds, since
- *    `Json { ignoreUnknownKeys = true }` does not suppress unknown enum
- *    constants — that path stays wrapped in try/catch at the call site.
+ * Moved to core/model alongside the type (the type was promoted out of the
+ * feature module so [LibraryBrowserState]/[LibraryBrowserReducer] can live in
+ * core/model). The on-disk wire format is unchanged from the legacy
+ * `SavedLibraryFilters` mirror — enums serialise by Kotlin `.name`, exactly what
+ * the String mirror stored.
  */
 class LibraryFiltersSerializationTest {
 
-    // Mirrors the private `libraryJson` in LibraryViewModel.kt — same flags.
+    // Mirrors the `libraryJson` in LibraryViewModel.kt — same flags.
     private val json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
@@ -47,8 +43,6 @@ class LibraryFiltersSerializationTest {
     fun `decodes the legacy SavedLibraryFilters wire format`() {
         // Exact JSON shape the deleted String-typed mirror used to emit:
         // enum fields stored as their .name, everything else as-is.
-        // `encodeDefaults` on the mirror guaranteed all 7 keys were present,
-        // but decode must also tolerate any subset (older backups).
         val legacy = """
             {
               "mediaTypes": ["MOVIE", "EPISODE"],
@@ -101,8 +95,6 @@ class LibraryFiltersSerializationTest {
 
     @Test
     fun `unknown object keys are ignored on decode`() {
-        // Forward-compatibility: a future field added to LibraryFilters and
-        // then removed again must not poison older decoders.
         val decoded = json.decodeFromString<LibraryFilters>(
             """{"sortBy":"RATING","futureField":42}""",
         )

--- a/core/model/src/test/java/com/raulshma/jellyplay/core/model/LibraryGrouperTest.kt
+++ b/core/model/src/test/java/com/raulshma/jellyplay/core/model/LibraryGrouperTest.kt
@@ -1,0 +1,98 @@
+package com.raulshma.jellyplay.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * JVM tests for [LibraryGrouper] — the pure grouping logic lifted out of
+ * `GroupedLibraryContent`. Pins the two #113 crash paths: the throw on
+ * [GroupBy.NONE] and the duplicate-lazy-key scatter from an unsorted snapshot.
+ */
+class LibraryGrouperTest {
+
+    private fun item(id: String, name: String, mediaType: MediaType = MediaType.MOVIE, year: Int? = null, genres: List<String> = emptyList()) =
+        MediaItem(id = id, name = name, mediaType = mediaType, year = year, genres = genres)
+
+    // ---- groupKey ----
+
+    @Test
+    fun `groupKey NONE returns empty string instead of throwing`() {
+        // Issue #113: persisted GroupBy flows in async and can transiently be NONE
+        // while a grouped view is mounted. Throwing crashed the app on open.
+        assertEquals("", LibraryGrouper.groupKey(item("1", "Anything"), GroupBy.NONE))
+    }
+
+    @Test
+    fun `groupKey NAME uppercases first letter`() {
+        assertEquals("A", LibraryGrouper.groupKey(item("1", "Apollo"), GroupBy.NAME))
+    }
+
+    @Test
+    fun `groupKey NAME falls back to hash for non-letter start`() {
+        assertEquals("#", LibraryGrouper.groupKey(item("1", "300"), GroupBy.NAME))
+        assertEquals("#", LibraryGrouper.groupKey(item("2", "Été"), GroupBy.NAME))
+        assertEquals("#", LibraryGrouper.groupKey(item("3", "_underscore"), GroupBy.NAME))
+    }
+
+    @Test
+    fun `groupKey NAME is case-insensitive`() {
+        assertEquals("B", LibraryGrouper.groupKey(item("1", "batman"), GroupBy.NAME))
+    }
+
+    @Test
+    fun `groupKey TYPE uses mediaType name`() {
+        assertEquals("MOVIE", LibraryGrouper.groupKey(item("1", "X", MediaType.MOVIE), GroupBy.TYPE))
+        assertEquals("SERIES", LibraryGrouper.groupKey(item("2", "Y", MediaType.SERIES), GroupBy.TYPE))
+    }
+
+    @Test
+    fun `groupKey GENRE uses first genre or Unknown`() {
+        assertEquals("Action", LibraryGrouper.groupKey(item("1", "X", genres = listOf("Action", "Drama")), GroupBy.GENRE))
+        assertEquals("Unknown", LibraryGrouper.groupKey(item("2", "X", genres = emptyList()), GroupBy.GENRE))
+    }
+
+    @Test
+    fun `groupKey YEAR uses year or Unknown`() {
+        assertEquals("2021", LibraryGrouper.groupKey(item("1", "X", year = 2021), GroupBy.YEAR))
+        assertEquals("Unknown", LibraryGrouper.groupKey(item("2", "X", year = null), GroupBy.YEAR))
+    }
+
+    // ---- groupComparator ----
+
+    @Test
+    fun `groupComparator sorts groups contiguous for a scattered snapshot`() {
+        // Issue #113: a snapshot server-sorted by a different dimension scattered
+        // the same group key across the list → duplicate "header_${key}" lazy keys
+        // → IllegalArgumentException crash. The comparator must make groups contiguous.
+        val scattered = listOf(
+            item("1", "Apple", year = 2020),
+            item("2", "Banana", year = 2021),
+            item("3", "Apricot", year = 2020),
+            item("4", "Blueberry", year = 2021),
+            item("5", "Almond", year = 2020),
+        )
+        val ordered = scattered.sortedWith(LibraryGrouper.groupComparator(GroupBy.NAME))
+        val keys = ordered.map { LibraryGrouper.groupKey(it, GroupBy.NAME) }
+        // All 'A' keys contiguous, then all 'B' keys.
+        assertEquals(listOf("A", "A", "A", "B", "B"), keys)
+    }
+
+    @Test
+    fun `groupComparator is stable - preserves within-group server order`() {
+        val scattered = listOf(
+            item("1", "Apple", year = 2020),
+            item("2", "Apricot", year = 2020),
+            item("3", "Almond", year = 2020),
+        )
+        val ordered = scattered.sortedWith(LibraryGrouper.groupComparator(GroupBy.NAME))
+        // Stable sort preserves input order within the single 'A' group.
+        assertEquals(listOf("1", "2", "3"), ordered.map { it.id })
+    }
+
+    @Test
+    fun `groupComparator with NONE is a stable no-op order`() {
+        val items = listOf(item("1", "A"), item("2", "B"), item("3", "C"))
+        val ordered = items.sortedWith(LibraryGrouper.groupComparator(GroupBy.NONE))
+        assertEquals(listOf("1", "2", "3"), ordered.map { it.id })
+    }
+}

--- a/core/model/src/test/java/com/raulshma/jellyplay/core/model/ResolvedSubtitleStyleTest.kt
+++ b/core/model/src/test/java/com/raulshma/jellyplay/core/model/ResolvedSubtitleStyleTest.kt
@@ -1,0 +1,119 @@
+package com.raulshma.jellyplay.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM tests for the shared subtitle resolution entry point ([resolveAgainst]) and
+ * the [SubtitleRenderDefaults] table — the single source every engine + the
+ * Compose overlay + the onboarding preview consume.
+ */
+class ResolvedSubtitleStyleTest {
+
+    // ---- SubtitleRenderDefaults table ----
+
+    @Test
+    fun `defaults table matches SubtitleStyle model defaults`() {
+        // "Defaults" must mean one thing. The table mirrors SubtitleStyle's
+        // zero-arg constructor so a no-edit user sees consistent values.
+        val d = SubtitleRenderDefaults.DEFAULT
+        val model = SubtitleStyle()
+        assertEquals(SubtitleRenderDefaults.REFERENCE_FONT_SIZE, d.fontSizeSp) // 24
+        assertEquals(model.fontSize, d.fontSizeSp)
+        assertEquals(SubtitleColor.WHITE.value, d.fontColor)
+        assertEquals(SubtitleColor.BLACK.value, d.backgroundColor)
+        assertEquals(0f, d.backgroundAlpha, 0.0001f)
+        assertEquals(SubtitleColor.BLACK.value, d.edgeColor)
+        assertEquals(SubtitleEdgeType.OUTLINE, d.edgeType)
+        assertEquals(model.borderWidth, d.borderWidth, 0.0001f)
+        assertEquals(model.shadowOffset, d.shadowOffset, 0.0001f)
+        assertFalse(d.bold)
+        assertFalse(d.italic)
+    }
+
+    // ---- resolveAgainst: custom branch ----
+
+    @Test
+    fun `custom branch uses ARGB over enum`() {
+        val style = SubtitleStyle(
+            applyCustomStyle = true,
+            fontColor = SubtitleColor.WHITE,
+            fontColorArgb = 0xFF112233.toInt(),
+            edgeColor = SubtitleColor.BLACK,
+            edgeColorArgb = 0xFF778899.toInt(),
+        )
+        val resolved = style.resolveAgainst()
+        assertEquals(0xFF112233.toInt(), resolved.fontColorArgb)
+        assertEquals(0xFF778899.toInt(), resolved.edgeColorArgb)
+    }
+
+    @Test
+    fun `custom branch falls back to enum value when ARGB null`() {
+        val style = SubtitleStyle(applyCustomStyle = true, fontColor = SubtitleColor.CYAN)
+        assertEquals(SubtitleColor.CYAN.value, style.resolveAgainst().fontColorArgb)
+    }
+
+    @Test
+    fun `custom branch carries user styling fields`() {
+        val style = SubtitleStyle(
+            applyCustomStyle = true,
+            borderWidth = 4.5f,
+            shadowOffset = 2.0f,
+            fontSize = 30,
+            bold = true,
+            italic = true,
+            edgeType = SubtitleEdgeType.DROP_SHADOW,
+        )
+        val resolved = style.resolveAgainst()
+        assertEquals(4.5f, resolved.borderWidth, 0.0001f)
+        assertEquals(2.0f, resolved.shadowOffset, 0.0001f)
+        assertEquals(30, resolved.fontSizeSp)
+        assertTrue(resolved.bold)
+        assertTrue(resolved.italic)
+        assertEquals(SubtitleEdgeType.DROP_SHADOW, resolved.edgeType)
+    }
+
+    // ---- resolveAgainst: default branch ----
+
+    @Test
+    fun `default branch returns the defaults table`() {
+        val resolved = SubtitleStyle(applyCustomStyle = false, fontSize = 99).resolveAgainst()
+        val d = SubtitleRenderDefaults.DEFAULT
+        assertEquals(d.fontColor, resolved.fontColorArgb)
+        assertEquals(d.backgroundColor, resolved.backgroundColorArgb)
+        assertEquals(d.edgeColor, resolved.edgeColorArgb)
+        assertEquals(d.edgeType, resolved.edgeType)
+        assertEquals(d.borderWidth, resolved.borderWidth, 0.0001f)
+        assertEquals(d.fontSizeSp, resolved.fontSizeSp) // 99 ignored
+    }
+
+    @Test
+    fun `default branch preserves verticalPosition and offsetMs`() {
+        // Layout fields carry over even when styling falls back to defaults.
+        val style = SubtitleStyle(applyCustomStyle = false, verticalPosition = 0.15f, offsetMs = 1200L)
+        val resolved = style.resolveAgainst()
+        assertEquals(0.15f, resolved.verticalPosition, 0.0001f)
+        assertEquals(1200L, resolved.offsetMs)
+    }
+
+    @Test
+    fun `custom branch preserves verticalPosition and offsetMs`() {
+        val style = SubtitleStyle(applyCustomStyle = true, verticalPosition = 0.2f, offsetMs = 500L)
+        val resolved = style.resolveAgainst()
+        assertEquals(0.2f, resolved.verticalPosition, 0.0001f)
+        assertEquals(500L, resolved.offsetMs)
+    }
+
+    // ---- custom defaults table override ----
+
+    @Test
+    fun `default branch honours a custom defaults table`() {
+        // Engines with a documented override (e.g. mpv border=3.0) pass their own table.
+        val mpvDefaults = SubtitleRenderDefaults.DEFAULT.copy(borderWidth = 3.0f, shadowOffset = 0.0f)
+        val resolved = SubtitleStyle(applyCustomStyle = false).resolveAgainst(mpvDefaults)
+        assertEquals(3.0f, resolved.borderWidth, 0.0001f)
+        assertEquals(0.0f, resolved.shadowOffset, 0.0001f)
+    }
+}

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/AdminApiClient.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/AdminApiClient.kt
@@ -29,6 +29,8 @@ interface AdminApiClient {
     suspend fun getActivityLogEntries(startIndex: Int? = null, limit: Int? = null, minDate: String? = null, hasUserId: Boolean? = null): Result<List<ActivityLogEntry>>
     suspend fun getSessions(): Result<List<SessionInfo>>
     suspend fun sendMessageToSession(sessionId: String, header: String, text: String, timeoutMs: Long = 5000): Result<Unit>
+    /** Stops active playback on the session (Jellyfin play-state STOP command). */
+    suspend fun stopSession(sessionId: String): Result<Unit>
     suspend fun play(
         sessionId: String,
         playCommand: String,

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/AdminApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/AdminApiClientImpl.kt
@@ -196,6 +196,14 @@ class AdminApiClientImpl @Inject constructor(
         )
     }
 
+    override suspend fun stopSession(sessionId: String): Result<Unit> = engine.apiResultWithRetry {
+        // Issue the play-state STOP command (canonical Jellyfin transport stop).
+        engine.requireApi().sessionApi.sendPlaystateCommand(
+            sessionId = sessionId,
+            command = org.jellyfin.sdk.model.api.PlaystateCommand.STOP,
+        )
+    }
+
     override suspend fun play(
         sessionId: String,
         playCommand: String,

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClient.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/LibraryApiClient.kt
@@ -48,11 +48,9 @@ interface LibraryApiClient {
         minRating: Float? = null,
         /**
          * Controls which nested media kinds the query excludes. Library browsing
-         * uses the default (seasons and episodes both excluded). Section mode
-         * ("See All" from a home Latest row) passes [com.raulshma.jellyplay.core.model.ItemKindFilter.LEAF_ITEMS]
-         * so the result matches what the home `/Items/Latest` row showed —
-         * episodes included — while seasons are still excluded so season cards
-         * don't leak in.
+         * and section mode ("See All" from a home Latest row) both use the
+         * default [com.raulshma.jellyplay.core.model.ItemKindFilter.TOP_LEVEL]
+         * (seasons and episodes excluded), differing only in sort order.
          */
         kindFilter: com.raulshma.jellyplay.core.model.ItemKindFilter = com.raulshma.jellyplay.core.model.ItemKindFilter.TOP_LEVEL,
     ): Result<SearchResult>

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/MediaInfoApiClient.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/MediaInfoApiClient.kt
@@ -13,6 +13,16 @@ import com.raulshma.jellyplay.core.model.WatchedMediaItem
 
 interface MediaInfoApiClient {
     suspend fun getNewsletterData(sinceDate: String, limit: Int = 20): Result<NewsletterData>
+
+    // NOTE: JellyPlay backend route required — `POST /newsletter/send` is not yet
+    // implemented server-side. This wires up the client so the feature lights up
+    // once the route lands; until then the call 404s and Result.failure surfaces it.
+    suspend fun sendNewsletter(): Result<Unit>
+
+    // NOTE: JellyPlay backend route required — `POST /newsletter/test` is not yet
+    // implemented server-side. This wires up the client so the feature lights up
+    // once the route lands; until then the call 404s and Result.failure surfaces it.
+    suspend fun sendTestNewsletter(): Result<Unit>
     suspend fun getUsers(): Result<List<JellyfinUser>>
     suspend fun getUserPlayedItemCount(userId: String, includeItemTypes: List<String>? = null): Result<Int>
     suspend fun getUserUnplayedItemCount(userId: String, includeItemTypes: List<String>? = null): Result<Int>

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/MediaInfoApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/api/MediaInfoApiClientImpl.kt
@@ -23,7 +23,9 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.contentOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
@@ -177,6 +179,32 @@ class MediaInfoApiClientImpl @Inject constructor(
                 nextUp = nextUp.await(),
                 curatedPicks = curatedPicks.await(),
             )
+        }
+    }
+
+    override suspend fun sendNewsletter(): Result<Unit> = engine.apiResultWithRetry {
+        val server = engine.currentServer.value?.address ?: throw IllegalStateException("Not connected")
+        val token = engine.currentUser.value?.accessToken ?: throw IllegalStateException("Not authenticated")
+        val request = Request.Builder()
+            .url("${server}/newsletter/send")
+            .header("X-Emby-Token", token)
+            .post("".toRequestBody("application/json".toMediaType()))
+            .build()
+        engine.okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception("Failed to send newsletter: ${response.code}")
+        }
+    }
+
+    override suspend fun sendTestNewsletter(): Result<Unit> = engine.apiResultWithRetry {
+        val server = engine.currentServer.value?.address ?: throw IllegalStateException("Not connected")
+        val token = engine.currentUser.value?.accessToken ?: throw IllegalStateException("Not authenticated")
+        val request = Request.Builder()
+            .url("${server}/newsletter/test")
+            .header("X-Emby-Token", token)
+            .post("".toRequestBody("application/json".toMediaType()))
+            .build()
+        engine.okHttpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) throw Exception("Failed to send test newsletter: ${response.code}")
         }
     }
 

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/ResilientSeerrApiClient.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/ResilientSeerrApiClient.kt
@@ -135,7 +135,8 @@ class ResilientSeerrApiClient @Inject constructor(
     override suspend fun getRequests(
         baseUrl: String, credentials: SeerrCredentials, take: Int, skip: Int,
         filter: String, sort: String, sortDirection: String, requestedBy: Int?, mediaType: String?,
-    ): Result<SeerrRequestListResponse> = req { delegate.getRequests(baseUrl, credentials, take, skip, filter, sort, sortDirection, requestedBy, mediaType) }
+        search: String?,
+    ): Result<SeerrRequestListResponse> = req { delegate.getRequests(baseUrl, credentials, take, skip, filter, sort, sortDirection, requestedBy, mediaType, search) }
 
     override suspend fun getRequest(
         baseUrl: String, credentials: SeerrCredentials, id: Int,

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/SeerrApiClient.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/SeerrApiClient.kt
@@ -180,6 +180,7 @@ interface SeerrApiClient {
         sortDirection: String = "desc",
         requestedBy: Int? = null,
         mediaType: String? = null,
+        search: String? = null,
     ): Result<SeerrRequestListResponse>
 
     suspend fun getRequest(

--- a/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/SeerrApiClientImpl.kt
+++ b/core/network/src/main/java/com/raulshma/jellyplay/core/network/seerr/SeerrApiClientImpl.kt
@@ -314,11 +314,16 @@ class SeerrApiClientImpl @Inject constructor(
         sortDirection: String,
         requestedBy: Int?,
         mediaType: String?,
+        search: String?,
     ): Result<SeerrRequestListResponse> {
         val path = buildString {
             append("/request?take=$take&skip=$skip&filter=$filter&sort=$sort&sortDirection=$sortDirection")
             requestedBy?.let { append("&requestedBy=$it") }
             mediaType?.let { append("&mediaType=$it") }
+            search?.takeIf { it.isNotBlank() }?.let {
+                append("&search=")
+                append(java.net.URLEncoder.encode(it, "UTF-8"))
+            }
         }
         val request = Request.Builder()
             .url(buildUrl(baseUrl, path))

--- a/core/notification/src/main/java/com/raulshma/jellyplay/core/notification/scheduler/NotificationReconnectListener.kt
+++ b/core/notification/src/main/java/com/raulshma/jellyplay/core/notification/scheduler/NotificationReconnectListener.kt
@@ -1,0 +1,45 @@
+package com.raulshma.jellyplay.core.notification.scheduler
+
+import com.raulshma.jellyplay.core.data.network.NetworkMonitor
+import com.raulshma.jellyplay.core.data.offline.OfflineModeManager
+import com.raulshma.jellyplay.core.data.worker.ReconnectTrigger
+import com.raulshma.jellyplay.core.datastore.di.ApplicationScope
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Watches the network status and enqueues an immediate
+ * [NewMediaCheckWorker] run when the device gains validated internet — the
+ * `Offline`/`Local` → `Online` transition. The periodic schedule is only a
+ * backstop; this is the low-latency catch-up trigger. The shared
+ * edge-detection scaffolding lives in [ReconnectTrigger].
+ *
+ * Constructed as a singleton so [start] is idempotent across callers.
+ */
+@Singleton
+class NotificationReconnectListener @Inject constructor(
+    private val networkMonitor: NetworkMonitor,
+    private val offlineModeManager: OfflineModeManager,
+    private val notificationScheduler: NotificationScheduler,
+    @ApplicationScope private val scope: CoroutineScope,
+) {
+    private val trigger = ReconnectTrigger(
+        networkMonitor = networkMonitor,
+        offlineModeManager = offlineModeManager,
+        scope = scope,
+        tag = TAG,
+        onReady = { notificationScheduler.enqueueNow() },
+    )
+
+    fun start() {
+        trigger.start()
+    }
+
+    /** Cancels the network collector. See [ReconnectTrigger.stop]. */
+    fun stop() = trigger.stop()
+
+    private companion object {
+        private const val TAG = "NotificationReconnect"
+    }
+}

--- a/core/notification/src/main/java/com/raulshma/jellyplay/core/notification/scheduler/NotificationScheduler.kt
+++ b/core/notification/src/main/java/com/raulshma/jellyplay/core/notification/scheduler/NotificationScheduler.kt
@@ -3,7 +3,9 @@ package com.raulshma.jellyplay.core.notification.scheduler
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.raulshma.jellyplay.core.datastore.notification.NotificationStore
@@ -33,6 +35,23 @@ class NotificationScheduler @Inject constructor(
         WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
     }
 
+    fun enqueueNow() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val request = OneTimeWorkRequestBuilder<NewMediaCheckWorker>()
+            .setConstraints(constraints)
+            .addTag(NewMediaCheckWorker.WORK_TAG)
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            UNIQUE_NOW_NAME,
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+    }
+
     private fun enqueue(intervalMinutes: Long) {
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -58,5 +77,6 @@ class NotificationScheduler @Inject constructor(
 
     companion object {
         const val WORK_NAME = "jellyplay_new_media_check"
+        const val UNIQUE_NOW_NAME = "jellyplay_new_media_check_now"
     }
 }

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/EpisodeFormatting.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/EpisodeFormatting.kt
@@ -1,0 +1,75 @@
+package com.raulshma.jellyplay.core.ui.components
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import com.raulshma.jellyplay.core.model.MediaItem
+import com.raulshma.jellyplay.core.model.MediaType
+
+/**
+ * Single source of truth for the `SxxExx · Series` context line shown under
+ * episode titles in list-style rows (downloads list, library list view, etc.).
+ *
+ * For non-episodes this returns `null` so callers can fall back to their own
+ * type-specific subtitle. The SxxExx tag is bold to draw the eye to the index,
+ * matching the downloads list and the library list view.
+ *
+ * Used by the downloads list, the resync sheets, and the library list view so a
+ * format change edits one place.
+ */
+fun episodeContextLine(
+    mediaType: MediaType?,
+    seriesName: String?,
+    seasonNumber: Int?,
+    episodeNumber: Int?,
+): AnnotatedString? {
+    if (mediaType != MediaType.EPISODE) return null
+    val tag = seasonNumber?.let { s ->
+        episodeNumber?.let { e ->
+            "S${s.toString().padStart(2, '0')}E${e.toString().padStart(2, '0')}"
+        }
+    }
+    val series = seriesName?.takeIf { it.isNotBlank() } ?: return tag?.let { plainTag ->
+        buildAnnotatedString { withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(plainTag) } }
+    }
+    return buildAnnotatedString {
+        if (tag != null) {
+            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(tag) }
+            append(" · ")
+        }
+        append(series)
+    }
+}
+
+/**
+ * Subtitle for a library list row: an episode context line for episodes (see
+ * [episodeContextLine]), otherwise a `Year · TypeLabel` string. Single source
+ * of truth for the library list view so the list path in [LibraryScreen] and
+ * the grouped list path in [GroupedLibraryContent] stay in sync — previously
+ * this block was duplicated verbatim in both call sites.
+ *
+ * The type label mirrors the labels used elsewhere in the library list; it is
+ * intentionally a hard-coded string rather than the localized
+ * `mediaTypeDisplayName` because the list view has always shown these short
+ * fixed labels and this preserves that behavior.
+ */
+fun MediaItem.libraryListSubtitle(): AnnotatedString? =
+    episodeContextLine(mediaType, seriesName, seasonNumber, episodeNumber)
+        ?: buildString {
+            if (year != null) append("$year")
+            val typeLabel = when (mediaType) {
+                MediaType.EPISODE -> "Episode"
+                MediaType.SERIES -> "Series"
+                MediaType.MOVIE -> "Movie"
+                MediaType.AUDIO -> "Audio"
+                MediaType.MUSIC -> "Music"
+                MediaType.PHOTO, MediaType.PHOTO_FOLDER -> "Photo"
+                else -> null
+            }
+            if (typeLabel != null) {
+                if (isNotEmpty()) append(" · ")
+                append(typeLabel)
+            }
+        }.let(::AnnotatedString)

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/EpisodeFormatting.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/EpisodeFormatting.kt
@@ -73,3 +73,31 @@ fun MediaItem.libraryListSubtitle(): AnnotatedString? =
                 append(typeLabel)
             }
         }.let(::AnnotatedString)
+
+/**
+ * Season card title context: `Sxx - SeriesName`. A season's own name (e.g.
+ * "Season 1") doesn't identify the show in flat season lists (library filtered
+ * by type, search results), so card titles render the series instead.
+ *
+ * The season number is read from [indexNumber] first, then [seasonNumber].
+ * Jellyfin season items carry their number in `IndexNumber` (mapped to
+ * [indexNumber]); `ParentIndexNumber` (mapped to [seasonNumber]) is null for
+ * seasons — it's only populated on episodes, where it means "the season this
+ * episode belongs to". The [seasonNumber] fallback covers non-Jellyfin sources
+ * that might populate it for seasons. Returns null for non-seasons, seasons
+ * without a series name, or seasons whose number is unknown.
+ */
+fun MediaItem.seasonContextTitle(): String? {
+    if (mediaType != MediaType.SEASON) return null
+    val series = seriesName?.takeIf { it.isNotBlank() } ?: return null
+    val number = indexNumber ?: seasonNumber ?: return null
+    return "S${number.toString().padStart(2, '0')} - $series"
+}
+
+/**
+ * Card/list title with season context: seasons render as `Sxx - SeriesName`
+ * (see [seasonContextTitle]), everything else keeps its plain name. Single
+ * source of truth for title rendering across card components (PosterCard,
+ * ThumbCard, WideMediaCard) and list rows.
+ */
+fun MediaItem.displayTitle(): String = seasonContextTitle() ?: name

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/EpisodePosterResolver.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/EpisodePosterResolver.kt
@@ -16,8 +16,33 @@ data class PosterCardImage(
 )
 
 /**
+ * Series-artwork fallback for a season whose own poster isn't available (e.g.
+ * a season whose library scan never generated season artwork). Returns the
+ * parent series' poster URL (resolved via [resolve]) when [item] is a season
+ * with a [MediaItem.seriesId]; an empty list otherwise. Used by card/list
+ * paths that don't go through [rememberEpisodeCardImage] (list rows, thumb card).
+ */
+fun MediaItem.seriesImageFallback(resolve: (String) -> String): List<String> =
+    if (mediaType == MediaType.SEASON) {
+        seriesId?.let { listOf(resolve(it)) } ?: emptyList()
+    } else {
+        emptyList()
+    }
+
+/**
+ * [remember]-wrapped [seriesImageFallback] for the list/thumb card paths. The
+ * memo is keyed on the only fields that affect the result (the item's type and
+ * [MediaItem.seriesId]) so a prefetch merge that produces a new item reference
+ * doesn't invalidate the fallback list each pass. Returns an empty list for
+ * non-seasons, so callers can pass it unconditionally as a `fallbackUrls` arg.
+ */
+@Composable
+fun MediaItem.rememberSeriesImageFallback(getImageUrl: (String) -> String): List<String> =
+    remember(mediaType, seriesId) { seriesImageFallback(getImageUrl) }
+
+/**
  * Picks the image shown on a poster card. Shared by the home rows and the
- * library grid so episodes render identically in both.
+ * library grid so episodes and seasons render identically in both.
  *
  * For episodes the item's own Jellyfin "Primary" image is a landscape scene
  * grab (essentially a still from the episode), which reads as a backdrop in a
@@ -30,6 +55,11 @@ data class PosterCardImage(
  * primary image is the last-resort fallback so a series with no images at all
  * still renders the episode still. The episode's primary blurhash is dropped
  * (it describes the landscape still, not the portrait poster we now show).
+ *
+ * For seasons the season's own Primary stays the card image (season covers are
+ * proper posters), but the parent series' poster is appended to the URL
+ * fallback chain so a season without its own artwork (or whose poster 404s)
+ * still shows the show's poster instead of a blank card.
  *
  * The series-name title + S# E# chip ([PosterCard]'s `showEpisodeSeriesBadge`)
  * is forced on for any episode card, since the poster now identifies the show
@@ -58,11 +88,13 @@ fun rememberEpisodeCardImage(
 ): PosterCardImage {
     return remember(item, itemImageUrl, seriesPosterResolver, seriesBackdropResolver, showEpisodeSeriesBadge) {
         val isEpisode = item.mediaType == MediaType.EPISODE
+        val isSeason = item.mediaType == MediaType.SEASON
         val seriesId = item.seriesId
-        val seriesPoster = if (isEpisode && !seriesId.isNullOrBlank()) {
+        val usesSeriesImage = isEpisode || isSeason
+        val seriesPoster = if (usesSeriesImage && !seriesId.isNullOrBlank()) {
             seriesPosterResolver(seriesId)
         } else ""
-        val seriesBackdrop = if (isEpisode && !seriesId.isNullOrBlank() && seriesPoster.isBlank()) {
+        val seriesBackdrop = if (usesSeriesImage && !seriesId.isNullOrBlank() && seriesPoster.isBlank()) {
             seriesBackdropResolver(seriesId)
         } else ""
         when {
@@ -89,6 +121,31 @@ fun rememberEpisodeCardImage(
                 fallbackUrls = fallbackImageUrls,
                 blurHash = item.blurHashes.primary,
                 showSeriesBadge = true,
+            )
+            isSeason && itemImageUrl.isBlank() && seriesPoster.isNotBlank() -> PosterCardImage(
+                // No season artwork at all — show the series poster outright.
+                imageUrl = seriesPoster,
+                fallbackUrls = if (seriesBackdrop.isNotBlank()) listOf(seriesBackdrop) + fallbackImageUrls else fallbackImageUrls,
+                blurHash = null,
+                showSeriesBadge = false,
+            )
+            isSeason && itemImageUrl.isBlank() && seriesBackdrop.isNotBlank() -> PosterCardImage(
+                imageUrl = seriesBackdrop,
+                fallbackUrls = fallbackImageUrls,
+                blurHash = null,
+                showSeriesBadge = false,
+            )
+            isSeason -> PosterCardImage(
+                // Season poster first; the parent series poster/backdrop are the
+                // fetch-time fallbacks when the season's own image 404s.
+                imageUrl = itemImageUrl,
+                fallbackUrls = buildList {
+                    if (seriesPoster.isNotBlank()) add(seriesPoster)
+                    if (seriesBackdrop.isNotBlank()) add(seriesBackdrop)
+                    addAll(fallbackImageUrls)
+                },
+                blurHash = item.blurHashes.primary,
+                showSeriesBadge = false,
             )
             else -> PosterCardImage(
                 imageUrl = itemImageUrl,

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/JellyPlaySnackbar.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/JellyPlaySnackbar.kt
@@ -3,7 +3,9 @@ package com.raulshma.jellyplay.core.ui.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -50,7 +52,12 @@ fun JellyPlaySnackbarHost(
     modifier: Modifier = Modifier,
 ) {
     SnackbarHost(hostState = hostState, modifier = modifier) { data ->
-        JellyPlaySnackbarContent(snackbarData = data)
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            JellyPlaySnackbarContent(snackbarData = data)
+        }
     }
 }
 

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/MediaCardComponents.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/MediaCardComponents.kt
@@ -303,12 +303,13 @@ fun PosterCard(
 
     // For episode cards in Latest Media rows, show the series name as the title
     // (the episode title alone doesn't identify the show); the season/episode
-    // chip on the image carries the S# E# context.
+    // chip on the image carries the S# E# context. Seasons use displayTitle so a
+    // flat season row shows "S01 - Series" instead of an ambiguous "Season 1".
     val titleText = remember(item, showEpisodeSeriesBadge) {
         if (showEpisodeSeriesBadge && item.mediaType == MediaType.EPISODE) {
-            item.seriesName?.takeIf { it.isNotBlank() } ?: item.name
+            item.seriesName?.takeIf { it.isNotBlank() } ?: item.displayTitle()
         } else {
-            item.name
+            item.displayTitle()
         }
     }
 

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/ResolvedSubtitleStyleCompose.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/ResolvedSubtitleStyleCompose.kt
@@ -1,0 +1,54 @@
+package com.raulshma.jellyplay.core.ui.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.raulshma.jellyplay.core.model.ResolvedSubtitleStyle
+import com.raulshma.jellyplay.core.model.SubtitleEdgeType
+
+/**
+ * Compose mapping for [ResolvedSubtitleStyle], shared by the player overlay and
+ * the onboarding [SubtitleStylePreview]. Lives in core/ui (not core/model) so it
+ * can return Compose `Color`/`Shadow` types — core/model depends only on
+ * compose-runtime and stays free of compose-ui.
+ *
+ * Replaces the preview's hand-rolled `subtitleColorToCompose` `when`, the
+ * `FontWeight.SemiBold` literal (now honours `bold`), and the inline shadow
+ * constants — one mapping, consumed by both surfaces.
+ */
+
+/** Map a resolved ARGB int to a Compose [Color]. */
+fun resolvedColor(argb: Int): Color = Color(argb)
+
+/** The Compose font weight for a resolved style: bold ⇒ Bold, else SemiBold (legibility default). */
+fun resolvedFontWeight(bold: Boolean): FontWeight =
+    if (bold) FontWeight.Bold else FontWeight.SemiBold
+
+/**
+ * The Compose [Shadow] for a resolved edge type, or null for NONE. The blur/offset
+ * magnitudes are the same ones the old preview hand-rolled; centralized here so the
+ * overlay and preview can't drift.
+ */
+fun resolvedShadow(style: ResolvedSubtitleStyle): Shadow? {
+    val edgeColor = Color(style.edgeColorArgb)
+    return when (style.edgeType) {
+        SubtitleEdgeType.NONE -> null
+        SubtitleEdgeType.OUTLINE -> Shadow(color = edgeColor, blurRadius = 4f)
+        SubtitleEdgeType.DROP_SHADOW -> Shadow(
+            color = edgeColor.copy(alpha = 0.8f),
+            blurRadius = 8f,
+            offset = androidx.compose.ui.geometry.Offset(2f, 2f),
+        )
+        SubtitleEdgeType.RAISED -> Shadow(
+            color = edgeColor.copy(alpha = 0.7f),
+            blurRadius = 2f,
+            offset = androidx.compose.ui.geometry.Offset(1.5f, 1.5f),
+        )
+        SubtitleEdgeType.DEPRESSED -> Shadow(
+            color = edgeColor.copy(alpha = 0.7f),
+            blurRadius = 2f,
+            offset = androidx.compose.ui.geometry.Offset(-1.5f, -1.5f),
+        )
+    }
+}

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SearchField.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SearchField.kt
@@ -1,0 +1,80 @@
+package com.raulshma.jellyplay.core.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.Search
+import com.composables.icons.tabler.outline.X
+import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
+import com.raulshma.jellyplay.core.ui.R
+
+/**
+ * The shared single-line search field used by the Requests, Devices and Logs
+ * screens (and any future screen needing the same affordance). A leading
+ * magnifier, a trailing clear-X that only appears when the field is non-empty,
+ * the smooth12 shape, and the focused-primary / unfocused-outlineVariant border
+ * pair — extracted so the three prior verbatim copies stay in sync.
+ *
+ * @param value current query text.
+ * @param onValueChange called on every keystroke and when the clear X is tapped
+ *   (with `""`).
+ * @param placeholder localized hint shown when empty.
+ * @param modifier outer modifier; defaults to fill-max-width.
+ */
+@Composable
+fun SearchField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier.fillMaxWidth(),
+        placeholder = {
+            Text(
+                placeholder,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        leadingIcon = {
+            Icon(
+                Tabler.Outline.Search,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = colorScheme.onSurfaceVariant,
+            )
+        },
+        trailingIcon = if (value.isNotEmpty()) {
+            {
+                IconButton(onClick = { onValueChange("") }) {
+                    Icon(
+                        Tabler.Outline.X,
+                        contentDescription = stringResource(R.string.core_clear),
+                        modifier = Modifier.size(18.dp),
+                        tint = colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        } else null,
+        singleLine = true,
+        shape = ShapeCache.smooth12,
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = colorScheme.primary,
+            unfocusedBorderColor = colorScheme.outlineVariant.copy(alpha = 0.5f),
+        ),
+        textStyle = MaterialTheme.typography.bodyMedium,
+    )
+}

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SubtitleStylePreview.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/SubtitleStylePreview.kt
@@ -11,8 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -20,8 +20,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.SubtitleColor
-import com.raulshma.jellyplay.core.model.SubtitleEdgeType
 import com.raulshma.jellyplay.core.model.SubtitleStyle
+import com.raulshma.jellyplay.core.model.resolveAgainst
 
 /**
  * Live preview of how [style] renders over a sample video frame. Lifted from
@@ -40,11 +40,14 @@ fun SubtitleStylePreview(
     modifier: Modifier = Modifier,
     sampleText: String = "The quick brown fox\njumps over the lazy dog.",
 ) {
-    val bgColor = subtitleColorToCompose(style.backgroundColor).copy(alpha = style.backgroundOpacity)
-    val fontColor = subtitleColorToCompose(style.fontColor)
-    val edgeColor = subtitleColorToCompose(style.edgeColor)
+    // Resolve through the shared entry point so the preview matches what the
+    // player overlay renders for the same input. Previously this hand-rolled its
+    // own color/edge/weight mapping and ignored the *Argb fields + applyCustomStyle.
+    val resolved = style.resolveAgainst()
+    val bgColor = resolvedColor(resolved.backgroundColorArgb).copy(alpha = resolved.backgroundAlpha)
+    val fontColor = resolvedColor(resolved.fontColorArgb)
     // verticalPosition is a 0..0.5 fraction of the preview height from the bottom.
-    val bottomOffsetDp = (style.verticalPosition * 200f).dp
+    val bottomOffsetDp = (resolved.verticalPosition * 200f).dp
 
     Box(
         modifier = modifier
@@ -52,7 +55,7 @@ fun SubtitleStylePreview(
             .aspectRatio(2.35f)
             .clip(ShapeCache.smooth16)
             .background(
-                androidx.compose.ui.graphics.Brush.verticalGradient(
+                Brush.verticalGradient(
                     listOf(Color(0xFF1B2330), Color(0xFF0A0E16)),
                 ),
             ),
@@ -64,40 +67,19 @@ fun SubtitleStylePreview(
                 .offset(y = -bottomOffsetDp)
                 .background(bgColor, ShapeCache.smooth8)
                 .padding(
-                    horizontal = if (style.backgroundOpacity > 0f) 10.dp else 0.dp,
-                    vertical = if (style.backgroundOpacity > 0f) 4.dp else 0.dp,
+                    horizontal = if (resolved.backgroundAlpha > 0f) 10.dp else 0.dp,
+                    vertical = if (resolved.backgroundAlpha > 0f) 4.dp else 0.dp,
                 ),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
                 text = sampleText,
-                fontSize = style.fontSize.coerceIn(12, 48).sp,
+                fontSize = resolved.fontSizeSp.coerceIn(12, 48).sp,
                 color = fontColor,
                 textAlign = TextAlign.Center,
-                fontWeight = FontWeight.SemiBold,
+                fontWeight = resolvedFontWeight(resolved.bold),
                 style = MaterialTheme.typography.bodyLarge.copy(
-                    shadow = when (style.edgeType) {
-                        SubtitleEdgeType.NONE -> null
-                        SubtitleEdgeType.OUTLINE -> androidx.compose.ui.graphics.Shadow(
-                            color = edgeColor,
-                            blurRadius = 4f,
-                        )
-                        SubtitleEdgeType.DROP_SHADOW -> androidx.compose.ui.graphics.Shadow(
-                            color = edgeColor.copy(alpha = 0.8f),
-                            blurRadius = 8f,
-                            offset = androidx.compose.ui.geometry.Offset(2f, 2f),
-                        )
-                        SubtitleEdgeType.RAISED -> androidx.compose.ui.graphics.Shadow(
-                            color = edgeColor.copy(alpha = 0.7f),
-                            blurRadius = 2f,
-                            offset = androidx.compose.ui.geometry.Offset(1.5f, 1.5f),
-                        )
-                        SubtitleEdgeType.DEPRESSED -> androidx.compose.ui.graphics.Shadow(
-                            color = edgeColor.copy(alpha = 0.7f),
-                            blurRadius = 2f,
-                            offset = androidx.compose.ui.geometry.Offset(-1.5f, -1.5f),
-                        )
-                    },
+                    shadow = resolvedShadow(resolved),
                 ),
             )
         }

--- a/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/WideMediaCard.kt
+++ b/core/ui/src/main/java/com/raulshma/jellyplay/core/ui/components/WideMediaCard.kt
@@ -72,7 +72,7 @@ fun WideMediaCard(
                 crossfade = false,
             )
         },
-        title = item.name,
+        title = item.displayTitle(),
         modifier = modifier,
         aspectRatio = 16f / 9f,
         clipToShape = clipToShape,

--- a/core/ui/src/test/java/com/raulshma/jellyplay/core/ui/components/EpisodeFormattingTest.kt
+++ b/core/ui/src/test/java/com/raulshma/jellyplay/core/ui/components/EpisodeFormattingTest.kt
@@ -1,0 +1,97 @@
+package com.raulshma.jellyplay.core.ui.components
+
+import com.raulshma.jellyplay.core.model.MediaItem
+import com.raulshma.jellyplay.core.model.MediaType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EpisodeFormattingTest {
+
+    private fun season(
+        series: String? = "Breaking Bad",
+        seasonNumber: Int? = null,
+        indexNumber: Int? = 1,
+    ) = MediaItem(
+        id = "season-1",
+        name = "Season 1",
+        mediaType = MediaType.SEASON,
+        seriesName = series,
+        seasonNumber = seasonNumber,
+        indexNumber = indexNumber,
+    )
+
+    @Test
+    fun `seasonContextTitle uses indexNumber as the number`() {
+        // Jellyfin season items carry their number in IndexNumber (mapped to
+        // indexNumber); ParentIndexNumber (mapped to seasonNumber) is null for
+        // seasons, so this is the real data shape for a season.
+        val item = season(series = "Breaking Bad", indexNumber = 1)
+        assertEquals("S01 - Breaking Bad", item.seasonContextTitle())
+    }
+
+    @Test
+    fun `seasonContextTitle falls back to seasonNumber when indexNumber is absent`() {
+        // Defensive fallback for non-Jellyfin sources that populate seasonNumber.
+        val item = season(series = "Stranger Things", seasonNumber = 2, indexNumber = null)
+        assertEquals("S02 - Stranger Things", item.seasonContextTitle())
+    }
+
+    @Test
+    fun `seasonContextTitle prefers indexNumber when both are present`() {
+        val item = season(series = "Stranger Things", seasonNumber = 2, indexNumber = 3)
+        assertEquals("S03 - Stranger Things", item.seasonContextTitle())
+    }
+
+    @Test
+    fun `seasonContextTitle pads numbers to two digits`() {
+        assertEquals("S01 - Breaking Bad", season(indexNumber = 1).seasonContextTitle())
+        assertEquals("S10 - Breaking Bad", season(indexNumber = 10).seasonContextTitle())
+        assertEquals("S100 - Breaking Bad", season(indexNumber = 100).seasonContextTitle())
+    }
+
+    @Test
+    fun `seasonContextTitle is null for non-seasons`() {
+        val movie = MediaItem(id = "m", name = "Arrival", mediaType = MediaType.MOVIE)
+        assertNull(movie.seasonContextTitle())
+    }
+
+    @Test
+    fun `seasonContextTitle is null when series name is blank`() {
+        assertNull(season(series = "   ").seasonContextTitle())
+        assertNull(season(series = "").seasonContextTitle())
+    }
+
+    @Test
+    fun `seasonContextTitle is null when the number is unknown`() {
+        assertNull(season(seasonNumber = null, indexNumber = null).seasonContextTitle())
+    }
+
+    @Test
+    fun `displayTitle returns season context for seasons and plain name otherwise`() {
+        assertEquals("S01 - Breaking Bad", season(indexNumber = 1).displayTitle())
+        assertEquals("Arrival", MediaItem(id = "m", name = "Arrival", mediaType = MediaType.MOVIE).displayTitle())
+        assertEquals("Season 1", season(series = null).displayTitle())
+    }
+
+    @Test
+    fun `seriesImageFallback resolves series poster for seasons only`() {
+        val seasonItem = MediaItem(
+            id = "season-1",
+            name = "Season 1",
+            mediaType = MediaType.SEASON,
+            seriesName = "Breaking Bad",
+            seriesId = "series-42",
+        )
+        val movie = MediaItem(id = "m", name = "Arrival", mediaType = MediaType.MOVIE, seriesId = "series-9")
+
+        assertEquals(
+            listOf("https://serv/img/series-42/primary"),
+            seasonItem.seriesImageFallback { id -> "https://serv/img/$id/primary" },
+        )
+        assertEquals(emptyList<String>(), movie.seriesImageFallback { id -> "https://serv/img/$id/primary" })
+
+        val noSeriesId = seasonItem.copy(seriesId = null)
+        assertEquals(emptyList<String>(), noSeriesId.seriesImageFallback { id -> "https://serv/img/$id/primary" })
+    }
+}

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/dashboard/AdminDashboardScreen.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/dashboard/AdminDashboardScreen.kt
@@ -51,6 +51,7 @@ import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
 import com.raulshma.jellyplay.core.ui.tv.TvGrabInitialFocus
 import com.raulshma.jellyplay.core.ui.tv.tvFocusRestorer
 import com.raulshma.jellyplay.feature.admin.dashboard.components.ActiveSessionsSection
+import com.raulshma.jellyplay.core.model.SessionInfo
 import com.raulshma.jellyplay.feature.admin.dashboard.components.LibraryStatsRow
 import com.raulshma.jellyplay.feature.admin.dashboard.components.QuickActionsSection
 import com.raulshma.jellyplay.feature.admin.dashboard.components.RecentActivityTimeline
@@ -123,6 +124,38 @@ fun AdminDashboardScreen(
         )
     }
 
+    // Stop active playback confirm dialog. Session to stop is held in VM
+    // state so it survives recomposition; dismissed on confirm/cancel/away-tap.
+    state.pendingStopSession?.let { session ->
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissStopSessionDialog() },
+            title = { Text(stringResource(R.string.admin_stop_session_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.admin_stop_session_body,
+                        session.userName.ifBlank { session.deviceName },
+                    ),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.stopSession() },
+                    enabled = !state.isStoppingSession,
+                    colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) { Text(stringResource(R.string.admin_stop)) }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { viewModel.dismissStopSessionDialog() },
+                    enabled = !state.isStoppingSession,
+                ) { Text(stringResource(R.string.admin_cancel)) }
+            },
+        )
+    }
+
     JellyPlayScreenScaffold(
         title = stringResource(R.string.admin_dashboard_title),
         onBack = onBack,
@@ -172,6 +205,7 @@ fun AdminDashboardScreen(
                     onWatchedMediaCleanup = onWatchedMediaCleanup,
                     onPlugins = onPlugins,
                     onUsers = onUsers,
+                    onStopSession = { viewModel.showStopSessionDialog(it) },
                     contentFocusRequester = contentFocusRequester,
                     modifier = Modifier.fillMaxSize(),
                 )
@@ -197,6 +231,7 @@ private fun DashboardContent(
     onWatchedMediaCleanup: () -> Unit = {},
     onPlugins: () -> Unit = {},
     onUsers: () -> Unit = {},
+    onStopSession: (SessionInfo) -> Unit = {},
     contentFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
 ) {
@@ -258,6 +293,7 @@ private fun DashboardContent(
                             ActiveSessionsSection(
                                 sessions = state.sessions,
                                 onViewAll = onDevices,
+                                onStop = onStopSession,
                             )
                         }
                     }
@@ -279,6 +315,7 @@ private fun DashboardContent(
                     ActiveSessionsSection(
                         sessions = state.sessions,
                         onViewAll = onDevices,
+                        onStop = onStopSession,
                     )
                 }
             }

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/dashboard/AdminDashboardViewModel.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/dashboard/AdminDashboardViewModel.kt
@@ -30,6 +30,10 @@ data class AdminDashboardState(
     val isRestarting: Boolean = false,
     val isShuttingDown: Boolean = false,
     val libraryScanState: LibraryScanState = LibraryScanState.Idle,
+    /** Session awaiting a stop confirmation, if any. Null hides the dialog. */
+    val pendingStopSession: SessionInfo? = null,
+    /** True while a stop request is in flight (disables the confirm button). */
+    val isStoppingSession: Boolean = false,
 )
 
 @HiltViewModel
@@ -156,6 +160,43 @@ class AdminDashboardViewModel @Inject constructor(
                     it.copy(
                         isShuttingDown = false,
                         error = "Shutdown failed: ${result.exceptionOrNull()?.message ?: "unknown error"}",
+                    )
+                }
+            }
+        }
+    }
+
+    /** Opens the "stop this session's playback?" confirm dialog. */
+    fun showStopSessionDialog(session: SessionInfo) {
+        _uiState.update { it.copy(pendingStopSession = session) }
+    }
+
+    fun dismissStopSessionDialog() {
+        if (!_uiState.value.isStoppingSession) {
+            _uiState.update { it.copy(pendingStopSession = null) }
+        }
+    }
+
+    /**
+     * Stops active playback on the session currently pending confirmation.
+     * Issues Jellyfin's play-state STOP command, then refreshes the dashboard
+     * so the card reflects the stopped state.
+     */
+    fun stopSession() {
+        val session = _uiState.value.pendingStopSession ?: return
+        launch {
+            _uiState.update { it.copy(isStoppingSession = true) }
+            val result = apiClient.stopSession(session.id)
+            if (result.isSuccess) {
+                _uiState.update {
+                    it.copy(isStoppingSession = false, pendingStopSession = null, error = null)
+                }
+                loadDashboard()
+            } else {
+                _uiState.update {
+                    it.copy(
+                        isStoppingSession = false,
+                        error = "Stop failed: ${result.exceptionOrNull()?.message ?: "unknown error"}",
                     )
                 }
             }

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/dashboard/components/ActiveSessionsSection.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/dashboard/components/ActiveSessionsSection.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -37,6 +38,7 @@ import com.composables.icons.tabler.Tabler
 import com.composables.icons.tabler.outline.DeviceDesktop
 import com.composables.icons.tabler.outline.DeviceMobile
 import com.composables.icons.tabler.outline.DeviceTv
+import com.composables.icons.tabler.outline.PlayerStop
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.SessionInfo
 import com.raulshma.jellyplay.core.ui.components.LocalReducedMotion
@@ -48,6 +50,7 @@ import com.raulshma.jellyplay.feature.admin.R
 fun ActiveSessionsSection(
     sessions: List<SessionInfo>,
     onViewAll: () -> Unit,
+    onStop: (SessionInfo) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val viewAllFocusState = rememberTvFocusState(focusedScale = 1.04f)
@@ -97,6 +100,7 @@ fun ActiveSessionsSection(
             sessions.take(5).forEachIndexed { index, session ->
                 SessionItem(
                     session = session,
+                    onStop = { onStop(session) },
                     showDivider = index < minOf(4, sessions.size - 1),
                 )
                 if (index < minOf(4, sessions.size - 1)) {
@@ -110,6 +114,7 @@ fun ActiveSessionsSection(
 @Composable
 private fun SessionItem(
     session: SessionInfo,
+    onStop: () -> Unit,
     showDivider: Boolean,
 ) {
     Row(
@@ -185,12 +190,34 @@ private fun SessionItem(
                     session.client.contains("iOS", ignoreCase = true) -> Tabler.Outline.DeviceMobile
                 else -> Tabler.Outline.DeviceDesktop
             }
-            Icon(
-                deviceIcon,
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    deviceIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                // Stop-playback affordance — only meaningful when something is
+                // actively playing on the session. Opens a confirm dialog.
+                if (session.nowPlayingItem != null) {
+                    Spacer(Modifier.width(4.dp))
+                    val stopFocusState = rememberTvFocusState()
+                    IconButton(
+                        onClick = onStop,
+                        modifier = Modifier
+                            .size(28.dp)
+                            .then(stopFocusState.focusModifier)
+                            .tvFocusIndicator(stopFocusState, CircleShape),
+                    ) {
+                        Icon(
+                            Tabler.Outline.PlayerStop,
+                            contentDescription = stringResource(R.string.admin_stop_session_cd),
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            }
             Spacer(Modifier.height(2.dp))
             Text(
                 session.client,

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/devices/DevicesScreen.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/devices/DevicesScreen.kt
@@ -34,7 +34,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -50,7 +52,9 @@ import com.composables.icons.tabler.outline.DeviceDesktop
 import com.composables.icons.tabler.outline.DeviceMobile
 import com.composables.icons.tabler.outline.Edit
 import com.composables.icons.tabler.outline.Refresh
+import com.composables.icons.tabler.outline.Search
 import com.composables.icons.tabler.outline.Trash
+import com.composables.icons.tabler.outline.X
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.DeviceInfo
 import com.raulshma.jellyplay.core.ui.adaptive.LocalAdaptiveInfo
@@ -59,6 +63,7 @@ import com.raulshma.jellyplay.core.ui.components.JellyPlayScreenScaffold
 import com.raulshma.jellyplay.core.ui.components.focusIndicator
 import com.raulshma.jellyplay.core.ui.components.ScreenEmptyState
 import com.raulshma.jellyplay.core.ui.components.ScreenLoadingState
+import com.raulshma.jellyplay.core.ui.components.SearchField
 import com.raulshma.jellyplay.core.ui.components.rememberScreenBackgroundColor
 import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
 import com.raulshma.jellyplay.core.ui.tv.TvGrabInitialFocus
@@ -165,35 +170,84 @@ fun DevicesScreen(
                 }
             }
             else -> {
-                PullToRefreshBox(
-                    isRefreshing = state.isRefreshing,
-                    onRefresh = { viewModel.refresh() },
-                ) {
-                    if (state.devices.isEmpty()) {
-                        ScreenEmptyState(
-                            icon = Tabler.Outline.DeviceDesktop,
-                            title = stringResource(R.string.admin_no_devices),
-                        )
-                    } else {
-                        LazyColumn(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .tvFocusRestorer()
-                                .focusRequester(listFocusRequester),
-                            contentPadding = PaddingValues(
-                                start = 16.dp,
-                                end = 16.dp,
-                                top = 8.dp,
-                                bottom = adaptiveInfo.bottomPadding(isTv),
-                            ),
-                            verticalArrangement = Arrangement.spacedBy(6.dp),
-                        ) {
-                            itemsIndexed(items = state.devices, key = { index, device -> "${index}_${device.id}" }) { _, device ->
-                                DeviceItem(
-                                    device = device,
-                                    onEdit = { viewModel.showEditNameDialog(device) },
-                                    onDelete = { viewModel.showDeleteDialog(device) },
-                                )
+                // Search-by-name/user + grouping by last user.
+                var searchQuery by remember { mutableStateOf("") }
+                val query = searchQuery.trim()
+                val filteredDevices = remember(state.devices, query) {
+                    if (query.isEmpty()) state.devices
+                    else state.devices.filter { device ->
+                        query in device.displayName() ||
+                            query in device.appName ||
+                            query in device.lastUserName
+                    }
+                }
+                // Group by last user name so multi-user servers stay scannable.
+                // Empty user names collapse into a single "Unknown" bucket.
+                val unknownUserLabel = stringResource(R.string.admin_unknown)
+                val grouped = remember(filteredDevices, unknownUserLabel) {
+                    filteredDevices.groupBy { it.lastUserName.ifBlank { unknownUserLabel } }
+                        .toList()
+                }
+                Column(modifier = Modifier.fillMaxSize()) {
+                    SearchField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        placeholder = stringResource(R.string.admin_devices_search_placeholder),
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                    )
+                    PullToRefreshBox(
+                        isRefreshing = state.isRefreshing,
+                        onRefresh = { viewModel.refresh() },
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        if (state.devices.isEmpty()) {
+                            ScreenEmptyState(
+                                icon = Tabler.Outline.DeviceDesktop,
+                                title = stringResource(R.string.admin_no_devices),
+                            )
+                        } else if (filteredDevices.isEmpty()) {
+                            ScreenEmptyState(
+                                icon = Tabler.Outline.Search,
+                                title = query,
+                            )
+                        } else {
+                            LazyColumn(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .tvFocusRestorer()
+                                    .focusRequester(listFocusRequester),
+                                contentPadding = PaddingValues(
+                                    start = 16.dp,
+                                    end = 16.dp,
+                                    top = 8.dp,
+                                    bottom = adaptiveInfo.bottomPadding(isTv),
+                                ),
+                                verticalArrangement = Arrangement.spacedBy(6.dp),
+                            ) {
+                                grouped.forEach { (userName, devices) ->
+                                    // Section header per user (only when grouping yields >1 group).
+                                    if (grouped.size > 1) {
+                                        item(key = "header_$userName") {
+                                            Text(
+                                                userName,
+                                                style = MaterialTheme.typography.labelLarge,
+                                                fontWeight = FontWeight.SemiBold,
+                                                color = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.padding(top = 8.dp, bottom = 2.dp),
+                                            )
+                                        }
+                                    }
+                                    itemsIndexed(
+                                        items = devices,
+                                        key = { index, device -> "${userName}_${index}_${device.id}" },
+                                    ) { _, device ->
+                                        DeviceItem(
+                                            device = device,
+                                            onEdit = { viewModel.showEditNameDialog(device) },
+                                            onDelete = { viewModel.showDeleteDialog(device) },
+                                        )
+                                    }
+                                }
                             }
                         }
                     }

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/logs/LogsScreen.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/logs/LogsScreen.kt
@@ -78,6 +78,7 @@ import com.raulshma.jellyplay.core.ui.adaptive.bottomPadding
 import com.raulshma.jellyplay.core.ui.components.JellyPlayScreenScaffold
 import com.raulshma.jellyplay.core.ui.components.focusIndicator
 import com.raulshma.jellyplay.core.ui.components.ScreenEmptyState
+import com.raulshma.jellyplay.core.ui.components.SearchField
 import com.raulshma.jellyplay.core.ui.components.rememberScreenBackgroundColor
 import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
 import com.raulshma.jellyplay.core.ui.tv.TvGrabInitialFocus
@@ -162,28 +163,57 @@ fun LogsScreen(
                 }
             }
 
+            // Message-text filter. Applies to whichever tab is active.
+            var searchQuery by remember { mutableStateOf("") }
+            SearchField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = stringResource(R.string.admin_logs_search_placeholder),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+            )
+
+            // Resolve the filtered list once per recomposition.
+            val query = searchQuery.trim()
             when (state.selectedTabIndex) {
-                0 -> LogFilesTab(
-                    logFiles = state.logFiles,
-                    selectedLogFileName = state.selectedLogFileName,
-                    selectedLogFileLines = state.selectedLogFileLines,
-                    isLoadingContent = state.isLoadingLogContent,
-                    isPollingActive = state.isLogPollingActive,
-                    onTogglePolling = { viewModel.toggleLogPolling() },
-                    onFileClick = { viewModel.loadLogFile(it) },
-                    onBackToList = { viewModel.clearSelectedLogFile() },
-                    bottomPadding = adaptiveInfo.bottomPadding(isTv),
-                    listFocusRequester = listFocusRequester,
-                )
-                1 -> ActivityLogTab(
-                    entries = state.activityEntries,
-                    isLiveActive = state.isLiveStreamActive,
-                    liveEntryIds = state.liveEntryIds,
-                    isLoadingMore = false,
-                    onLoadMore = { viewModel.loadMoreActivity() },
-                    bottomPadding = adaptiveInfo.bottomPadding(isTv),
-                    listFocusRequester = listFocusRequester,
-                )
+                0 -> {
+                    val filteredLines = remember(state.selectedLogFileLines, query) {
+                        if (query.isEmpty()) state.selectedLogFileLines
+                        else state.selectedLogFileLines.filter { query in it.text }
+                    }
+                    val filteredFiles = remember(state.logFiles, query) {
+                        if (query.isEmpty()) state.logFiles
+                        else state.logFiles.filter { query in it.name }
+                    }
+                    LogFilesTab(
+                        logFiles = filteredFiles,
+                        selectedLogFileName = state.selectedLogFileName,
+                        selectedLogFileLines = filteredLines,
+                        isLoadingContent = state.isLoadingLogContent,
+                        isPollingActive = state.isLogPollingActive,
+                        onTogglePolling = { viewModel.toggleLogPolling() },
+                        onFileClick = { viewModel.loadLogFile(it) },
+                        onBackToList = { viewModel.clearSelectedLogFile() },
+                        bottomPadding = adaptiveInfo.bottomPadding(isTv),
+                        listFocusRequester = listFocusRequester,
+                    )
+                }
+                1 -> {
+                    val filteredEntries = remember(state.activityEntries, query) {
+                        if (query.isEmpty()) state.activityEntries
+                        else state.activityEntries.filter { entry ->
+                            query in entry.name || (entry.overview?.contains(query) == true) || query in entry.type
+                        }
+                    }
+                    ActivityLogTab(
+                        entries = filteredEntries,
+                        isLiveActive = state.isLiveStreamActive,
+                        liveEntryIds = state.liveEntryIds,
+                        isLoadingMore = false,
+                        onLoadMore = { viewModel.loadMoreActivity() },
+                        bottomPadding = adaptiveInfo.bottomPadding(isTv),
+                        listFocusRequester = listFocusRequester,
+                    )
+                }
             }
         }
     }

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/statistics/UserStatisticsScreen.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/statistics/UserStatisticsScreen.kt
@@ -1,5 +1,8 @@
 package com.raulshma.jellyplay.feature.admin.statistics
 
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -21,28 +24,39 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import com.raulshma.jellyplay.core.ui.components.JellyPlayLinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.core.content.FileProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.ArrowsUpDown
+import com.composables.icons.tabler.outline.Check
+import com.composables.icons.tabler.outline.FileDownload
 import com.composables.icons.tabler.outline.InfoCircle
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.PlaybackReportingStatus
@@ -58,6 +72,7 @@ import com.raulshma.jellyplay.core.ui.tv.TvGrabInitialFocus
 import com.raulshma.jellyplay.core.ui.tv.tvFocusRestorer
 import com.raulshma.jellyplay.feature.admin.R
 import com.raulshma.jellyplay.feature.admin.statistics.components.SummaryStatCard
+import java.io.File
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,6 +83,8 @@ fun UserStatisticsScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val adaptiveInfo = LocalAdaptiveInfo.current
+    val context = LocalContext.current
+    var showSortMenu by remember { mutableStateOf(false) }
 
     // TV focus-on-launch: focus the first user card once data arrives so D-pad input lands on
     // content, not the navigation drawer.
@@ -78,9 +95,52 @@ fun UserStatisticsScreen(
         tag = "user_stats_init",
     )
 
+    if (state.shareRequested) {
+        LaunchedEffect(state.shareRequested) {
+            shareUserStatsCsv(context, state.users)
+            Toast.makeText(context, context.getString(R.string.user_stats_export_shared), Toast.LENGTH_SHORT).show()
+            viewModel.consumeExportRequest()
+        }
+    }
+
     JellyPlayScreenScaffold(
         title = stringResource(R.string.admin_user_statistics_title),
         onBack = onBack,
+        actions = {
+            IconButton(onClick = { showSortMenu = true }) {
+                Icon(
+                    Tabler.Outline.ArrowsUpDown,
+                    contentDescription = stringResource(R.string.user_stats_sort_cd),
+                )
+            }
+            DropdownMenu(
+                expanded = showSortMenu,
+                onDismissRequest = { showSortMenu = false },
+            ) {
+                UserStatisticsSort.entries.forEach { sort ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(sort.labelRes)) },
+                        onClick = {
+                            viewModel.setSort(sort)
+                            showSortMenu = false
+                        },
+                        leadingIcon = {
+                            if (state.sort == sort) {
+                                Icon(Tabler.Outline.Check, contentDescription = null, modifier = Modifier.size(18.dp))
+                            } else {
+                                Spacer(modifier = Modifier.size(18.dp))
+                            }
+                        },
+                    )
+                }
+            }
+            IconButton(onClick = { viewModel.requestExport() }) {
+                Icon(
+                    Tabler.Outline.FileDownload,
+                    contentDescription = stringResource(R.string.user_stats_export_cd),
+                )
+            }
+        },
     ) { paddingValues ->
         when {
             state.isLoading -> ScreenLoadingState()
@@ -350,3 +410,33 @@ private fun StatPill(text: String) {
 
 private fun formatDuration(seconds: Long): String =
     com.raulshma.jellyplay.core.ui.components.formatDurationApproxSeconds(seconds)
+
+private fun shareUserStatsCsv(context: Context, users: List<UserStatistics>) {
+    val header = "User,Plays,Movies,Episodes,Songs,WatchTimeSec,CompletionRate"
+    val rows = users.joinToString("\n") { u ->
+        val name = "\"" + u.userName.replace("\"", "\"\"") + "\""
+        listOf(
+            name,
+            u.totalPlayCount.toString(),
+            u.moviePlayCount.toString(),
+            u.episodePlayCount.toString(),
+            u.songPlayCount.toString(),
+            u.totalWatchTimeSec.toString(),
+            u.completionRate.toString(),
+        ).joinToString(",")
+    }
+    val csv = "$header\n$rows"
+    val file = File(context.cacheDir, "user_stats_${System.currentTimeMillis()}.csv")
+    file.writeText(csv)
+    val uri = FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.fileprovider",
+        file,
+    )
+    val shareIntent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/csv"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    context.startActivity(Intent.createChooser(shareIntent, "Export CSV"))
+}

--- a/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/statistics/UserStatisticsViewModel.kt
+++ b/feature/admin/src/main/java/com/raulshma/jellyplay/feature/admin/statistics/UserStatisticsViewModel.kt
@@ -1,12 +1,20 @@
 package com.raulshma.jellyplay.feature.admin.statistics
 
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Immutable
 import com.raulshma.jellyplay.core.data.repository.AdminStatisticsRepository
 import com.raulshma.jellyplay.core.model.PlaybackReportingStatus
 import com.raulshma.jellyplay.core.model.UserStatistics
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
+import com.raulshma.jellyplay.feature.admin.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+
+enum class UserStatisticsSort(@StringRes val labelRes: Int) {
+    PLAYS(R.string.user_stats_sort_plays),
+    TIME(R.string.user_stats_sort_time),
+    NAME(R.string.user_stats_sort_name),
+}
 
 @Immutable
 data class UserStatisticsState(
@@ -18,6 +26,8 @@ data class UserStatisticsState(
     val activeThisWeek: Int = 0,
     val totalPlays: Int = 0,
     val pluginStatus: PlaybackReportingStatus = PlaybackReportingStatus.UNKNOWN,
+    val sort: UserStatisticsSort = UserStatisticsSort.PLAYS,
+    val shareRequested: Boolean = false,
 )
 
 @HiltViewModel
@@ -41,6 +51,20 @@ class UserStatisticsViewModel @Inject constructor(
         }
     }
 
+    private fun applySort(users: List<UserStatistics>, sort: UserStatisticsSort): List<UserStatistics> {
+        val comparator = when (sort) {
+            UserStatisticsSort.PLAYS -> compareByDescending<UserStatistics> { it.totalPlayCount }
+                .thenByDescending { it.totalWatchTimeSec }
+                .thenBy { it.userName.lowercase() }
+            UserStatisticsSort.TIME -> compareByDescending<UserStatistics> { it.totalWatchTimeSec }
+                .thenByDescending { it.totalPlayCount }
+                .thenBy { it.userName.lowercase() }
+            UserStatisticsSort.NAME -> compareBy<UserStatistics> { it.userName.lowercase() }
+                .thenByDescending { it.totalPlayCount }
+        }
+        return users.sortedWith(comparator)
+    }
+
     fun loadStatistics() {
         launch {
             _state.update { it.copy(isLoading = true, error = null) }
@@ -52,7 +76,7 @@ class UserStatisticsViewModel @Inject constructor(
                     _state.update {
                         it.copy(
                             isLoading = false,
-                            users = users,
+                            users = applySort(users, it.sort),
                             totalUsers = users.size,
                             activeThisWeek = activeCount,
                             totalPlays = totalPlays,
@@ -81,7 +105,7 @@ class UserStatisticsViewModel @Inject constructor(
                     _state.update {
                         it.copy(
                             isRefreshing = false,
-                            users = users,
+                            users = applySort(users, it.sort),
                             totalUsers = users.size,
                             activeThisWeek = activeCount,
                             totalPlays = totalPlays,
@@ -92,5 +116,22 @@ class UserStatisticsViewModel @Inject constructor(
                     _state.update { it.copy(isRefreshing = false) }
                 }
         }
+    }
+
+    fun setSort(sort: UserStatisticsSort) {
+        _state.update {
+            it.copy(
+                sort = sort,
+                users = applySort(it.users, sort),
+            )
+        }
+    }
+
+    fun requestExport() {
+        _state.update { it.copy(shareRequested = true) }
+    }
+
+    fun consumeExportRequest() {
+        _state.update { it.copy(shareRequested = false) }
     }
 }

--- a/feature/admin/src/main/res/values-de/strings.xml
+++ b/feature/admin/src/main/res/values-de/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">Live stoppen</string>
     <string name="admin_start_live_cd">Live starten</string>
     <string name="admin_stop">Stopp</string>
+    <string name="admin_stop_session_cd">Wiedergabe stoppen</string>
+    <string name="admin_stop_session_title">Wiedergabe stoppen?</string>
+    <string name="admin_stop_session_body">Die aktuell auf \"%1$s\" laufende Medienwiedergabe stoppen?</string>
     <string name="admin_run">Ausführen</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">Gerätenamen bearbeiten</string>
     <string name="admin_custom_name">Benutzerdefinierter Name</string>
     <string name="admin_no_devices">Keine Geräte gefunden</string>
+    <string name="admin_devices_search_placeholder">Nach Name oder Benutzer suchen</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">Protokolle</string>
     <string name="admin_no_log_files">Keine Protokolldateien gefunden</string>
     <string name="admin_no_activity_log">Keine Aktivitätsprotokolleinträge</string>
+    <string name="admin_logs_search_placeholder">Nachrichten filtern</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">Plugins</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">von %1$s</string>
     <string name="admin_audit_items_removed">%1$d Elemente entfernt</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">Wiedergaben</string>
+    <string name="user_stats_sort_time">Schauzeit</string>
+    <string name="user_stats_sort_name">Name</string>
+    <string name="user_stats_sort_cd">Sortieren</string>
+    <string name="user_stats_export_cd">CSV exportieren</string>
+    <string name="user_stats_export_shared">Benutzerstatistiken exportiert</string>
 
 </resources>

--- a/feature/admin/src/main/res/values-es/strings.xml
+++ b/feature/admin/src/main/res/values-es/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">Detener en vivo</string>
     <string name="admin_start_live_cd">Iniciar en vivo</string>
     <string name="admin_stop">Detener</string>
+    <string name="admin_stop_session_cd">Detener reproducción</string>
+    <string name="admin_stop_session_title">¿Detener la reproducción?</string>
+    <string name="admin_stop_session_body">¿Detener el medio que se reproduce en \"%1$s\"?</string>
     <string name="admin_run">Ejecutar</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">Editar nombre del dispositivo</string>
     <string name="admin_custom_name">Nombre personalizado</string>
     <string name="admin_no_devices">No se encontraron dispositivos</string>
+    <string name="admin_devices_search_placeholder">Buscar por nombre o usuario</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">Registros</string>
     <string name="admin_no_log_files">No se encontraron archivos de registro</string>
     <string name="admin_no_activity_log">No hay entradas en el registro de actividad</string>
+    <string name="admin_logs_search_placeholder">Filtrar mensajes</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">Plugins</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">de %1$s</string>
     <string name="admin_audit_items_removed">%1$d elementos eliminados</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">Reproducciones</string>
+    <string name="user_stats_sort_time">Tiempo visto</string>
+    <string name="user_stats_sort_name">Nombre</string>
+    <string name="user_stats_sort_cd">Ordenar</string>
+    <string name="user_stats_export_cd">Exportar CSV</string>
+    <string name="user_stats_export_shared">Estadísticas exportadas</string>
 
 </resources>

--- a/feature/admin/src/main/res/values-fr/strings.xml
+++ b/feature/admin/src/main/res/values-fr/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">Arrêter le direct</string>
     <string name="admin_start_live_cd">Démarrer le direct</string>
     <string name="admin_stop">Arrêter</string>
+    <string name="admin_stop_session_cd">Arrêter la lecture</string>
+    <string name="admin_stop_session_title">Arrêter la lecture ?</string>
+    <string name="admin_stop_session_body">Arrêter le média en cours de lecture sur « %1$s » ?</string>
     <string name="admin_run">Exécuter</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">Modifier le nom de l\'appareil</string>
     <string name="admin_custom_name">Nom personnalisé</string>
     <string name="admin_no_devices">Aucun appareil trouvé</string>
+    <string name="admin_devices_search_placeholder">Rechercher par nom ou utilisateur</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">Journaux</string>
     <string name="admin_no_log_files">Aucun fichier journal trouvé</string>
     <string name="admin_no_activity_log">Aucune entrée dans le journal d\'activité</string>
+    <string name="admin_logs_search_placeholder">Filtrer les messages</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">Plugins</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">par %1$s</string>
     <string name="admin_audit_items_removed">%1$d éléments supprimés</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">Lectures</string>
+    <string name="user_stats_sort_time">Temps de visionnage</string>
+    <string name="user_stats_sort_name">Nom</string>
+    <string name="user_stats_sort_cd">Trier</string>
+    <string name="user_stats_export_cd">Exporter CSV</string>
+    <string name="user_stats_export_shared">Statistiques exportées</string>
 
 </resources>

--- a/feature/admin/src/main/res/values-it/strings.xml
+++ b/feature/admin/src/main/res/values-it/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">Ferma live</string>
     <string name="admin_start_live_cd">Avvia live</string>
     <string name="admin_stop">Ferma</string>
+    <string name="admin_stop_session_cd">Ferma riproduzione</string>
+    <string name="admin_stop_session_title">Fermare la riproduzione?</string>
+    <string name="admin_stop_session_body">Fermare il media attualmente in riproduzione su \"%1$s\"?</string>
     <string name="admin_run">Esegui</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">Modifica nome dispositivo</string>
     <string name="admin_custom_name">Nome personalizzato</string>
     <string name="admin_no_devices">Nessun dispositivo trovato</string>
+    <string name="admin_devices_search_placeholder">Cerca per nome o utente</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">Log</string>
     <string name="admin_no_log_files">Nessun file di log trovato</string>
     <string name="admin_no_activity_log">Nessuna voce nel log attività</string>
+    <string name="admin_logs_search_placeholder">Filtra messaggi</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">Plugin</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">di %1$s</string>
     <string name="admin_audit_items_removed">%1$d elementi rimossi</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">Riproduzioni</string>
+    <string name="user_stats_sort_time">Tempo di visione</string>
+    <string name="user_stats_sort_name">Nome</string>
+    <string name="user_stats_sort_cd">Ordina</string>
+    <string name="user_stats_export_cd">Esporta CSV</string>
+    <string name="user_stats_export_shared">Statistiche esportate</string>
 
 </resources>

--- a/feature/admin/src/main/res/values-ja/strings.xml
+++ b/feature/admin/src/main/res/values-ja/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">ライブを停止</string>
     <string name="admin_start_live_cd">ライブを開始</string>
     <string name="admin_stop">停止</string>
+    <string name="admin_stop_session_cd">再生を停止</string>
+    <string name="admin_stop_session_title">再生を停止しますか？</string>
+    <string name="admin_stop_session_body">「%1$s」で再生中のメディアを停止しますか？</string>
     <string name="admin_run">実行</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">デバイス名を編集</string>
     <string name="admin_custom_name">カスタム名</string>
     <string name="admin_no_devices">デバイスが見つかりません</string>
+    <string name="admin_devices_search_placeholder">名前またはユーザーで検索</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">ログ</string>
     <string name="admin_no_log_files">ログファイルが見つかりません</string>
     <string name="admin_no_activity_log">アクティビティログのエントリがありません</string>
+    <string name="admin_logs_search_placeholder">メッセージを絞り込み</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">プラグイン</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">から %1$s</string>
     <string name="admin_audit_items_removed">%1$d 件削除済み</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">再生回数</string>
+    <string name="user_stats_sort_time">視聴時間</string>
+    <string name="user_stats_sort_name">名前</string>
+    <string name="user_stats_sort_cd">並び替え</string>
+    <string name="user_stats_export_cd">CSVをエクスポート</string>
+    <string name="user_stats_export_shared">エクスポートしました</string>
 
 </resources>

--- a/feature/admin/src/main/res/values-ko/strings.xml
+++ b/feature/admin/src/main/res/values-ko/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">라이브 중지</string>
     <string name="admin_start_live_cd">라이브 시작</string>
     <string name="admin_stop">중지</string>
+    <string name="admin_stop_session_cd">재생 중지</string>
+    <string name="admin_stop_session_title">재생을 중지하시겠습니까?</string>
+    <string name="admin_stop_session_body">\"%1$s\"에서 재생 중인 미디어를 중지하시겠습니까?</string>
     <string name="admin_run">실행</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">기기 이름 편집</string>
     <string name="admin_custom_name">사용자 지정 이름</string>
     <string name="admin_no_devices">기기를 찾을 수 없습니다</string>
+    <string name="admin_devices_search_placeholder">이름 또는 사용자로 검색</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">로그</string>
     <string name="admin_no_log_files">로그 파일을 찾을 수 없습니다</string>
     <string name="admin_no_activity_log">활동 로그 항목이 없습니다</string>
+    <string name="admin_logs_search_placeholder">메시지 필터</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">플러그인</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">에서 %1$s</string>
     <string name="admin_audit_items_removed">%1$d개 항목 제거됨</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">재생 수</string>
+    <string name="user_stats_sort_time">시청 시간</string>
+    <string name="user_stats_sort_name">이름</string>
+    <string name="user_stats_sort_cd">정렬</string>
+    <string name="user_stats_export_cd">CSV 내보내기</string>
+    <string name="user_stats_export_shared">내보냈습니다</string>
 
 </resources>

--- a/feature/admin/src/main/res/values-pt/strings.xml
+++ b/feature/admin/src/main/res/values-pt/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">Parar ao vivo</string>
     <string name="admin_start_live_cd">Iniciar ao vivo</string>
     <string name="admin_stop">Parar</string>
+    <string name="admin_stop_session_cd">Parar reprodução</string>
+    <string name="admin_stop_session_title">Parar a reprodução?</string>
+    <string name="admin_stop_session_body">Parar a mídia em reprodução em \"%1$s\"?</string>
     <string name="admin_run">Executar</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">Editar nome do dispositivo</string>
     <string name="admin_custom_name">Nome personalizado</string>
     <string name="admin_no_devices">Nenhum dispositivo encontrado</string>
+    <string name="admin_devices_search_placeholder">Pesquisar por nome ou usuário</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">Registros</string>
     <string name="admin_no_log_files">Nenhum arquivo de registro encontrado</string>
     <string name="admin_no_activity_log">Nenhuma entrada no registro de atividade</string>
+    <string name="admin_logs_search_placeholder">Filtrar mensagens</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">Plugins</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">por %1$s</string>
     <string name="admin_audit_items_removed">%1$d itens removidos</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">Reproduções</string>
+    <string name="user_stats_sort_time">Tempo de visualização</string>
+    <string name="user_stats_sort_name">Nome</string>
+    <string name="user_stats_sort_cd">Ordenar</string>
+    <string name="user_stats_export_cd">Exportar CSV</string>
+    <string name="user_stats_export_shared">Estatísticas exportadas</string>
 
 </resources>

--- a/feature/admin/src/main/res/values-zh/strings.xml
+++ b/feature/admin/src/main/res/values-zh/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">停止直播</string>
     <string name="admin_start_live_cd">开始直播</string>
     <string name="admin_stop">停止</string>
+    <string name="admin_stop_session_cd">停止播放</string>
+    <string name="admin_stop_session_title">停止播放？</string>
+    <string name="admin_stop_session_body">停止“%1$s”上正在播放的媒体？</string>
     <string name="admin_run">运行</string>
 
     <!-- Relative time -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">编辑设备名称</string>
     <string name="admin_custom_name">自定义名称</string>
     <string name="admin_no_devices">未找到设备</string>
+    <string name="admin_devices_search_placeholder">按名称或用户搜索</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">日志</string>
     <string name="admin_no_log_files">未找到日志文件</string>
     <string name="admin_no_activity_log">没有活动日志条目</string>
+    <string name="admin_logs_search_placeholder">筛选消息</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">插件</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">作者：%1$s</string>
     <string name="admin_audit_items_removed">已删除 %1$d 项</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">播放次数</string>
+    <string name="user_stats_sort_time">观看时长</string>
+    <string name="user_stats_sort_name">名称</string>
+    <string name="user_stats_sort_cd">排序</string>
+    <string name="user_stats_export_cd">导出 CSV</string>
+    <string name="user_stats_export_shared">已导出</string>
 
 </resources>

--- a/feature/admin/src/main/res/values/strings.xml
+++ b/feature/admin/src/main/res/values/strings.xml
@@ -38,6 +38,9 @@
     <string name="admin_stop_live_cd">Stop Live</string>
     <string name="admin_start_live_cd">Start Live</string>
     <string name="admin_stop">Stop</string>
+    <string name="admin_stop_session_cd">Stop playback</string>
+    <string name="admin_stop_session_title">Stop playback?</string>
+    <string name="admin_stop_session_body">Stop the media currently playing on \"%1$s\"?</string>
     <string name="admin_run">Run</string>
 
     <!-- Relative time (DevicesScreen.formatRelativeTime) -->
@@ -79,11 +82,13 @@
     <string name="admin_edit_device_name_title">Edit Device Name</string>
     <string name="admin_custom_name">Custom Name</string>
     <string name="admin_no_devices">No devices found</string>
+    <string name="admin_devices_search_placeholder">Search by name or user</string>
 
     <!-- LogsScreen -->
     <string name="admin_logs_title">Logs</string>
     <string name="admin_no_log_files">No log files found</string>
     <string name="admin_no_activity_log">No activity log entries</string>
+    <string name="admin_logs_search_placeholder">Filter messages</string>
 
     <!-- Plugins -->
     <string name="admin_plugins_title">Plugins</string>
@@ -380,5 +385,13 @@
     <!-- Audit history row labels (batch) -->
     <string name="admin_audit_by_user">by %1$s</string>
     <string name="admin_audit_items_removed">%1$d items removed</string>
+
+    <!-- User statistics sort & export -->
+    <string name="user_stats_sort_plays">Play count</string>
+    <string name="user_stats_sort_time">Watch time</string>
+    <string name="user_stats_sort_name">Name</string>
+    <string name="user_stats_sort_cd">Sort</string>
+    <string name="user_stats_export_cd">Export CSV</string>
+    <string name="user_stats_export_shared">User statistics exported</string>
 
 </resources>

--- a/feature/auth/src/main/java/com/raulshma/jellyplay/feature/auth/AuthViewModel.kt
+++ b/feature/auth/src/main/java/com/raulshma/jellyplay/feature/auth/AuthViewModel.kt
@@ -2,8 +2,10 @@ package com.raulshma.jellyplay.feature.auth
 
 import android.content.Context
 import com.raulshma.jellyplay.core.data.repository.AuthRepository
+import com.raulshma.jellyplay.core.model.ServerHealth
 import com.raulshma.jellyplay.core.model.ServerInfo
 import com.raulshma.jellyplay.core.model.UserInfo
+import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -25,11 +27,15 @@ sealed class QuickConnectUiState {
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val authRepository: AuthRepository,
+    private val apiClient: JellyfinApiClient,
     @ApplicationContext private val appContext: Context,
 ) : JellyPlayViewModel() {
 
     val servers = authRepository.servers
         .stateIn(scope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    private val _serverHealth = stateFlow<Map<String, ServerHealth>>(emptyMap())
+    val serverHealth = _serverHealth.flow
 
     val currentServerUsers = authRepository.currentServerUsers
         .stateIn(scope, SharingStarted.WhileSubscribed(5_000), emptyList())
@@ -54,6 +60,35 @@ class AuthViewModel @Inject constructor(
     fun removeServer(serverId: String) {
         launch {
             authRepository.removeServer(serverId)
+        }
+    }
+
+    /**
+     * Pings each saved server once and publishes per-address [ServerHealth]
+     * into [serverHealth]. Safe to call repeatedly; concurrent calls are
+     * guarded by cancelling any in-flight batch.
+     */
+    private var healthCheckJob: Job? = null
+    fun checkServersHealth(addresses: List<String>) {
+        healthCheckJob?.cancel()
+        if (addresses.isEmpty()) {
+            _serverHealth.set(emptyMap())
+            return
+        }
+        // Immediately mark everything as Checking so the UI can render a dot.
+        _serverHealth.set(addresses.associateWith { ServerHealth.Checking })
+        healthCheckJob = launch {
+            addresses.forEach { address ->
+                val startTime = System.currentTimeMillis()
+                val result = apiClient.getServerInfo(address)
+                val latency = System.currentTimeMillis() - startTime
+                val health = if (result.isSuccess) {
+                    ServerHealth.Healthy(latencyMs = latency)
+                } else {
+                    ServerHealth.Unreachable
+                }
+                _serverHealth.update { it + (address to health) }
+            }
         }
     }
 
@@ -188,5 +223,6 @@ class AuthViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         quickConnectPollingJob?.cancel()
+        healthCheckJob?.cancel()
     }
 }

--- a/feature/auth/src/main/java/com/raulshma/jellyplay/feature/auth/ServerListScreen.kt
+++ b/feature/auth/src/main/java/com/raulshma/jellyplay/feature/auth/ServerListScreen.kt
@@ -3,6 +3,7 @@ package com.raulshma.jellyplay.feature.auth
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
@@ -35,6 +37,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import com.raulshma.jellyplay.core.model.ServerHealth
 import com.raulshma.jellyplay.core.designsystem.theme.LocalIsSynthwave
 import com.raulshma.jellyplay.core.designsystem.theme.LocalIsSoothingTheme
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
@@ -47,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
@@ -81,11 +85,17 @@ fun ServerListScreen(
 ) {
     val servers by viewModel.servers.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val serverHealth by viewModel.serverHealth.collectAsStateWithLifecycle()
 
     val isSynthwave = LocalIsSynthwave.current
     val backgroundColor = rememberScreenBackgroundColor()
 
     val navOffsetPx = LocalFloatingNavOffset.current
+
+    // One-shot reachability ping per saved server on screen entry.
+    LaunchedEffect(servers.map { it.address }) {
+        viewModel.checkServersHealth(servers.map { it.address })
+    }
 
     Scaffold(
         containerColor = backgroundColor,
@@ -144,6 +154,7 @@ fun ServerListScreen(
                         ) {
                             ServerItem(
                                 server = server,
+                                health = serverHealth[server.address],
                                 firstFocusModifier = if (index == 0) Modifier.focusRequester(firstItemFocusRequester) else Modifier,
                                 onClick = { onServerSelected(server) },
                                 onDelete = { viewModel.removeServer(server.id) },
@@ -181,6 +192,7 @@ fun ServerListScreen(
 @Composable
 private fun ServerItem(
     server: ServerInfo,
+    health: ServerHealth?,
     onClick: () -> Unit,
     onDelete: () -> Unit,
     firstFocusModifier: Modifier = Modifier,
@@ -241,6 +253,10 @@ private fun ServerItem(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                if (health != null) {
+                    Spacer(modifier = Modifier.size(6.dp))
+                    ServerHealthBadge(health = health)
+                }
             }
             val deleteFocusState = rememberTvFocusState()
             IconButton(
@@ -264,6 +280,36 @@ private fun ServerItem(
             dismissText = stringResource(R.string.auth_cancel),
             onConfirm = onDelete,
             onDismiss = { showDeleteConfirm = false },
+        )
+    }
+}
+
+@Composable
+private fun ServerHealthBadge(
+    health: ServerHealth,
+) {
+    val (dotColor, label) = when (health) {
+        is ServerHealth.Healthy -> MaterialTheme.colorScheme.tertiary to
+            stringResource(R.string.server_health_healthy)
+        is ServerHealth.Unreachable -> MaterialTheme.colorScheme.error to
+            stringResource(R.string.server_health_unreachable)
+        is ServerHealth.Checking -> MaterialTheme.colorScheme.outline to
+            stringResource(R.string.server_health_checking)
+        is ServerHealth.Unknown -> MaterialTheme.colorScheme.outline to
+            stringResource(R.string.server_health_checking)
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(dotColor),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/feature/auth/src/main/res/values-de/strings.xml
+++ b/feature/auth/src/main/res/values-de/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">Schnellverbindung</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">Online</string>
+    <string name="server_health_unreachable">Offline</string>
+    <string name="server_health_checking">Prüfen…</string>
 </resources>

--- a/feature/auth/src/main/res/values-es/strings.xml
+++ b/feature/auth/src/main/res/values-es/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">Conexión rápida</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">En línea</string>
+    <string name="server_health_unreachable">Sin conexión</string>
+    <string name="server_health_checking">Comprobando…</string>
 </resources>

--- a/feature/auth/src/main/res/values-fr/strings.xml
+++ b/feature/auth/src/main/res/values-fr/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">Connexion rapide</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">En ligne</string>
+    <string name="server_health_unreachable">Hors ligne</string>
+    <string name="server_health_checking">Vérification…</string>
 </resources>

--- a/feature/auth/src/main/res/values-it/strings.xml
+++ b/feature/auth/src/main/res/values-it/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">Connessione rapida</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">Online</string>
+    <string name="server_health_unreachable">Offline</string>
+    <string name="server_health_checking">Verifica…</string>
 </resources>

--- a/feature/auth/src/main/res/values-ja/strings.xml
+++ b/feature/auth/src/main/res/values-ja/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">クイック接続</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">オンライン</string>
+    <string name="server_health_unreachable">オフライン</string>
+    <string name="server_health_checking">確認中…</string>
 </resources>

--- a/feature/auth/src/main/res/values-ko/strings.xml
+++ b/feature/auth/src/main/res/values-ko/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">빠른 연결</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">온라인</string>
+    <string name="server_health_unreachable">오프라인</string>
+    <string name="server_health_checking">확인 중…</string>
 </resources>

--- a/feature/auth/src/main/res/values-pt/strings.xml
+++ b/feature/auth/src/main/res/values-pt/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">Ligação rápida</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">Online</string>
+    <string name="server_health_unreachable">Offline</string>
+    <string name="server_health_checking">Verificando…</string>
 </resources>

--- a/feature/auth/src/main/res/values-zh/strings.xml
+++ b/feature/auth/src/main/res/values-zh/strings.xml
@@ -87,4 +87,9 @@
 
     <!-- auto-localized: previously translatable="false" (1) -->
     <string name="auth_quick_connect">快速连接</string>
+
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">在线</string>
+    <string name="server_health_unreachable">离线</string>
+    <string name="server_health_checking">检查中…</string>
 </resources>

--- a/feature/auth/src/main/res/values/strings.xml
+++ b/feature/auth/src/main/res/values/strings.xml
@@ -80,6 +80,11 @@
     <string name="auth_remove_server_message">This removes \"%1$s\" and every saved user on it. This can\'t be undone.</string>
     <string name="auth_remove">Remove</string>
 
+    <!-- Server health indicator -->
+    <string name="server_health_healthy">Online</string>
+    <string name="server_health_unreachable">Offline</string>
+    <string name="server_health_checking">Checking…</string>
+
     <!-- User selection screen -->
     <string name="auth_loading_users">Loading users…</string>
     <string name="auth_no_users_title">No users on this server</string>

--- a/feature/auth/src/test/java/com/raulshma/jellyplay/feature/auth/AuthViewModelTest.kt
+++ b/feature/auth/src/test/java/com/raulshma/jellyplay/feature/auth/AuthViewModelTest.kt
@@ -3,6 +3,7 @@ package com.raulshma.jellyplay.feature.auth
 import android.content.Context
 import com.raulshma.jellyplay.core.data.repository.AuthRepository
 import com.raulshma.jellyplay.core.model.QuickConnectInfo
+import com.raulshma.jellyplay.core.network.JellyfinApiClient
 import com.raulshma.jellyplay.core.model.QuickConnectState
 import com.raulshma.jellyplay.core.model.UserInfo
 import io.mockk.coEvery
@@ -41,7 +42,8 @@ class AuthViewModelTest {
         // route those two keys to the real strings.xml values.
         every { appContext.getString(R.string.auth_qc_error_not_enabled) } returns "Quick Connect is not enabled on this server"
         every { appContext.getString(R.string.auth_qc_error_timeout) } returns "Quick Connect timed out. Please try again."
-        viewModel = AuthViewModel(authRepository, appContext)
+        val apiClient = mockk<JellyfinApiClient>()
+        viewModel = AuthViewModel(authRepository, apiClient, appContext)
     }
 
     @After

--- a/feature/calendar/src/main/java/com/raulshma/jellyplay/feature/calendar/UpcomingCalendarScreen.kt
+++ b/feature/calendar/src/main/java/com/raulshma/jellyplay/feature/calendar/UpcomingCalendarScreen.kt
@@ -1,5 +1,6 @@
 package com.raulshma.jellyplay.feature.calendar
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,6 +16,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -27,9 +30,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -54,6 +61,7 @@ import com.raulshma.jellyplay.core.ui.feedback.LocalUserMessageBus
 import com.raulshma.jellyplay.core.ui.feedback.uiTextOf
 import com.raulshma.jellyplay.core.model.arr.ArrMediaType
 import java.time.LocalDate
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -68,6 +76,24 @@ fun UpcomingCalendarScreen(
     val userMessageBus = LocalUserMessageBus.current
     val listState = rememberLazyListState()
     val today = remember { today() }
+
+    // Tap-month → date-picker affordance. After a date is picked the
+    // visible month swaps (if needed) and the list scrolls to that day's row.
+    var showDatePicker by remember { mutableStateOf(false) }
+    var pendingScrollDate by remember { mutableStateOf<LocalDate?>(null) }
+
+    // Scroll the day-header for [pendingScrollDate] into view once the items
+    // for its month have loaded. Re-runs whenever the items snapshot changes.
+    LaunchedEffect(pendingScrollDate, state.items) {
+        val target = pendingScrollDate ?: return@LaunchedEffect
+        val dayGroups = groupByDay(state.items, state.filter)
+        val index = dayGroups.indexOfFirst { it.date == target }
+        if (index >= 0) {
+            // +2 offsets for the two leading header items (monthNav, filterRow).
+            listState.animateScrollToItem(index + 2)
+            pendingScrollDate = null
+        }
+    }
 
     JellyPlayScreenScaffold(
         title = stringResource(R.string.calendar_title),
@@ -135,6 +161,7 @@ fun UpcomingCalendarScreen(
                                         onPrevious = { viewModel.changeMonth(-1) },
                                         onNext = { viewModel.changeMonth(1) },
                                         onToday = { viewModel.goToToday() },
+                                        onLabelClick = { showDatePicker = true },
                                     )
                                 }
                                 item(key = "filterRow") {
@@ -178,6 +205,40 @@ fun UpcomingCalendarScreen(
                 }
             }
         }
+
+        if (showDatePicker) {
+            val datePickerState = rememberDatePickerState(
+                initialSelectedDateMillis = state.visibleMonth
+                    .atDay(1)
+                    .atStartOfDay(ZoneId.systemDefault())
+                    .toInstant()
+                    .toEpochMilli(),
+            )
+            DatePickerDialog(
+                onDismissRequest = { showDatePicker = false },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            datePickerState.selectedDateMillis?.let { millis ->
+                                val picked = LocalDate.ofEpochDay(millis / 86_400_000L)
+                                viewModel.goToDate(picked)
+                                pendingScrollDate = picked
+                            }
+                            showDatePicker = false
+                        },
+                    ) {
+                        Text(stringResource(com.raulshma.jellyplay.core.ui.R.string.core_ok))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showDatePicker = false }) {
+                        Text(stringResource(com.raulshma.jellyplay.core.ui.R.string.core_cancel))
+                    }
+                },
+            ) {
+                DatePicker(state = datePickerState)
+            }
+        }
     }
 }
 
@@ -190,6 +251,7 @@ private fun MonthNavHeader(
     onPrevious: () -> Unit,
     onNext: () -> Unit,
     onToday: () -> Unit,
+    onLabelClick: () -> Unit = {},
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -203,12 +265,36 @@ private fun MonthNavHeader(
             IconButton(onClick = onPrevious, enabled = canGoBack) {
                 Icon(Tabler.Outline.ChevronLeft, contentDescription = stringResource(R.string.calendar_prev_month_cd))
             }
-            Text(
-                text = label,
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.weight(1f),
-            )
+            // Tapping the month label opens a date picker so the user can
+            // jump straight to a day instead of paging month by month.
+            val pickDateLabel = stringResource(R.string.calendar_pick_date_cd)
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(
+                        interactionSource = remember { androidx.compose.foundation.interaction.MutableInteractionSource() },
+                        indication = null,
+                        onClickLabel = pickDateLabel,
+                        role = androidx.compose.ui.semantics.Role.Button,
+                        onClick = onLabelClick,
+                    )
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.size(6.dp))
+                Icon(
+                    Tabler.Outline.Calendar,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             IconButton(onClick = onNext) {
                 Icon(Tabler.Outline.ChevronRight, contentDescription = stringResource(R.string.calendar_next_month_cd))
             }

--- a/feature/calendar/src/main/java/com/raulshma/jellyplay/feature/calendar/UpcomingCalendarViewModel.kt
+++ b/feature/calendar/src/main/java/com/raulshma/jellyplay/feature/calendar/UpcomingCalendarViewModel.kt
@@ -197,6 +197,22 @@ class UpcomingCalendarViewModel @Inject constructor(
         refresh()
     }
 
+    /**
+     * Jumps the visible month to the month containing [date] (used by the
+     * tap-month → date-picker affordance). If the month is already visible
+     * this is a no-op fetch; otherwise it swaps the month + refreshes like
+     * [changeMonth]. Returns whether the month actually changed, so the
+     * caller can decide whether to request a scroll-to-day.
+     */
+    fun goToDate(date: LocalDate): Boolean {
+        val target = YearMonth.from(date)
+        if (_state.value.visibleMonth == target) return false
+        _state.value = _state.value.copy(visibleMonth = target, items = emptyList(), error = null)
+        startMonthCollector()
+        refresh()
+        return true
+    }
+
     /** Pure client-side filter switch; no network. */
     fun setFilter(filter: CalendarFilter) {
         _state.value = _state.value.copy(filter = filter)

--- a/feature/calendar/src/main/res/values-de/strings.xml
+++ b/feature/calendar/src/main/res/values-de/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">Heute</string>
+    <string name="calendar_pick_date_cd">Datum wählen</string>
     <string name="calendar_prev_month_cd">Vorheriger Monat</string>
     <string name="calendar_next_month_cd">Nächster Monat</string>
     <string name="calendar_refresh_cd">Aktualisieren</string>

--- a/feature/calendar/src/main/res/values-es/strings.xml
+++ b/feature/calendar/src/main/res/values-es/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">Hoy</string>
+    <string name="calendar_pick_date_cd">Elegir fecha</string>
     <string name="calendar_prev_month_cd">Mes anterior</string>
     <string name="calendar_next_month_cd">Mes siguiente</string>
     <string name="calendar_refresh_cd">Actualizar</string>

--- a/feature/calendar/src/main/res/values-fr/strings.xml
+++ b/feature/calendar/src/main/res/values-fr/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">Aujourd\'hui</string>
+    <string name="calendar_pick_date_cd">Choisir une date</string>
     <string name="calendar_prev_month_cd">Mois précédent</string>
     <string name="calendar_next_month_cd">Mois suivant</string>
     <string name="calendar_refresh_cd">Actualiser</string>

--- a/feature/calendar/src/main/res/values-it/strings.xml
+++ b/feature/calendar/src/main/res/values-it/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">Oggi</string>
+    <string name="calendar_pick_date_cd">Scegli una data</string>
     <string name="calendar_prev_month_cd">Mese precedente</string>
     <string name="calendar_next_month_cd">Mese successivo</string>
     <string name="calendar_refresh_cd">Aggiorna</string>

--- a/feature/calendar/src/main/res/values-ja/strings.xml
+++ b/feature/calendar/src/main/res/values-ja/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">今日</string>
+    <string name="calendar_pick_date_cd">日付を選択</string>
     <string name="calendar_prev_month_cd">前の月</string>
     <string name="calendar_next_month_cd">翌月</string>
     <string name="calendar_refresh_cd">更新</string>

--- a/feature/calendar/src/main/res/values-ko/strings.xml
+++ b/feature/calendar/src/main/res/values-ko/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">오늘</string>
+    <string name="calendar_pick_date_cd">날짜 선택</string>
     <string name="calendar_prev_month_cd">이전 달</string>
     <string name="calendar_next_month_cd">다음 달</string>
     <string name="calendar_refresh_cd">새로고침</string>

--- a/feature/calendar/src/main/res/values-pt/strings.xml
+++ b/feature/calendar/src/main/res/values-pt/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">Hoje</string>
+    <string name="calendar_pick_date_cd">Escolher data</string>
     <string name="calendar_prev_month_cd">Mês anterior</string>
     <string name="calendar_next_month_cd">Mês seguinte</string>
     <string name="calendar_refresh_cd">Atualizar</string>

--- a/feature/calendar/src/main/res/values-zh/strings.xml
+++ b/feature/calendar/src/main/res/values-zh/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">今天</string>
+    <string name="calendar_pick_date_cd">选择日期</string>
     <string name="calendar_prev_month_cd">上个月</string>
     <string name="calendar_next_month_cd">下个月</string>
     <string name="calendar_refresh_cd">刷新</string>

--- a/feature/calendar/src/main/res/values/strings.xml
+++ b/feature/calendar/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
 
     <!-- Month nav -->
     <string name="calendar_today">Today</string>
+    <string name="calendar_pick_date_cd">Pick a date</string>
     <string name="calendar_prev_month_cd">Previous month</string>
     <string name="calendar_next_month_cd">Next month</string>
     <string name="calendar_refresh_cd">Refresh</string>

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/ManageSeriesScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/ManageSeriesScreen.kt
@@ -149,7 +149,6 @@ fun ManageSeriesScreen(
             hostState = snackbarHostState,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .fillMaxWidth()
                 .padding(bottom = 80.dp),
         )
     }

--- a/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
+++ b/feature/details/src/main/java/com/raulshma/jellyplay/feature/details/MediaDetailScreen.kt
@@ -3,7 +3,6 @@ package com.raulshma.jellyplay.feature.details
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
@@ -486,7 +485,6 @@ fun MediaDetailScreen(
             hostState = snackbarHostState,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .fillMaxWidth()
                 .padding(bottom = 80.dp),
         )
 

--- a/feature/downloads/src/main/java/com/raulshma/jellyplay/feature/downloads/DownloadsScreen.kt
+++ b/feature/downloads/src/main/java/com/raulshma/jellyplay/feature/downloads/DownloadsScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.TriStateCheckbox
 import com.raulshma.jellyplay.core.designsystem.theme.Dimensions
 import com.raulshma.jellyplay.core.ui.components.JellyPlayLinearProgressIndicator
+import com.raulshma.jellyplay.core.ui.components.episodeContextLine
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -65,10 +66,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.state.ToggleableState
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -860,43 +858,6 @@ private fun SelectionHintRow() {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-    }
-}
-
-/**
- * Builds the single-line episode context ("**SXXEXX** · Series Name") used by the
- * downloads list row and both resync sheets, so episodes are identifiable in a
- * flat list. The SxxExx tag is bolded and the series name follows in the
- * default weight — exactly the styling the main downloads list row uses, so the
- * sheets match it visually (not just textually).
- *
- * Returns null when the item carries no episode context (movies/standalone
- * items or a non-episode type), so callers can omit the line entirely. The
- * single source of truth for the SxxExx + " · " + series shape — the downloads
- * list row, the resync sheet rows and the force-resync picker all render it via
- * this helper so a format change edits one place.
- */
-private fun episodeContextLine(
-    mediaType: com.raulshma.jellyplay.core.model.MediaType?,
-    seriesName: String?,
-    seasonNumber: Int?,
-    episodeNumber: Int?,
-): androidx.compose.ui.text.AnnotatedString? {
-    if (mediaType != com.raulshma.jellyplay.core.model.MediaType.EPISODE) return null
-    val tag = seasonNumber?.let { s ->
-        episodeNumber?.let { e ->
-            "S${s.toString().padStart(2, '0')}E${e.toString().padStart(2, '0')}"
-        }
-    }
-    val series = seriesName?.takeIf { it.isNotBlank() } ?: return tag?.let { plainTag ->
-        buildAnnotatedString { withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(plainTag) } }
-    }
-    return buildAnnotatedString {
-        if (tag != null) {
-            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(tag) }
-            append(" · ")
-        }
-        append(series)
     }
 }
 

--- a/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/raulshma/jellyplay/feature/home/HomeViewModel.kt
@@ -37,6 +37,7 @@ import com.raulshma.jellyplay.core.data.repository.PlaybackOutboxEntry
 import com.raulshma.jellyplay.core.data.worker.PlaybackSyncScheduler
 import com.raulshma.jellyplay.core.data.worker.TvWatchNextScheduler
 import com.raulshma.jellyplay.core.data.widget.ContinueWatchingBroadcaster
+import com.raulshma.jellyplay.core.data.widget.LibrarySyncHook
 import com.raulshma.jellyplay.core.model.UserInfo
 import com.raulshma.jellyplay.core.model.seerr.DiscoverSectionType
 import com.raulshma.jellyplay.core.model.seerr.SeerrSearchResponse
@@ -118,6 +119,7 @@ class HomeViewModel @Inject constructor(
     private val arrRepository: ArrRepository,
     private val tvWatchNextScheduler: TvWatchNextScheduler,
     private val continueWatchingBroadcaster: ContinueWatchingBroadcaster,
+    private val librarySyncHook: LibrarySyncHook,
     private val timeSource: TimeSource,
 ) : JellyPlayViewModel(), DefaultLifecycleObserver {
 
@@ -1090,6 +1092,13 @@ class HomeViewModel @Inject constructor(
                         }
 
                         _uiState.update { it.copy(error = null) }
+
+                        // A successful foreground library scan is the
+                        // shared hook for the auto-download foreground drain and
+                        // the widget recommendations refresh. Wrapped in try/catch
+                        // (the impl also self-guards) so a downstream failure can
+                        // never break the home refresh.
+                        runCatching { librarySyncHook.onLibraryScanComplete() }
                     }
                     .onFailure { throwable ->
                         if (_uiState.value.sections.isEmpty()) {

--- a/feature/home/src/test/java/com/raulshma/jellyplay/feature/home/HomeViewModelTest.kt
+++ b/feature/home/src/test/java/com/raulshma/jellyplay/feature/home/HomeViewModelTest.kt
@@ -20,6 +20,7 @@ import com.raulshma.jellyplay.core.data.util.ImageUrlProvider
 import com.raulshma.jellyplay.core.data.util.PhotoFolderPrefetcher
 import com.raulshma.jellyplay.core.data.util.TimeSource
 import com.raulshma.jellyplay.core.data.widget.ContinueWatchingBroadcaster
+import com.raulshma.jellyplay.core.data.widget.LibrarySyncHook
 import com.raulshma.jellyplay.core.data.worker.PlaybackSyncScheduler
 import com.raulshma.jellyplay.core.data.worker.TvWatchNextScheduler
 import com.raulshma.jellyplay.core.datastore.PreferencesEditScope
@@ -111,6 +112,7 @@ class HomeViewModelTest {
     private lateinit var arrRepository: ArrRepository
     private lateinit var tvWatchNextScheduler: TvWatchNextScheduler
     private lateinit var continueWatchingBroadcaster: ContinueWatchingBroadcaster
+    private lateinit var librarySyncHook: LibrarySyncHook
     private lateinit var playbackOutboxRepository: PlaybackOutboxRepository
     private lateinit var playbackSyncScheduler: PlaybackSyncScheduler
     private lateinit var fakeTimeSource: FakeTimeSource
@@ -153,6 +155,7 @@ class HomeViewModelTest {
         arrRepository = mockk(relaxed = true)
         tvWatchNextScheduler = mockk(relaxed = true)
         continueWatchingBroadcaster = mockk(relaxed = true)
+        librarySyncHook = mockk(relaxed = true)
         playbackOutboxRepository = mockk(relaxed = true)
         playbackSyncScheduler = mockk(relaxed = true)
         fakeTimeSource = FakeTimeSource()
@@ -204,6 +207,7 @@ class HomeViewModelTest {
         arrRepository = arrRepository,
         tvWatchNextScheduler = tvWatchNextScheduler,
         continueWatchingBroadcaster = continueWatchingBroadcaster,
+        librarySyncHook = librarySyncHook,
         timeSource = fakeTimeSource,
     )
 

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/FavoritesScreen.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/FavoritesScreen.kt
@@ -212,12 +212,14 @@ private fun MediaTypeFilterRow(
     selectedType: MediaType?,
     onTypeSelected: (MediaType?) -> Unit,
 ) {
+    // (type, string resource) pairs — labels resolved at render time so they
+    // follow the active locale. Reuses the shared core media-type strings.
     val filterTypes = remember {
-        listOf<Pair<MediaType?, String>>(
-            null to "All",
-            MediaType.MOVIE to "Movies",
-            MediaType.SERIES to "TV Shows",
-            MediaType.EPISODE to "Episodes",
+        listOf<Pair<MediaType?, Int>>(
+            null to R.string.library_all,
+            MediaType.MOVIE to com.raulshma.jellyplay.core.ui.R.string.core_media_movie_plural,
+            MediaType.SERIES to com.raulshma.jellyplay.core.ui.R.string.core_media_series_plural,
+            MediaType.EPISODE to com.raulshma.jellyplay.core.ui.R.string.core_media_episode_plural,
         )
     }
 
@@ -227,8 +229,9 @@ private fun MediaTypeFilterRow(
             .padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        filterTypes.forEach { (type, label) ->
+        filterTypes.forEach { (type, labelRes) ->
             val isSelected = selectedType == type
+            val label = stringResource(labelRes)
             val containerColor by animateColorAsState(
                 targetValue = if (isSelected) MaterialTheme.colorScheme.primaryContainer
                 else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
@@ -64,6 +64,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import com.raulshma.jellyplay.core.ui.components.JellyPlayLinearProgressIndicator
 import com.raulshma.jellyplay.core.ui.components.libraryListSubtitle
+import com.raulshma.jellyplay.core.ui.components.displayTitle
+import com.raulshma.jellyplay.core.ui.components.rememberSeriesImageFallback
 import com.raulshma.jellyplay.core.ui.components.progressFraction
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
@@ -147,6 +149,7 @@ import com.raulshma.jellyplay.feature.library.components.GenreFilterSheet
 import com.raulshma.jellyplay.feature.library.components.TagFilterSheet
 import com.raulshma.jellyplay.feature.library.components.YearRangeFilterSheet
 import com.raulshma.jellyplay.feature.library.components.LibraryListItem
+import com.raulshma.jellyplay.feature.library.components.LibraryResetConfirmDialog
 import com.raulshma.jellyplay.feature.library.components.ThumbCard
 import com.raulshma.jellyplay.core.ui.animation.animateContentSizeNoClip
 import com.raulshma.jellyplay.core.ui.animation.isReducedMotion
@@ -186,6 +189,7 @@ fun LibraryScreen(
     val sectionTitle by viewModel.title.collectAsStateWithLifecycle()
     val posterSize by viewModel.posterSize.collectAsStateWithLifecycle()
     val groupBy by viewModel.groupBy.collectAsStateWithLifecycle()
+    val resetDialogVisible by viewModel.resetDialogVisible.collectAsStateWithLifecycle()
 
     // Section mode: configure the VM once with the injected context. Idempotent
     // (configureSection early-returns on an equal context) so recomposition is
@@ -245,10 +249,11 @@ fun LibraryScreen(
         }
     }
     val isAnySheetOpen = openFilterSheet != null || showPosterSizeSheet || showGroupBySheet
-    val backHandlerEnabled = showFilters || isAnySheetOpen || (!inSectionMode && hasActiveFilters)
+    val backHandlerEnabled = showFilters || isAnySheetOpen || resetDialogVisible || (!inSectionMode && hasActiveFilters)
 
     BackHandler(enabled = backHandlerEnabled) {
         when {
+            resetDialogVisible -> viewModel.dismissResetDialog()
             showFilters -> viewModel.toggleShowFilters() // closes when open
             openFilterSheet != null -> openFilterSheet = null
             showPosterSizeSheet -> showPosterSizeSheet = false
@@ -369,6 +374,32 @@ fun LibraryScreen(
                                 errorMessage = error,
                                 modifier = Modifier.padding(start = 8.dp),
                             )
+                            if (!inSectionMode) {
+                                // Reset-all pill — matches the screen's chip/action
+                                // language (glass chip, press scale, TV focus glow).
+                                com.raulshma.jellyplay.core.ui.components.ExpressiveChipContainer(
+                                    onClick = { viewModel.onResetClick() },
+                                    containerColor = if (LocalIsLightTheme.current) {
+                                        Color.Black.copy(alpha = 0.06f)
+                                    } else {
+                                        Color.White.copy(alpha = 0.12f)
+                                    },
+                                    modifier = Modifier.padding(start = 4.dp),
+                                ) {
+                                    Icon(
+                                        Tabler.Outline.Restore,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp),
+                                        tint = MaterialTheme.colorScheme.onSurface,
+                                    )
+                                    Text(
+                                        text = stringResource(R.string.library_reset),
+                                        style = MaterialTheme.typography.labelLarge,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                        fontWeight = FontWeight.Medium,
+                                    )
+                                }
+                            }
                         }
                     }
 
@@ -694,10 +725,14 @@ fun LibraryScreen(
                                                         // grouped list path via libraryListSubtitle.
                                                         item.libraryListSubtitle()
                                                     }
+                                                    // Seasons fall back to the parent series poster when the
+                                                    // season's own artwork 404s (shared with the grouped list).
+                                                    val fallbackUrls = item.rememberSeriesImageFallback(viewModel::getImageUrl)
                                                     LibraryListItem(
-                                                        title = item.name,
+                                                        title = item.displayTitle(),
                                                         subtitle = subtitle,
                                                         imageUrl = remember(item.id) { viewModel.getImageUrl(item.id) },
+                                                        fallbackUrls = fallbackUrls,
                                                         blurHash = item.blurHashes.primary,
                                                         onClick = memoizedClick,
                                                         modifier = Modifier.animateItem(placementSpec = placementSpec),
@@ -729,6 +764,9 @@ fun LibraryScreen(
                                                     { onItemClick(item.id, item.mediaType, item.parentId, item.name) }
                                                 }
                                                 val itemProgress = item.progressFraction()
+                                                // Seasons fall back to the parent series poster when the
+                                                // season's own artwork 404s in the thumb view too.
+                                                val fallbackUrls = item.rememberSeriesImageFallback(viewModel::getImageUrl)
                                                 ThumbCard(
                                                     item = item,
                                                     imageUrl = remember(item.id, item.blurHashes.backdrop) {
@@ -738,6 +776,7 @@ fun LibraryScreen(
                                                             viewModel.getImageUrl(item.id)
                                                         }
                                                     },
+                                                    fallbackUrls = fallbackUrls,
                                                     onClick = memoizedClick,
                                                     showProgress = itemProgress != null && itemProgress > 0f,
                                                     progressPercent = itemProgress ?: 0f,
@@ -1042,6 +1081,13 @@ fun LibraryScreen(
         } // close CompositionLocalProvider
     }
     MediaQuickActionHost(quickActionController)
+
+    if (resetDialogVisible) {
+        LibraryResetConfirmDialog(
+            onConfirm = { dontShowAgain -> viewModel.confirmResetAll(dontShowAgain) },
+            onDismiss = { viewModel.dismissResetDialog() },
+        )
+    }
 
     if (showFilters) {
         LibraryFilterSheet(

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
@@ -180,15 +180,26 @@ fun LibraryScreen(
     val folders by viewModel.folders.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
-    val selectedFolder by viewModel.selectedFolder.collectAsStateWithLifecycle()
-    val filters by viewModel.filters.collectAsStateWithLifecycle()
+    // One browser-state object owns {folder, filters, viewMode, groupBy,
+    // posterSize, sectionContext, title} — replacing 13 individual
+    // collectAsStateWithLifecycle reads that re-derived presentation from
+    // scattered sources. "In section mode" now derives from the state, unifying
+    // the two drift-prone sources (screen used to trust the nav-arg, the VM
+    // trusted its own _sectionContext). The nav-arg still drives the
+    // LaunchedEffect below; it just stops being a parallel source of truth for
+    // gating.
+    val browser by viewModel.browserState.collectAsStateWithLifecycle()
+    // Destructured from the single browser subscription above (one state read,
+    // not 13). The body keeps the plain field names for readability.
+    val selectedFolder = browser.folder
+    val filters = browser.filters
+    val viewMode = browser.viewMode
+    val sectionTitle = browser.title
+    val posterSize = browser.posterSize
+    val groupBy = browser.groupBy
     val genres by viewModel.genres.collectAsStateWithLifecycle()
     val tags by viewModel.tags.collectAsStateWithLifecycle()
     val showFilters by viewModel.showFilters.collectAsStateWithLifecycle()
-    val viewMode by viewModel.viewMode.collectAsStateWithLifecycle()
-    val sectionTitle by viewModel.title.collectAsStateWithLifecycle()
-    val posterSize by viewModel.posterSize.collectAsStateWithLifecycle()
-    val groupBy by viewModel.groupBy.collectAsStateWithLifecycle()
     val resetDialogVisible by viewModel.resetDialogVisible.collectAsStateWithLifecycle()
 
     // Section mode: configure the VM once with the injected context. Idempotent
@@ -235,7 +246,10 @@ fun LibraryScreen(
     // Hoisted (not local to the MASONRY branch) so the alphabet rail can drive
     // the staggered grid's scroll state from the screen root.
     val staggeredState = rememberLazyStaggeredGridState()
-    val inSectionMode = sectionContext != null
+    // Derives from the browser state (the single source of truth), not the
+    // nav-arg parameter — the two used to drift. The nav-arg still drives the
+    // configureSection/clearSectionMode LaunchedEffect above.
+    val inSectionMode = browser.isSection
     // Which (if any) per-filter sheet is open. Null = none. Hoisted here so the
     // chips toggle it and the matching sheet renders at the screen root.
     var openFilterSheet by remember { mutableStateOf<FilterSheetKind?>(null) }
@@ -243,9 +257,9 @@ fun LibraryScreen(
     var showGroupBySheet by remember { mutableStateOf(false) }
     val hasActiveFilters by remember {
         derivedStateOf {
-            filters.mediaTypes.isNotEmpty() ||
-                filters.genres.isNotEmpty() ||
-                filters.playedStatus != PlayedStatus.ALL
+            browser.filters.mediaTypes.isNotEmpty() ||
+                browser.filters.genres.isNotEmpty() ||
+                browser.filters.playedStatus != PlayedStatus.ALL
         }
     }
     val isAnySheetOpen = openFilterSheet != null || showPosterSizeSheet || showGroupBySheet
@@ -294,11 +308,11 @@ fun LibraryScreen(
         bottom = bottomPad,
     )
 
-    val gridCellSize = adaptiveInfo.gridCellSize(isTv) / posterSize
+    val gridCellSize = adaptiveInfo.gridCellSize(isTv) / browser.posterSize
     // Landscape thumbnails are wider than they are tall (16:9), so the THUMB
     // grid needs a larger min cell width than the poster (2:3) grid to avoid
     // rendering tiny cards. Scaled from the same adaptive baseline.
-    val thumbCellSize = adaptiveInfo.gridCellSize(isTv) / posterSize * (16f / 9f) * (3f / 4f)
+    val thumbCellSize = adaptiveInfo.gridCellSize(isTv) / browser.posterSize * (16f / 9f) * (3f / 4f)
 
     Box(
         modifier = Modifier
@@ -356,7 +370,7 @@ fun LibraryScreen(
                                 Spacer(Modifier.width(8.dp))
                             }
                             Text(
-                                text = sectionTitle ?: stringResource(R.string.library_title),
+                                text = browser.title ?: stringResource(R.string.library_title),
                                 // Matches MediaDetail's DetailTopBar title treatment
                                 // (titleLarge / SemiBold) rather than the old
                                 // headlineLarge / Bold — keeps the library header
@@ -424,7 +438,7 @@ fun LibraryScreen(
                                 item {
                                     GlassPill(
                                         label = stringResource(R.string.library_all),
-                                        selected = selectedFolder == null,
+                                        selected = browser.folder == null,
                                         onClick = { viewModel.selectFolder(null) },
                                     )
                                 }
@@ -434,7 +448,7 @@ fun LibraryScreen(
                                     Box(modifier = Modifier.animateItem(placementSpec = placementSpec)) {
                                         GlassPill(
                                             label = folder.name,
-                                            selected = selectedFolder?.id == folder.id,
+                                            selected = browser.folder?.id == folder.id,
                                             onClick = { viewModel.selectFolder(folder) },
                                         )
                                     }

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryScreen.kt
@@ -63,6 +63,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import com.raulshma.jellyplay.core.ui.components.JellyPlayLinearProgressIndicator
+import com.raulshma.jellyplay.core.ui.components.libraryListSubtitle
 import com.raulshma.jellyplay.core.ui.components.progressFraction
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
@@ -188,9 +189,16 @@ fun LibraryScreen(
 
     // Section mode: configure the VM once with the injected context. Idempotent
     // (configureSection early-returns on an equal context) so recomposition is
-    // safe. Skipped in tab mode (sectionContext == null).
+    // safe. In tab mode (sectionContext == null) clear any leftover section state
+    // so the Library tab shows its default view — the VM is shared across the
+    // tab and the section deep-link, so without this reset the "Latest X"
+    // filters/sort would leak into the tab (issue #113).
     LaunchedEffect(sectionContext) {
-        sectionContext?.let { viewModel.configureSection(it) }
+        if (sectionContext != null) {
+            viewModel.configureSection(sectionContext)
+        } else {
+            viewModel.clearSectionMode()
+        }
     }
 
     val pagedItems = viewModel.pagedItems.collectAsLazyPagingItems()
@@ -680,23 +688,11 @@ fun LibraryScreen(
                                                     val memoizedClick = remember(item.id, item.mediaType, item.parentId, item.name) {
                                                         { onItemClick(item.id, item.mediaType, item.parentId, item.name) }
                                                     }
-                                                    val subtitle = remember(item.year, item.mediaType) {
-                                                        buildString {
-                                                            if (item.year != null) append("${item.year}")
-                                                            val typeLabel = when (item.mediaType) {
-                                                                MediaType.EPISODE -> "Episode"
-                                                                MediaType.SERIES -> "Series"
-                                                                MediaType.MOVIE -> "Movie"
-                                                                MediaType.AUDIO -> "Audio"
-                                                                MediaType.MUSIC -> "Music"
-                                                                MediaType.PHOTO, MediaType.PHOTO_FOLDER -> "Photo"
-                                                                else -> null
-                                                            }
-                                                            if (typeLabel != null) {
-                                                                if (isNotEmpty()) append(" · ")
-                                                                append(typeLabel)
-                                                            }
-                                                        }
+                                                    val subtitle = remember(item.mediaType, item.seriesName, item.seasonNumber, item.episodeNumber, item.year) {
+                                                        // Episodes show an SxxExx + series context line (bold tag);
+                                                        // other types keep the year/type label. Shared with the
+                                                        // grouped list path via libraryListSubtitle.
+                                                        item.libraryListSubtitle()
                                                     }
                                                     LibraryListItem(
                                                         title = item.name,

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
@@ -68,15 +68,6 @@ class LibraryViewModel @Inject constructor(
     // enforced by hand-scattered guards. The reducer is now the single source.
     private val _browserState = stateFlow(LibraryBrowserState())
     val browserState = _browserState.flow
-    // Back-compat accessors so the screen/tests can read individual slices without
-    // a wider churn; they all derive from the single browser state value.
-    val folder = _browserState.flow.map { it.folder }
-    val filters = _browserState.flow.map { it.filters }
-    val viewMode = _browserState.flow.map { it.viewMode }
-    val posterSize = _browserState.flow.map { it.posterSize }
-    val groupBy = _browserState.flow.map { it.groupBy }
-    val sectionContext = _browserState.flow.map { it.sectionContext }
-    val title = _browserState.flow.map { it.title }
 
     // ---- Non-browser flows that genuinely stay separate ----
     private val _folders = stateFlow<List<LibraryFolder>>(emptyList())

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
@@ -1,6 +1,5 @@
 package com.raulshma.jellyplay.feature.library
 
-import androidx.compose.runtime.Immutable
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.raulshma.jellyplay.core.data.repository.MediaRepository
@@ -10,13 +9,14 @@ import com.raulshma.jellyplay.core.datastore.library.LibraryStore
 import com.raulshma.jellyplay.core.model.Genre
 import com.raulshma.jellyplay.core.model.GroupBy
 import com.raulshma.jellyplay.core.model.ItemKindFilter
+import com.raulshma.jellyplay.core.model.LibraryBrowserReducer
+import com.raulshma.jellyplay.core.model.LibraryBrowserState
+import com.raulshma.jellyplay.core.model.LibraryFilters
 import com.raulshma.jellyplay.core.model.LibraryFolder
 import com.raulshma.jellyplay.core.model.LibrarySectionContext
 import com.raulshma.jellyplay.core.model.LibraryViewMode
-import com.raulshma.jellyplay.core.model.defaultViewMode
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.PlayedStatus
-import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.model.SortOption
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 
@@ -42,21 +41,6 @@ private val libraryJson = Json {
     encodeDefaults = true
 }
 
-@Immutable
-@Serializable
-data class LibraryFilters(
-    val mediaTypes: List<MediaType> = emptyList(),
-    val genres: List<String> = emptyList(),
-    val years: List<Int> = emptyList(),
-    // Newest (highest production year first) is the most useful landing sort for
-    // a media library — a user opening the tab wants to see fresh content, not an
-    // alphabetical list. Overridden per-folder by the persisted filter blob.
-    val sortBy: SortOption = SortOption.YEAR_DESC,
-    val playedStatus: PlayedStatus = PlayedStatus.ALL,
-    val tags: List<String> = emptyList(),
-    val minRating: Float = 0f,
-)
-
 /** Projected slice of [UserPreferences] used to derive the active library view mode. */
 private data class ViewModePrefs(
     val libraryViewMode: LibraryViewMode,
@@ -69,9 +53,6 @@ private data class ViewModePrefs(
  */
 private const val FILTER_RETRY_DELAY_MS: Long = 800
 
-/** Factory-default poster-size multiplier (matches the toolbar slider's 1.0 center). */
-private const val DEFAULT_POSTER_SIZE = 1.0f
-
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     private val mediaRepository: MediaRepository,
@@ -80,6 +61,24 @@ class LibraryViewModel @Inject constructor(
     private val libraryStore: com.raulshma.jellyplay.core.datastore.library.LibraryStore,
 ) : JellyPlayViewModel() {
 
+    // ---- Browser state: one value type owning {folder, filters, viewMode, ----
+    // ---- groupBy, posterSize, sectionContext, title} as a consistent unit. --
+    // Previously this was a swarm of 8+ separate StateFlows whose invariants
+    // (view-mode precedence, "don't persist synthetic section folders") were
+    // enforced by hand-scattered guards. The reducer is now the single source.
+    private val _browserState = stateFlow(LibraryBrowserState())
+    val browserState = _browserState.flow
+    // Back-compat accessors so the screen/tests can read individual slices without
+    // a wider churn; they all derive from the single browser state value.
+    val folder = _browserState.flow.map { it.folder }
+    val filters = _browserState.flow.map { it.filters }
+    val viewMode = _browserState.flow.map { it.viewMode }
+    val posterSize = _browserState.flow.map { it.posterSize }
+    val groupBy = _browserState.flow.map { it.groupBy }
+    val sectionContext = _browserState.flow.map { it.sectionContext }
+    val title = _browserState.flow.map { it.title }
+
+    // ---- Non-browser flows that genuinely stay separate ----
     private val _folders = stateFlow<List<LibraryFolder>>(emptyList())
     val folders = _folders.flow
 
@@ -88,12 +87,6 @@ class LibraryViewModel @Inject constructor(
 
     private val _error = stateFlow<String?>(null)
     val error = _error.flow
-
-    private val _selectedFolder = stateFlow<LibraryFolder?>(null)
-    val selectedFolder = _selectedFolder.flow
-
-    private val _filters = stateFlow(LibraryFilters())
-    val filters = _filters.flow
 
     private val _genres = stateFlow<List<Genre>>(emptyList())
     val genres = _genres.flow
@@ -104,49 +97,8 @@ class LibraryViewModel @Inject constructor(
     private val _showFilters = stateFlow(false)
     val showFilters = _showFilters.flow
 
-    private val _viewMode = stateFlow(LibraryViewMode.GRID)
-    val viewMode = _viewMode.flow
-
-    /**
-     * The user's explicit in-memory view-mode choice (set by [setViewMode]).
-     * While non-null, [loadViewMode]'s collector refuses to overwrite
-     * [_viewMode] — closing a race where the async store write re-emits the
-     * old persisted value (or the collectionType-derived default) and snaps the
-     * grid back to the previous mode moments after a tap. Reset on folder
-     * change so the new folder loads its own saved mode.
-     */
-    private val _userViewModeOverride = kotlinx.coroutines.flow.MutableStateFlow<LibraryViewMode?>(null)
-
     private val _photoFolderChildUrls = stateFlow<Map<String, List<String>>>(emptyMap())
     val photoFolderChildUrls = _photoFolderChildUrls.flow
-
-    /**
-     * Non-null when this VM is driving a home-section "See All" deep-link. While
-     * set, the folder chips are hidden, folder loading is skipped, and the
-     * pre-applied sort / media-type filter from the source section is used
-     * instead of the persisted per-folder state.
-     *
-     * NOTE: this VM is shared across the Library tab ([Route.Library]) and the
-     * section deep-link ([Route.LibrarySection]) because there is no per-entry
-     * ViewModel store — `hiltViewModel()` resolves to the Activity scope. So
-     * section state is NOT cleared implicitly; the tab entry must call
-     * [clearSectionMode] on entry to reset to the default browsing view,
-     * otherwise stale "Latest X" filters leak into the Library tab (issue #113).
-     */
-    private val _sectionContext = stateFlow<LibrarySectionContext?>(null)
-    val sectionContext = _sectionContext.flow
-
-    /** Title to show in the toolbar. Null ⇒ the default "Library" string. */
-    private val _title = stateFlow<String?>(null)
-    val title = _title.flow
-
-    /** Poster-size multiplier persisted globally (see [LibraryStore]). */
-    private val _posterSize = stateFlow(1.0f)
-    val posterSize = _posterSize.flow
-
-    /** Client-side grouping dimension persisted globally (see [LibraryStore]). */
-    private val _groupBy = stateFlow(GroupBy.NONE)
-    val groupBy = _groupBy.flow
 
     /**
      * Whether the reset-all confirmation dialog is currently visible. Mirrors
@@ -162,6 +114,18 @@ class LibraryViewModel @Inject constructor(
      * "Don't show again" choice survives navigation and restarts.
      */
     private val _confirmResetEnabled = stateFlow(true)
+
+    /**
+     * True once the user has taken an explicit [setViewMode] action this session.
+     * While set, the [loadViewMode] async collector refuses to overwrite the
+     * browser state's viewMode — closing the race where the async store write
+     * re-emits the stale persisted value and snaps the grid back moments after a
+     * tap. Reset on folder/section change so the new folder loads its own mode.
+     *
+     * One flag with one meaning, replacing the old `_userViewModeOverride`
+     * StateFlow (which conflated "the user touched it" with "here is the value").
+     */
+    private var userTouchedViewMode: Boolean = false
 
     /**
      * Per-item slice of [photoFolderChildUrls]. Lets each photo-folder card
@@ -189,12 +153,10 @@ class LibraryViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val pagedItems: Flow<PagingData<MediaItem>> = combine(
-        _selectedFolder.flow,
-        _filters.flow,
-        _sectionContext.flow,
+        _browserState.flow,
         _refreshTrigger,
-    ) { folder, filters, _, _ ->
-        folder to filters
+    ) { browser, _ ->
+        browser.folder to browser.filters
     }.flatMapLatest { (folder, filters) ->
       mediaRepository.getMediaItemsPaged(
           parentId = folder?.id,
@@ -233,48 +195,21 @@ class LibraryViewModel @Inject constructor(
      * (the section is already scoped), and skips the folder fetch.
      */
     fun configureSection(ctx: LibrarySectionContext) {
-        if (_sectionContext.value == ctx) return
-        _sectionContext.set(ctx)
-        _title.set(ctx.title)
-        val folder = ctx.parentId?.let { LibraryFolder(id = it, name = ctx.title, collectionType = ctx.collectionType) }
-        _selectedFolder.set(folder)
-        val sectionSort = ctx.sortBy?.let { api ->
-            SortOption.entries.firstOrNull { it.apiValue == api || it.name == api }
-        } ?: SortOption.DATE_ADDED
-        // "See All" from a home Latest row should mirror the default library tab
-        // view (top-level items: series for TV, movies for a movie library, …)
-        // and only differ in sort order (latest first). Previously this defaulted
-        // to leaf episodes for a TV library, which produced large blocks of flat
-        // episode rows — unintuitive and not what the user expects from "Latest".
-        // Explicit ctx.mediaTypes (if ever passed) still win; otherwise we show
-        // top-level items sorted by latest. See pagedItems' kindFilter below.
-        _userViewModeOverride.value = null
-        _filters.set(
-            LibraryFilters(
-                sortBy = sectionSort,
-                mediaTypes = ctx.mediaTypes,
-            )
-        )
+        if (_browserState.value.sectionContext == ctx) return
+        userTouchedViewMode = false
+        _browserState.set(LibraryBrowserReducer.configureSection(_browserState.value, ctx))
     }
 
     /**
      * Resets all section-mode state so the Library tab renders its default
      * browsing view. Called when the tab entry ([Route.Library]) is shown after a
      * section deep-link, because the VM is shared across both entries (see the
-     * note on [_sectionContext]). Idempotent: a no-op when not in section mode,
+     * note on [browserState]). Idempotent: a no-op when not in section mode,
      * so repeated recompositions are safe.
-     *
-     * Restores the default filter set and clears the synthetic folder/title so
-     * the folder chips reload and the toolbar shows "Library" again. Per-folder
-     * persisted filters are re-applied the next time a folder is selected.
      */
     fun clearSectionMode() {
-        if (_sectionContext.value == null) return
-        _sectionContext.set(null)
-        _title.set(null)
-        _selectedFolder.set(null)
-        _filters.set(LibraryFilters())
-        _userViewModeOverride.value = null
+        userTouchedViewMode = false
+        _browserState.set(LibraryBrowserReducer.clearSectionMode(_browserState.value))
     }
 
     private fun loadLayoutPrefs() {
@@ -283,8 +218,7 @@ class LibraryViewModel @Inject constructor(
                 .map { it.libraryPosterSize to it.libraryGroupBy }
                 .distinctUntilChanged()
                 .collect { (posterSize, groupBy) ->
-                    _posterSize.set(posterSize)
-                    _groupBy.set(groupBy)
+                    _browserState.set(_browserState.value.copy(posterSize = posterSize, groupBy = groupBy))
                 }
         }
     }
@@ -299,14 +233,10 @@ class LibraryViewModel @Inject constructor(
     }
 
     private fun loadViewMode() {
-        // Project only the view-mode fields (avoid re-evaluating on every
-        // unrelated pref write) and combine with the selected folder so a
-        // folder change also triggers re-evaluation (was a latent correctness
-        // edge: the old collector only read _selectedFolder inside the prefs
-        // collector, so a folder-only change wouldn't re-derive the mode).
+        // Re-derive the view mode whenever the persisted view-mode prefs or the
+        // selected folder change, via the reducer's single precedence rule:
+        // per-folder override > collectionType default (defaultViewMode) > global.
         //
-        // Precedence: explicit per-folder user override > collectionType-driven
-        // default (see LibraryFolder.defaultViewMode) > global pref default.
         // This makes the layout server-driven by default — a music library shows
         // as a list, a movies library as a poster grid — while still letting the
         // user override per-folder via the toolbar toggle.
@@ -315,52 +245,52 @@ class LibraryViewModel @Inject constructor(
                 libraryStore.library
                     .map { ViewModePrefs(it.libraryViewMode, it.libraryViewModes) }
                     .distinctUntilChanged(),
-                _selectedFolder.flow,
+                _browserState.flow.map { it.folder }.distinctUntilChanged(),
             ) { viewModePrefs, folder ->
                 val perLibrary = folder?.id?.let { id ->
                     viewModePrefs.libraryViewModes[id]?.let { modeName ->
                         runCatching { LibraryViewMode.valueOf(modeName) }.getOrNull()
                     }
                 }
-                perLibrary ?: folder?.defaultViewMode() ?: viewModePrefs.libraryViewMode
+                LibraryBrowserReducer.resolveViewMode(
+                    current = _browserState.value,
+                    perFolderOverride = perLibrary,
+                    globalDefault = viewModePrefs.libraryViewMode,
+                )
             }.collect { mode ->
                 // Don't clobber an explicit user choice. A view-mode tap writes
                 // the store asynchronously; that store re-emission lands here and
                 // would otherwise snap the grid back to the stale/derived value
-                // (the "changes then switches back" bug). The override is cleared
-                // on folder change so each folder still loads its saved mode.
-                if (_userViewModeOverride.value == null) {
-                    _viewMode.set(mode)
+                // (the "changes then switches back" bug). The flag is cleared on
+                // folder/section change so each folder still loads its saved mode.
+                if (!userTouchedViewMode) {
+                    _browserState.set(_browserState.value.copy(viewMode = mode))
                 }
             }
         }
     }
 
     fun setViewMode(mode: LibraryViewMode) {
-        _viewMode.set(mode)
-        // Record the choice so the loadViewMode collector yields until the store
-        // settles, then clear it — subsequent folder switches re-derive normally.
-        _userViewModeOverride.value = mode
+        userTouchedViewMode = true
+        _browserState.set(LibraryBrowserReducer.setViewMode(_browserState.value, mode))
         launch {
             libraryStore.setLibraryViewMode(mode)
-            val folderId = _selectedFolder.value?.id
-            // In section mode the synthetic folder id is the section's parentId;
-            // persisting a per-folder view-mode override there would leak the
-            // section scope into the user's real per-library settings, so only
-            // persist the global default in section mode.
-            if (folderId != null && _sectionContext.value == null) {
-                libraryStore.setLibraryViewMode(folderId, mode.name)
+            val state = _browserState.value
+            // Only persist a per-folder override for a real folder — a section's
+            // synthetic parentId must never be written as a library key.
+            if (LibraryBrowserReducer.shouldPersistPerFolder(state)) {
+                libraryStore.setLibraryViewMode(state.folder!!.id, mode.name)
             }
         }
     }
 
     fun setPosterSize(size: Float) {
-        _posterSize.set(size)
+        _browserState.set(LibraryBrowserReducer.setPosterSize(_browserState.value, size))
         launch { libraryStore.setLibraryPosterSize(size) }
     }
 
     fun setGroupBy(groupBy: GroupBy) {
-        _groupBy.set(groupBy)
+        _browserState.set(LibraryBrowserReducer.setGroupBy(_browserState.value, groupBy))
         launch { libraryStore.setLibraryGroupBy(groupBy) }
     }
 
@@ -379,7 +309,7 @@ class LibraryViewModel @Inject constructor(
                     // as a non-blocking status (the screen shows ErrorScreen only
                     // when there are also zero items). This stops a single failed
                     // fetch — e.g. a transient 403 — from making the app unusable
-                    
+
                     if (_folders.value.isNullOrEmpty()) {
                         _error.set(error.message ?: "${error::class.simpleName}")
                     }
@@ -420,18 +350,13 @@ class LibraryViewModel @Inject constructor(
     }
 
     fun selectFolder(folder: LibraryFolder?) {
-        // Clear any explicit override from the previous folder so the new folder
-        // loads its own saved/derived view mode (otherwise the override would
-        // suppress the loadViewMode collector for the new selection).
-        _userViewModeOverride.value = null
-        _selectedFolder.set(folder)
+        userTouchedViewMode = false
+        val prefs = libraryStore.library.value
+        // Decode saved filters/sort for the folder (or fall back to defaults).
+        var newFilters = LibraryFilters()
         if (folder != null) {
-            val prefs = libraryStore.library.value
             val savedOrder = prefs.defaultLibrarySortOrders[folder.id]
             val savedFiltersJson = prefs.libraryFilters[folder.id]
-
-            var newFilters = LibraryFilters()
-
             if (savedFiltersJson != null) {
                 try {
                     newFilters = libraryJson.decodeFromString<LibraryFilters>(savedFiltersJson)
@@ -442,30 +367,36 @@ class LibraryViewModel @Inject constructor(
                 val option = SortOption.entries.find { it.name == savedOrder || it.apiValue == savedOrder } ?: SortOption.YEAR_DESC
                 newFilters = LibraryFilters(sortBy = option)
             }
-
-            _filters.set(newFilters)
-
-            val savedViewMode = prefs.libraryViewModes[folder.id]?.let { modeName ->
+        }
+        // Single view-mode precedence rule via the reducer — fixes the old
+        // divergence where this sync path omitted the collectionType default.
+        val perFolderOverride = folder?.id?.let { id ->
+            prefs.libraryViewModes[id]?.let { modeName ->
                 runCatching { LibraryViewMode.valueOf(modeName) }.getOrNull()
             }
-            if (savedViewMode != null) {
-                _viewMode.set(savedViewMode)
-            } else {
-                _viewMode.set(prefs.libraryViewMode)
-            }
         }
+        _browserState.set(
+            LibraryBrowserReducer.selectFolder(
+                current = _browserState.value,
+                folder = folder,
+                filters = newFilters,
+                perFolderOverride = perFolderOverride,
+                globalDefault = prefs.libraryViewMode,
+            )
+        )
     }
 
     fun updateFilters(newFilters: LibraryFilters) {
-        _filters.set(newFilters)
-        // Skip persistence in section mode: the folder id is synthetic (a
-        // section parentId) and persisting there would leak section state into
-        // the user's real per-library filter overrides.
-        val folder = _selectedFolder.value
-        if (folder != null && _sectionContext.value == null) {
+        _browserState.set(LibraryBrowserReducer.updateFilters(_browserState.value, newFilters))
+        // Skip persistence for a synthetic section folder: its id is a section
+        // parentId and persisting there would leak section state into the user's
+        // real per-library filter overrides. The reducer owns that gate.
+        val state = _browserState.value
+        if (LibraryBrowserReducer.shouldPersistPerFolder(state)) {
+            val folderId = state.folder!!.id
             launch {
-                libraryStore.setDefaultLibrarySortOrder(folder.id, newFilters.sortBy.name)
-                libraryStore.setLibraryFilters(folder.id, libraryJson.encodeToString(newFilters))
+                libraryStore.setDefaultLibrarySortOrder(folderId, newFilters.sortBy.name)
+                libraryStore.setLibraryFilters(folderId, libraryJson.encodeToString(newFilters))
             }
         }
     }
@@ -479,11 +410,11 @@ class LibraryViewModel @Inject constructor(
         // don't overwrite the folder's saved default sort order (which is what
         // a regular filter change via updateFilters persists). On the next visit
         // the user's chosen sort (e.g. Recently Added) is restored as expected.
-        _filters.set(_filters.value.copy(sortBy = SortOption.RANDOM))
+        _browserState.set(_browserState.value.copy(filters = _browserState.value.filters.copy(sortBy = SortOption.RANDOM)))
     }
 
     fun clearFilters() {
-        _filters.set(LibraryFilters())
+        _browserState.set(LibraryBrowserReducer.updateFilters(_browserState.value, LibraryFilters()))
     }
 
     /**
@@ -527,35 +458,24 @@ class LibraryViewModel @Inject constructor(
      * with the defaults so re-selecting the folder shows a clean slate.
      *
      * In section mode ("See All" deep-link) the Reset pill is hidden from the
-     * UI, but this method stays defensive: it also tears down the section
-     * context so the synthetic folder/title can't linger after the reset, and
-     * the captured [wasInSection] flag (not the post-clear state) gates
-     * per-folder persistence — the section's parentId must never be written as
-     * a real library's saved filters.
+     * UI, but this method stays defensive: the reducer tears down the section
+     * context so the synthetic folder/title can't linger, and the returned
+     * `realFolderIdToClean` (captured *before* the clear, not the post-clear
+     * state) gates per-folder persistence — the section's parentId must never be
+     * written as a real library's saved filters.
      */
     fun resetToDefault() {
-        val currentFolder = _selectedFolder.value
-        val wasInSection = _sectionContext.value != null
-        if (wasInSection) {
-            _sectionContext.set(null)
-            _title.set(null)
-        }
-        // Clear the override so loadViewMode's collector is free to re-derive.
-        _userViewModeOverride.value = null
-        _selectedFolder.set(null)
-        _filters.set(LibraryFilters())
-        _posterSize.set(DEFAULT_POSTER_SIZE)
-        _groupBy.set(GroupBy.NONE)
-        // Optimistic snapshot so the grid doesn't flash the stale mode before
-        // loadViewMode re-emits (folder is null now, so this is the global pref).
-        _viewMode.set(libraryStore.library.value.libraryViewMode)
+        userTouchedViewMode = false
+        val globalDefault = libraryStore.library.value.libraryViewMode
+        val result = LibraryBrowserReducer.resetToDefault(_browserState.value, globalDefault)
+        _browserState.set(result.state)
         launch {
-            if (currentFolder != null && !wasInSection) {
-                libraryStore.setLibraryFilters(currentFolder.id, libraryJson.encodeToString(LibraryFilters()))
-                libraryStore.setDefaultLibrarySortOrder(currentFolder.id, SortOption.YEAR_DESC.name)
+            result.realFolderIdToClean?.let { folderId ->
+                libraryStore.setLibraryFilters(folderId, libraryJson.encodeToString(LibraryFilters()))
+                libraryStore.setDefaultLibrarySortOrder(folderId, SortOption.YEAR_DESC.name)
             }
-            libraryStore.setLibraryPosterSize(DEFAULT_POSTER_SIZE)
-            libraryStore.setLibraryGroupBy(GroupBy.NONE)
+            libraryStore.setLibraryPosterSize(result.state.posterSize)
+            libraryStore.setLibraryGroupBy(result.state.groupBy)
         }
     }
 

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
@@ -48,7 +48,10 @@ data class LibraryFilters(
     val mediaTypes: List<MediaType> = emptyList(),
     val genres: List<String> = emptyList(),
     val years: List<Int> = emptyList(),
-    val sortBy: SortOption = SortOption.SORT_NAME,
+    // Newest (highest production year first) is the most useful landing sort for
+    // a media library — a user opening the tab wants to see fresh content, not an
+    // alphabetical list. Overridden per-folder by the persisted filter blob.
+    val sortBy: SortOption = SortOption.YEAR_DESC,
     val playedStatus: PlayedStatus = PlayedStatus.ALL,
     val tags: List<String> = emptyList(),
     val minRating: Float = 0f,
@@ -118,8 +121,14 @@ class LibraryViewModel @Inject constructor(
      * Non-null when this VM is driving a home-section "See All" deep-link. While
      * set, the folder chips are hidden, folder loading is skipped, and the
      * pre-applied sort / media-type filter from the source section is used
-     * instead of the persisted per-folder state. Cleared implicitly when the VM
-     * is disposed (each route entry gets a fresh VM).
+     * instead of the persisted per-folder state.
+     *
+     * NOTE: this VM is shared across the Library tab ([Route.Library]) and the
+     * section deep-link ([Route.LibrarySection]) because there is no per-entry
+     * ViewModel store — `hiltViewModel()` resolves to the Activity scope. So
+     * section state is NOT cleared implicitly; the tab entry must call
+     * [clearSectionMode] on entry to reset to the default browsing view,
+     * otherwise stale "Latest X" filters leak into the Library tab (issue #113).
      */
     private val _sectionContext = stateFlow<LibrarySectionContext?>(null)
     val sectionContext = _sectionContext.flow
@@ -166,9 +175,9 @@ class LibraryViewModel @Inject constructor(
         _filters.flow,
         _sectionContext.flow,
         _refreshTrigger,
-    ) { folder, filters, sectionCtx, _ ->
-        Triple(folder, filters, sectionCtx)
-    }.flatMapLatest { (folder, filters, sectionCtx) ->
+    ) { folder, filters, _, _ ->
+        folder to filters
+    }.flatMapLatest { (folder, filters) ->
       mediaRepository.getMediaItemsPaged(
           parentId = folder?.id,
           mediaTypes = filters.mediaTypes.ifEmpty { null },
@@ -179,12 +188,13 @@ class LibraryViewModel @Inject constructor(
           tags = filters.tags.ifEmpty { null },
           playedStatus = filters.playedStatus.takeIf { it != PlayedStatus.ALL },
           minRating = filters.minRating.takeIf { it > 0f },
-          // Section mode ("See All" from a home Latest row) must match what the
-          // home row showed. Home's /Items/Latest returns leaf items: episodes
-          // for a TV library, movies for a movie library. To reproduce that leaf
-          // set, section mode includes episodes; normal library tab browsing
-          // shows top-level items only.
-          kindFilter = if (sectionCtx == null) ItemKindFilter.TOP_LEVEL else ItemKindFilter.LEAF_ITEMS,
+          // Section mode ("See All" from a home Latest row) shows the same
+          // top-level items as the default library tab — series for a TV library,
+          // movies for a movie library — just sorted by latest. (Previously this
+          // returned leaf episodes for a TV library, which stacked flat episode
+          // blocks; issue #113.) Filtering to a specific leaf type is still
+          // possible via the Media Type filter.
+          kindFilter = ItemKindFilter.TOP_LEVEL,
       )
     }
     .cachedIn(scope)
@@ -212,27 +222,40 @@ class LibraryViewModel @Inject constructor(
         val sectionSort = ctx.sortBy?.let { api ->
             SortOption.entries.firstOrNull { it.apiValue == api || it.name == api }
         } ?: SortOption.DATE_ADDED
-        // Reproduce the home row's /Items/Latest item set:
-        // a TV library's Latest row shows episodes, so "See All" must scope to
-        // EPISODE too. Explicitly-passed ctx.mediaTypes win over the derived
-        // default. All other library types show their top-level items as the
-        // row does.
+        // "See All" from a home Latest row should mirror the default library tab
+        // view (top-level items: series for TV, movies for a movie library, …)
+        // and only differ in sort order (latest first). Previously this defaulted
+        // to leaf episodes for a TV library, which produced large blocks of flat
+        // episode rows — unintuitive and not what the user expects from "Latest".
+        // Explicit ctx.mediaTypes (if ever passed) still win; otherwise we show
+        // top-level items sorted by latest. See pagedItems' kindFilter below.
         _userViewModeOverride.value = null
-        val sectionMediaTypes = ctx.mediaTypes.ifEmpty {
-            when (ctx.collectionType) {
-                "tvshows" -> listOf(MediaType.EPISODE)
-                "movies" -> listOf(MediaType.MOVIE)
-                "music" -> listOf(MediaType.AUDIO)
-                "musicvideos" -> listOf(MediaType.MUSIC_VIDEO)
-                else -> emptyList()
-            }
-        }
         _filters.set(
             LibraryFilters(
                 sortBy = sectionSort,
-                mediaTypes = sectionMediaTypes,
+                mediaTypes = ctx.mediaTypes,
             )
         )
+    }
+
+    /**
+     * Resets all section-mode state so the Library tab renders its default
+     * browsing view. Called when the tab entry ([Route.Library]) is shown after a
+     * section deep-link, because the VM is shared across both entries (see the
+     * note on [_sectionContext]). Idempotent: a no-op when not in section mode,
+     * so repeated recompositions are safe.
+     *
+     * Restores the default filter set and clears the synthetic folder/title so
+     * the folder chips reload and the toolbar shows "Library" again. Per-folder
+     * persisted filters are re-applied the next time a folder is selected.
+     */
+    fun clearSectionMode() {
+        if (_sectionContext.value == null) return
+        _sectionContext.set(null)
+        _title.set(null)
+        _selectedFolder.set(null)
+        _filters.set(LibraryFilters())
+        _userViewModeOverride.value = null
     }
 
     private fun loadLayoutPrefs() {
@@ -388,7 +411,7 @@ class LibraryViewModel @Inject constructor(
                     newFilters = LibraryFilters()
                 }
             } else if (savedOrder != null) {
-                val option = SortOption.entries.find { it.name == savedOrder || it.apiValue == savedOrder } ?: SortOption.SORT_NAME
+                val option = SortOption.entries.find { it.name == savedOrder || it.apiValue == savedOrder } ?: SortOption.YEAR_DESC
                 newFilters = LibraryFilters(sortBy = option)
             }
 

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/LibraryViewModel.kt
@@ -69,6 +69,9 @@ private data class ViewModePrefs(
  */
 private const val FILTER_RETRY_DELAY_MS: Long = 800
 
+/** Factory-default poster-size multiplier (matches the toolbar slider's 1.0 center). */
+private const val DEFAULT_POSTER_SIZE = 1.0f
+
 @HiltViewModel
 class LibraryViewModel @Inject constructor(
     private val mediaRepository: MediaRepository,
@@ -146,6 +149,21 @@ class LibraryViewModel @Inject constructor(
     val groupBy = _groupBy.flow
 
     /**
+     * Whether the reset-all confirmation dialog is currently visible. Mirrors
+     * [_confirmResetEnabled]: the dialog only ever appears while the user opted
+     * to keep confirmations on.
+     */
+    private val _resetDialogVisible = stateFlow(false)
+    val resetDialogVisible = _resetDialogVisible.flow
+
+    /**
+     * Whether the reset-all confirmation is enabled. Persisted via
+     * [com.raulshma.jellyplay.core.datastore.library.LibraryStore] so a
+     * "Don't show again" choice survives navigation and restarts.
+     */
+    private val _confirmResetEnabled = stateFlow(true)
+
+    /**
      * Per-item slice of [photoFolderChildUrls]. Lets each photo-folder card
      * collect only its own urls so a prefetch merge (which produces a new Map
      * reference) doesn't invalidate the entire [LibraryScreen] — only the one
@@ -205,6 +223,7 @@ class LibraryViewModel @Inject constructor(
         loadTags()
         loadViewMode()
         loadLayoutPrefs()
+        loadResetConfirmPref()
     }
 
     /**
@@ -267,6 +286,15 @@ class LibraryViewModel @Inject constructor(
                     _posterSize.set(posterSize)
                     _groupBy.set(groupBy)
                 }
+        }
+    }
+
+    private fun loadResetConfirmPref() {
+        launch {
+            libraryStore.library
+                .map { it.confirmLibraryReset }
+                .distinctUntilChanged()
+                .collect { _confirmResetEnabled.set(it) }
         }
     }
 
@@ -456,6 +484,79 @@ class LibraryViewModel @Inject constructor(
 
     fun clearFilters() {
         _filters.set(LibraryFilters())
+    }
+
+    /**
+     * Entry point for the top-bar Reset pill. Shows the confirmation dialog while
+     * the user hasn't opted out; otherwise resets immediately so the pill stays a
+     * one-tap action for users who dismissed the confirmation.
+     */
+    fun onResetClick() {
+        if (_confirmResetEnabled.value) {
+            _resetDialogVisible.set(true)
+        } else {
+            resetToDefault()
+        }
+    }
+
+    /** Dismisses the reset confirmation without resetting anything. */
+    fun dismissResetDialog() {
+        _resetDialogVisible.set(false)
+    }
+
+    /**
+     * Confirmed reset-all. Optionally persists "don't show again" so future
+     * reset taps skip the dialog and reset immediately.
+     */
+    fun confirmResetAll(dontShowAgain: Boolean) {
+        _resetDialogVisible.set(false)
+        if (dontShowAgain) {
+            launch {
+                libraryStore.setConfirmLibraryReset(false)
+                _confirmResetEnabled.set(false)
+            }
+        }
+        resetToDefault()
+    }
+
+    /**
+     * Resets the whole library screen to defaults: clears all filters, returns to
+     * the "All" folder chip, restores the default view mode, resets poster size
+     * and grouping, and persists the reset so it survives navigation. Any stale
+     * per-folder saved filters for the currently selected folder are overwritten
+     * with the defaults so re-selecting the folder shows a clean slate.
+     *
+     * In section mode ("See All" deep-link) the Reset pill is hidden from the
+     * UI, but this method stays defensive: it also tears down the section
+     * context so the synthetic folder/title can't linger after the reset, and
+     * the captured [wasInSection] flag (not the post-clear state) gates
+     * per-folder persistence — the section's parentId must never be written as
+     * a real library's saved filters.
+     */
+    fun resetToDefault() {
+        val currentFolder = _selectedFolder.value
+        val wasInSection = _sectionContext.value != null
+        if (wasInSection) {
+            _sectionContext.set(null)
+            _title.set(null)
+        }
+        // Clear the override so loadViewMode's collector is free to re-derive.
+        _userViewModeOverride.value = null
+        _selectedFolder.set(null)
+        _filters.set(LibraryFilters())
+        _posterSize.set(DEFAULT_POSTER_SIZE)
+        _groupBy.set(GroupBy.NONE)
+        // Optimistic snapshot so the grid doesn't flash the stale mode before
+        // loadViewMode re-emits (folder is null now, so this is the global pref).
+        _viewMode.set(libraryStore.library.value.libraryViewMode)
+        launch {
+            if (currentFolder != null && !wasInSection) {
+                libraryStore.setLibraryFilters(currentFolder.id, libraryJson.encodeToString(LibraryFilters()))
+                libraryStore.setDefaultLibrarySortOrder(currentFolder.id, SortOption.YEAR_DESC.name)
+            }
+            libraryStore.setLibraryPosterSize(DEFAULT_POSTER_SIZE)
+            libraryStore.setLibraryGroupBy(GroupBy.NONE)
+        }
     }
 
     fun refresh() {

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/CustomYearRangeSelector.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/CustomYearRangeSelector.kt
@@ -1,0 +1,135 @@
+package com.raulshma.jellyplay.feature.library.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.*
+import com.raulshma.jellyplay.core.ui.components.yearRangePresets
+import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
+import com.raulshma.jellyplay.core.ui.tv.components.TvOrTouchSlider
+import com.raulshma.jellyplay.feature.library.R
+
+/**
+ * From/To year range selector for the library year-range filter sheets. Two
+ * thumb sliders (one per bound) anchored to the same 1920→now domain as the
+ * decade presets ([yearRangePresets]); each tick is one year. The bounds
+ * cross-clamp each other so the range never inverts (From ≤ To).
+ *
+ * [current] seeds the slider positions from the active year selection
+ * (min..max, or the full domain when nothing is selected). The change is
+ * committed via [onRangeChange] on release only (commit-on-release), so a drag
+ * doesn't fire a filter query per tick.
+ *
+ * Coordination with the decade presets: the slider and the preset chips feed
+ * the same underlying year set, so committing a slider range **replaces** the
+ * selection (it doesn't union onto toggled presets), and toggling a preset
+ * after a custom range unions onto it. To start a fresh custom range after
+ * mixing presets, tap "Any" first — this is the single clear-state affordance
+ * both controls share.
+ */
+@Composable
+fun CustomYearRangeSelector(
+    current: Collection<Int>,
+    onRangeChange: (IntRange) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val presets = remember { yearRangePresets() }
+    val domainStart = presets.first().years.first
+    val domainEnd = presets.last().years.last
+    val seedStart = current.minOrNull()?.coerceIn(domainStart, domainEnd) ?: domainStart
+    val seedEnd = current.maxOrNull()?.coerceIn(domainStart, domainEnd) ?: domainEnd
+
+    var from by remember(current) { mutableFloatStateOf(seedStart.toFloat()) }
+    var to by remember(current) { mutableFloatStateOf(seedEnd.toFloat()) }
+    val isTv = LocalTvMode.current
+
+    // Full-domain track for both sliders (avoids degenerate zero-width ranges
+    // at the extremes); the bounds are kept apart by clamping on change.
+    val domain = domainStart.toFloat()..domainEnd.toFloat()
+    val steps = domainEnd - domainStart - 1
+
+    Column(modifier = modifier) {
+        CustomYearRangeSlider(
+            label = stringResource(R.string.library_year_from, from.toInt()),
+            icon = Tabler.Outline.CalendarPlus,
+            value = from,
+            onValueChange = { from = it.coerceAtMost(to - 1).coerceIn(domain) },
+            onValueChangeFinished = {
+                val range = from.toInt()..to.toInt()
+                if (range.last >= range.first) onRangeChange(range)
+            },
+            domain = domain,
+            steps = steps,
+            isTv = isTv,
+        )
+        CustomYearRangeSlider(
+            label = stringResource(R.string.library_year_to, to.toInt()),
+            icon = Tabler.Outline.Calendar,
+            value = to,
+            onValueChange = { to = it.coerceAtLeast(from + 1).coerceIn(domain) },
+            onValueChangeFinished = {
+                val range = from.toInt()..to.toInt()
+                if (range.last >= range.first) onRangeChange(range)
+            },
+            domain = domain,
+            steps = steps,
+            isTv = isTv,
+        )
+    }
+}
+
+@Composable
+private fun CustomYearRangeSlider(
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    onValueChangeFinished: () -> Unit,
+    domain: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    isTv: Boolean,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 8.dp).size(width = 92.dp, height = 24.dp),
+        )
+        TvOrTouchSlider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = domain,
+            isTv = isTv,
+            steps = steps,
+            onValueChangeFinished = onValueChangeFinished,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/GroupedLibraryContent.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/GroupedLibraryContent.kt
@@ -35,7 +35,9 @@ import com.raulshma.jellyplay.core.model.LibraryViewMode
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.ui.components.PosterCard
+import com.raulshma.jellyplay.core.ui.components.displayTitle
 import com.raulshma.jellyplay.core.ui.components.libraryListSubtitle
+import com.raulshma.jellyplay.core.ui.components.rememberSeriesImageFallback
 import com.raulshma.jellyplay.core.ui.components.progressFraction
 import com.raulshma.jellyplay.core.ui.util.safeItemKey
 import com.raulshma.jellyplay.feature.library.components.LibraryListItem
@@ -183,10 +185,14 @@ fun GroupedLibraryContent(
                         // ungrouped list path via libraryListSubtitle.
                         item.libraryListSubtitle()
                     }
+                    // Seasons fall back to the parent series poster when the season's
+                    // own artwork 404s (shared with the ungrouped list path).
+                    val fallbackUrls = item.rememberSeriesImageFallback(getImageUrl)
                     LibraryListItem(
-                        title = item.name,
+                        title = item.displayTitle(),
                         subtitle = subtitle,
                         imageUrl = remember(item.id) { getImageUrl(item.id) },
+                        fallbackUrls = fallbackUrls,
                         blurHash = item.blurHashes.primary,
                         onClick = memoizedClick,
                         modifier = Modifier.onFocusChanged {

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/GroupedLibraryContent.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/GroupedLibraryContent.kt
@@ -35,20 +35,61 @@ import com.raulshma.jellyplay.core.model.LibraryViewMode
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.ui.components.PosterCard
+import com.raulshma.jellyplay.core.ui.components.libraryListSubtitle
 import com.raulshma.jellyplay.core.ui.components.progressFraction
 import com.raulshma.jellyplay.core.ui.util.safeItemKey
 import com.raulshma.jellyplay.feature.library.components.LibraryListItem
 
 /**
- * A group key derived from a [MediaItem] for client-side grouping. Returns the
+ * A group key derived from a [MediaItem] for the active [GroupBy] dimension. Returns the
  * header label (and a stable bucket id) for the active [GroupBy] dimension.
+ *
+ * Returns an empty string for [GroupBy.NONE] instead of throwing: although the caller
+ * only mounts this composable when grouping is active, the persisted [GroupBy] value
+ * flows in asynchronously (see [LibraryViewModel.loadLayoutPrefs]) and can transiently
+ * resolve to NONE while a grouped view is still mounted (e.g. across an
+ * AnimatedContent view-mode transition). Throwing here crashed the app on every library
+ * open once a non-NONE value had been persisted (issue #113).
  */
 private fun MediaItem.groupKey(groupBy: GroupBy): String = when (groupBy) {
-    GroupBy.NONE -> error("unreachable: GroupedLibraryContent requires a non-NONE GroupBy")
+    GroupBy.NONE -> ""
     GroupBy.NAME -> (name.firstOrNull()?.uppercaseChar()?.takeIf { it in 'A'..'Z' } ?: '#').toString()
     GroupBy.TYPE -> mediaType.name
     GroupBy.GENRE -> genres.firstOrNull() ?: "Unknown"
     GroupBy.YEAR -> year?.toString() ?: "Unknown"
+}
+
+/**
+ * Sort comparator that orders items to match the active [GroupBy] dimension, so groups
+ * come out contiguous when building header/item rows. Without this, grouping a snapshot
+ * that is server-sorted by a different dimension (e.g. Name) scatters the same group key
+ * across the list, which produced duplicate `"header_${key}"` lazy keys and crashed the
+ * app (issue #113). Within a group, the server's existing order is preserved (stable sort).
+ */
+private fun groupComparator(groupBy: GroupBy): Comparator<MediaItem> = Comparator { a, b ->
+    a.groupKey(groupBy).compareTo(b.groupKey(groupBy))
+}
+
+/**
+ * A flattened (header | item) row emitted into the grouped LazyColumn/LazyVerticalGrid.
+ *
+ * Each variant exposes a unique Compose lazy [key]: items key on their stable item id,
+ * headers key on a monotonically increasing sequence id. The sequence id guarantees key
+ * uniqueness even if the same group label appears in non-contiguous positions (which
+ * previously produced duplicate keys and crashed the app — issue #113).
+ */
+private sealed interface GroupedRow {
+    val key: Any
+
+    /** A section header. [id] is unique within a single grouping pass. */
+    data class Header(val label: String?, val id: Int) : GroupedRow {
+        override val key: Any = "header_$id"
+    }
+
+    /** A media item row. */
+    data class Item(val item: MediaItem) : GroupedRow {
+        override val key: Any = "item_${item.id}"
+    }
 }
 
 /**
@@ -80,22 +121,42 @@ fun GroupedLibraryContent(
     onFocusedItemChange: ((MediaItem?) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
-    require(groupBy != GroupBy.NONE) { "GroupedLibraryContent requires a non-NONE GroupBy" }
+    // NOTE: do not throw for GroupBy.NONE here. The persisted group-by flows in
+    // asynchronously (loadLayoutPrefs) and can transiently be NONE while a grouped
+    // view is mounted; throwing crashed the app (issue #113). The caller still guards
+    // `if (groupBy != GroupBy.NONE)` before composing this, but if NONE does slip
+    // through we render the items ungrouped rather than crashing.
     // Flatten the loaded snapshot into an ordered list of (header | item) rows
     // so the grid can emit header items spanning all columns. Recomputed via
     // derivedStateOf so it only re-evaluates when the snapshot actually changes.
+    //
+    // The snapshot is first sorted by the active group dimension so groups come out
+    // contiguous. Without this, grouping a snapshot that is server-sorted by a
+    // different dimension (e.g. Name) scattered the same group key across the list
+    // and produced duplicate `"header_${key}"` lazy keys → IllegalArgumentException
+    // crash (issue #113). sortedBy is stable so the server order is preserved within
+    // each group. Header rows carry a monotonically increasing sequence id so their
+    // lazy keys are unique regardless of the input order — a defensive guarantee
+    // against future regressions in the grouping logic.
     val rows by remember(pagedItems, groupBy) {
         derivedStateOf {
             val items = pagedItems.itemSnapshotList.items
-            buildList<Pair<String?, MediaItem?>> {
-                var lastHeader: String? = null
-                for (item in items) {
-                    val header = item.groupKey(groupBy)
-                    if (header != lastHeader) {
-                        add(header to null)
-                        lastHeader = header
+            if (groupBy == GroupBy.NONE) {
+                // Degenerate case: render every item with no headers.
+                items.map { item -> GroupedRow.Item(item) }
+            } else {
+                val ordered = items.sortedWith(groupComparator(groupBy))
+                buildList<GroupedRow> {
+                    var lastHeader: String? = null
+                    var headerSeq = 0
+                    for (item in ordered) {
+                        val header = item.groupKey(groupBy)
+                        if (header != lastHeader) {
+                            add(GroupedRow.Header(label = header, id = headerSeq++))
+                            lastHeader = header
+                        }
+                        add(GroupedRow.Item(item))
                     }
-                    add(null to item)
                 }
             }
         }
@@ -107,32 +168,20 @@ fun GroupedLibraryContent(
             verticalArrangement = Arrangement.spacedBy(2.dp),
             modifier = modifier.fillMaxSize(),
         ) {
-            items(count = rows.size, key = { idx ->
-                val (header, item) = rows[idx]
-                if (item != null) "item_${item.id}" else "header_${header}"
-            }, contentType = { idx -> if (rows[idx].second != null) "mediaItem" else "header" }) { idx ->
-                val (header, item) = rows[idx]
-                if (item != null) {
+            items(count = rows.size, key = { idx -> rows[idx].key }, contentType = { idx ->
+                if (rows[idx] is GroupedRow.Item) "mediaItem" else "header"
+            }) { idx ->
+                val row = rows[idx]
+                if (row is GroupedRow.Item) {
+                    val item = row.item
                     val memoizedClick = remember(item.id, item.mediaType, item.parentId, item.name) {
                         { onItemClick(item.id, item.mediaType, item.parentId, item.name) }
                     }
-                    val subtitle = remember(item.year, item.mediaType) {
-                        buildString {
-                            if (item.year != null) append("${item.year}")
-                            val typeLabel = when (item.mediaType) {
-                                MediaType.EPISODE -> "Episode"
-                                MediaType.SERIES -> "Series"
-                                MediaType.MOVIE -> "Movie"
-                                MediaType.AUDIO -> "Audio"
-                                MediaType.MUSIC -> "Music"
-                                MediaType.PHOTO, MediaType.PHOTO_FOLDER -> "Photo"
-                                else -> null
-                            }
-                            if (typeLabel != null) {
-                                if (isNotEmpty()) append(" · ")
-                                append(typeLabel)
-                            }
-                        }
+                    val subtitle = remember(item.mediaType, item.seriesName, item.seasonNumber, item.episodeNumber, item.year) {
+                        // Episodes show an SxxExx + series context line (bold tag); all
+                        // other types fall back to the year/type label. Shared with the
+                        // ungrouped list path via libraryListSubtitle.
+                        item.libraryListSubtitle()
                     }
                     LibraryListItem(
                         title = item.name,
@@ -145,7 +194,7 @@ fun GroupedLibraryContent(
                         },
                     )
                 } else {
-                    GroupHeader(label = header.orEmpty())
+                    GroupHeader(label = (row as GroupedRow.Header).label.orEmpty())
                 }
             }
         }
@@ -159,14 +208,14 @@ fun GroupedLibraryContent(
             verticalArrangement = Arrangement.spacedBy(spacing),
             modifier = modifier.fillMaxSize(),
         ) {
-            items(count = rows.size, key = { idx ->
-                val (header, item) = rows[idx]
-                if (item != null) "item_${item.id}" else "header_${header}"
-            }, contentType = { idx -> if (rows[idx].second != null) "mediaItem" else "header" }, span = { idx ->
-                if (rows[idx].second == null) GridItemSpan(maxLineSpan) else GridItemSpan(1)
+            items(count = rows.size, key = { idx -> rows[idx].key }, contentType = { idx ->
+                if (rows[idx] is GroupedRow.Item) "mediaItem" else "header"
+            }, span = { idx ->
+                if (rows[idx] is GroupedRow.Header) GridItemSpan(maxLineSpan) else GridItemSpan(1)
             }) { idx ->
-                val (header, item) = rows[idx]
-                if (item != null) {
+                val row = rows[idx]
+                if (row is GroupedRow.Item) {
+                    val item = row.item
                     val memoizedClick = remember(item.id, item.mediaType, item.parentId, item.name) {
                         { onItemClick(item.id, item.mediaType, item.parentId, item.name) }
                     }
@@ -191,7 +240,7 @@ fun GroupedLibraryContent(
                         },
                     )
                 } else {
-                    GroupHeader(label = header.orEmpty())
+                    GroupHeader(label = (row as GroupedRow.Header).label.orEmpty())
                 }
             }
         }

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/GroupedLibraryContent.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/GroupedLibraryContent.kt
@@ -31,6 +31,7 @@ import androidx.paging.compose.LazyPagingItems
 import com.raulshma.jellyplay.core.designsystem.theme.LocalIsLightTheme
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.GroupBy
+import com.raulshma.jellyplay.core.model.LibraryGrouper
 import com.raulshma.jellyplay.core.model.LibraryViewMode
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
@@ -48,18 +49,14 @@ import com.raulshma.jellyplay.feature.library.components.LibraryListItem
  *
  * Returns an empty string for [GroupBy.NONE] instead of throwing: although the caller
  * only mounts this composable when grouping is active, the persisted [GroupBy] value
- * flows in asynchronously (see [LibraryViewModel.loadLayoutPrefs]) and can transiently
- * resolve to NONE while a grouped view is still mounted (e.g. across an
- * AnimatedContent view-mode transition). Throwing here crashed the app on every library
- * open once a non-NONE value had been persisted (issue #113).
+ * flows in asynchronously and can transiently resolve to NONE while a grouped view is
+ * still mounted. Throwing here crashed the app on every library open once a non-NONE
+ * value had been persisted (issue #113).
+ *
+ * Delegates to the pure, tested [LibraryGrouper] — the logic was lifted out of this
+ * Composable so it can be unit-tested (it was the site of two #113 crashes).
  */
-private fun MediaItem.groupKey(groupBy: GroupBy): String = when (groupBy) {
-    GroupBy.NONE -> ""
-    GroupBy.NAME -> (name.firstOrNull()?.uppercaseChar()?.takeIf { it in 'A'..'Z' } ?: '#').toString()
-    GroupBy.TYPE -> mediaType.name
-    GroupBy.GENRE -> genres.firstOrNull() ?: "Unknown"
-    GroupBy.YEAR -> year?.toString() ?: "Unknown"
-}
+private fun MediaItem.groupKey(groupBy: GroupBy): String = LibraryGrouper.groupKey(this, groupBy)
 
 /**
  * Sort comparator that orders items to match the active [GroupBy] dimension, so groups
@@ -68,9 +65,7 @@ private fun MediaItem.groupKey(groupBy: GroupBy): String = when (groupBy) {
  * across the list, which produced duplicate `"header_${key}"` lazy keys and crashed the
  * app (issue #113). Within a group, the server's existing order is preserved (stable sort).
  */
-private fun groupComparator(groupBy: GroupBy): Comparator<MediaItem> = Comparator { a, b ->
-    a.groupKey(groupBy).compareTo(b.groupKey(groupBy))
-}
+private fun groupComparator(groupBy: GroupBy): Comparator<MediaItem> = LibraryGrouper.groupComparator(groupBy)
 
 /**
  * A flattened (header | item) row emitted into the grouped LazyColumn/LazyVerticalGrid.

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterChipRow.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterChipRow.kt
@@ -64,7 +64,7 @@ fun LibraryFilterChipRow(
             FilterOptionChip(
                 label = filters.sortBy.displayName,
                 onClick = { onOpenSheet(FilterSheetKind.SORT) },
-                highlight = filters.sortBy != SortOption.SORT_NAME,
+                highlight = filters.sortBy != SortOption.YEAR_DESC,
             )
         }
         item(key = "type") {

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterChipRow.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterChipRow.kt
@@ -25,8 +25,8 @@ import com.raulshma.jellyplay.core.ui.components.yearRangePresets
 import com.raulshma.jellyplay.core.ui.components.toggleYearPreset
 import com.raulshma.jellyplay.core.ui.components.YearPresetSelection
 import com.raulshma.jellyplay.core.ui.model.mediaTypeDisplayNamePlural
+import com.raulshma.jellyplay.core.model.LibraryFilters
 import com.raulshma.jellyplay.core.model.MediaType
-import com.raulshma.jellyplay.feature.library.LibraryFilters
 import com.raulshma.jellyplay.feature.library.R
 
 /**

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterChipRow.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterChipRow.kt
@@ -1,6 +1,7 @@
 package com.raulshma.jellyplay.feature.library.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -263,7 +264,8 @@ fun TagFilterSheet(
     )
 }
 
-/** Year-range sheet — decade presets (multi-select toggle), reusing core/ui helpers. */
+/** Year-range sheet — decade presets (multi-select toggle) plus a custom
+ * From/To slider range, reusing core/ui helpers. */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun YearRangeFilterSheet(
@@ -273,23 +275,30 @@ fun YearRangeFilterSheet(
 ) {
     val presets = remember { yearRangePresets() }
     FilterSelectionSheet(title = stringResource(R.string.library_year_range), onDismiss = onDismiss) {
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            GlassFilterChip(
-                label = stringResource(R.string.library_any),
-                selected = current.isEmpty(),
-                onClick = { onApply(emptySet()) },
-            )
-            presets.forEach { preset ->
-                val selection = yearPresetSelection(preset, current)
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 GlassFilterChip(
-                    label = preset.label,
-                    selected = selection == YearPresetSelection.Full,
-                    onClick = { onApply(toggleYearPreset(preset, current)) },
+                    label = stringResource(R.string.library_any),
+                    selected = current.isEmpty(),
+                    onClick = { onApply(emptySet()) },
                 )
+                presets.forEach { preset ->
+                    val selection = yearPresetSelection(preset, current)
+                    GlassFilterChip(
+                        label = preset.label,
+                        selected = selection == YearPresetSelection.Full,
+                        onClick = { onApply(toggleYearPreset(preset, current)) },
+                    )
+                }
             }
+
+            CustomYearRangeSelector(
+                current = current,
+                onRangeChange = { range -> onApply(range.toSet()) },
+            )
         }
     }
 }

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterSheet.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterSheet.kt
@@ -301,6 +301,12 @@ fun LibraryFilterSheet(
                         )
                     }
                 }
+
+                CustomYearRangeSelector(
+                    current = selectedYears,
+                    onRangeChange = { range -> selectedYears = range.toSet() },
+                    modifier = Modifier.padding(top = 8.dp),
+                )
             }
 
             // ── Tags (collapsed by default) ──

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterSheet.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterSheet.kt
@@ -56,7 +56,7 @@ import com.raulshma.jellyplay.core.ui.model.mediaTypeDisplayNamePlural
 import com.raulshma.jellyplay.core.ui.components.GlassFilterChip
 import com.raulshma.jellyplay.core.ui.tv.rememberTvFocusState
 import com.raulshma.jellyplay.core.ui.tv.tvFocusIndicator
-import com.raulshma.jellyplay.feature.library.LibraryFilters
+import com.raulshma.jellyplay.core.model.LibraryFilters
 import com.raulshma.jellyplay.core.model.SortOption
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterSheet.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryFilterSheet.kt
@@ -144,7 +144,7 @@ fun LibraryFilterSheet(
                                 selectedMediaTypes = emptyList()
                                 selectedGenres = emptyList()
                                 selectedYears = emptySet()
-                                selectedSort = SortOption.SORT_NAME
+                                selectedSort = SortOption.YEAR_DESC
                                 selectedPlayedStatus = PlayedStatus.ALL
                                 selectedTags = emptySet()
                                 selectedMinRating = 0f

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryListItem.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryListItem.kt
@@ -42,6 +42,7 @@ fun LibraryListItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     sharedElementKey: String? = null,
+    fallbackUrls: List<String> = emptyList(),
 ) {
     var isFocused by remember { mutableStateOf(false) }
     Row(
@@ -64,6 +65,7 @@ fun LibraryListItem(
             if (imageUrl != null) {
                 MediaImage(
                     url = imageUrl,
+                    fallbackUrls = fallbackUrls,
                     contentDescription = title,
                     modifier = Modifier.matchParentSize(),
                     blurHash = blurHash,

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryListItem.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryListItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -35,7 +36,7 @@ import com.raulshma.jellyplay.core.ui.tv.enableMarqueeOnFocus
 @Composable
 fun LibraryListItem(
     title: String,
-    subtitle: String?,
+    subtitle: AnnotatedString?,
     imageUrl: String?,
     blurHash: String?,
     onClick: () -> Unit,

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryResetConfirmDialog.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/LibraryResetConfirmDialog.kt
@@ -1,0 +1,73 @@
+package com.raulshma.jellyplay.feature.library.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.raulshma.jellyplay.feature.library.R
+
+/**
+ * Confirmation shown before the top-bar Reset pill resets the library to
+ * defaults. Explains what the reset clears and offers a persisted "Don't show
+ * again" opt-out — once checked and confirmed, future reset taps reset
+ * immediately (the ViewModel still shows this dialog only while
+ * `confirmLibraryReset` is enabled).
+ */
+@Composable
+fun LibraryResetConfirmDialog(
+    onConfirm: (dontShowAgain: Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var dontShowAgain by remember { mutableStateOf(false) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.library_reset_confirm_title)) },
+        text = {
+            Column {
+                Text(stringResource(R.string.library_reset_confirm_message))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .clickable { dontShowAgain = !dontShowAgain },
+                ) {
+                    Checkbox(
+                        checked = dontShowAgain,
+                        onCheckedChange = { dontShowAgain = it },
+                    )
+                    Text(
+                        text = stringResource(R.string.library_reset_dont_show_again),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(dontShowAgain) }) {
+                Text(
+                    stringResource(R.string.library_reset_all),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(com.raulshma.jellyplay.core.ui.R.string.core_cancel))
+            }
+        },
+    )
+}

--- a/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/ThumbCard.kt
+++ b/feature/library/src/main/java/com/raulshma/jellyplay/feature/library/components/ThumbCard.kt
@@ -34,6 +34,7 @@ import coil3.size.Size as CoilSize
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.ui.animation.pressScale
+import com.raulshma.jellyplay.core.ui.components.displayTitle
 import com.raulshma.jellyplay.core.ui.components.focusIndicator
 import com.raulshma.jellyplay.core.ui.components.rememberSharedElementModifier
 import com.raulshma.jellyplay.core.ui.image.MediaImage
@@ -55,6 +56,7 @@ fun ThumbCard(
     progressPercent: Float = 0f,
     blurHash: String? = null,
     sharedElementKey: String? = null,
+    fallbackUrls: List<String> = emptyList(),
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -90,7 +92,8 @@ fun ThumbCard(
             ) {
                 MediaImage(
                     url = imageUrl,
-                    contentDescription = item.name,
+                    fallbackUrls = fallbackUrls,
+                    contentDescription = item.displayTitle(),
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .matchParentSize()
@@ -115,7 +118,7 @@ fun ThumbCard(
                         .padding(8.dp),
                 ) {
                     Text(
-                        text = item.name,
+                        text = item.displayTitle(),
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
                         color = Color.White,

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -51,11 +51,20 @@
 
     <!-- LibraryFilterSheet -->
     <string name="library_reset">Reset</string>
+    <string name="library_reset_all">Reset all</string>
+    <string name="library_reset_confirm_title">Reset library?</string>
+    <!-- Info shown in the reset confirmation dialog. -->
+    <string name="library_reset_confirm_message">This clears all filters and returns to the default library. Your view mode, poster size and grouping, plus the saved filters and sort order for the current folder, will be reset.</string>
+    <string name="library_reset_dont_show_again">Don\'t show again</string>
     <string name="library_sort_by">Sort By</string>
     <string name="library_media_type">Filter by Type</string>
     <string name="library_status">Status</string>
     <string name="library_genres">Genres</string>
     <string name="library_year_range">Year Range</string>
+    <!-- %1$d = selected start year -->
+    <string name="library_year_from">From %1$d</string>
+    <!-- %1$d = selected end year -->
+    <string name="library_year_to">To %1$d</string>
     <string name="library_tags">Tags</string>
     <string name="library_minimum_rating">Minimum Rating</string>
     <string name="library_apply_filters">Apply Filters</string>

--- a/feature/library/src/main/res/values/strings.xml
+++ b/feature/library/src/main/res/values/strings.xml
@@ -30,11 +30,11 @@
     <!-- Filter chip row -->
     <string name="library_all_filters">All Filters</string>
     <string name="library_sort">Sort</string>
-    <string name="library_type">Type</string>
+    <string name="library_type">Filter by Type</string>
     <string name="library_any">Any</string>
 
     <!-- Group by -->
-    <string name="library_group_by">Group by</string>
+    <string name="library_group_by">Group results by</string>
     <string name="library_group_by_none">None</string>
     <string name="library_group_by_name">Name</string>
     <string name="library_group_by_type">Type</string>
@@ -52,7 +52,7 @@
     <!-- LibraryFilterSheet -->
     <string name="library_reset">Reset</string>
     <string name="library_sort_by">Sort By</string>
-    <string name="library_media_type">Media Type</string>
+    <string name="library_media_type">Filter by Type</string>
     <string name="library_status">Status</string>
     <string name="library_genres">Genres</string>
     <string name="library_year_range">Year Range</string>

--- a/feature/library/src/test/java/com/raulshma/jellyplay/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/com/raulshma/jellyplay/feature/library/LibraryViewModelTest.kt
@@ -8,10 +8,11 @@ import com.raulshma.jellyplay.core.data.util.PhotoFolderPrefetcher
 import com.raulshma.jellyplay.core.datastore.library.LibrarySlice
 import com.raulshma.jellyplay.core.datastore.library.LibraryStore
 import com.raulshma.jellyplay.core.model.GroupBy
+import com.raulshma.jellyplay.core.model.LibraryFilters
+import com.raulshma.jellyplay.core.model.LibraryFolder
 import com.raulshma.jellyplay.core.model.LibrarySectionContext
 import com.raulshma.jellyplay.core.model.LibraryViewMode
 import com.raulshma.jellyplay.core.model.MediaType
-import com.raulshma.jellyplay.core.model.PlayedStatus
 import com.raulshma.jellyplay.core.model.SortOption
 import com.raulshma.jellyplay.core.testing.MainDispatcherRule
 import io.mockk.coEvery
@@ -19,10 +20,8 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import com.raulshma.jellyplay.core.model.LibraryFolder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -65,6 +64,9 @@ class LibraryViewModelTest {
         libraryStore = libraryStore,
     )
 
+    /** Browser-state snapshot, the single source of truth post-refactor. */
+    private fun LibraryViewModel.state() = browserState.value
+
     @Test
     fun `configureSection scopes selectedFolder to parentId and pre-applies Date Added sort`() = runTest {
         val vm = createViewModel()
@@ -77,10 +79,10 @@ class LibraryViewModelTest {
             )
         )
 
-        val folder = vm.selectedFolder.value
-        assertEquals("lib-movies", folder?.id)
-        assertEquals("Latest Movies", vm.title.value)
-        assertEquals(SortOption.DATE_ADDED, vm.filters.value.sortBy)
+        val state = vm.state()
+        assertEquals("lib-movies", state.folder?.id)
+        assertEquals("Latest Movies", state.title)
+        assertEquals(SortOption.DATE_ADDED, state.filters.sortBy)
     }
 
     @Test
@@ -94,8 +96,9 @@ class LibraryViewModelTest {
             )
         )
 
-        assertNull(vm.selectedFolder.value)
-        assertEquals(SortOption.DATE_ADDED, vm.filters.value.sortBy)
+        val state = vm.state()
+        assertNull(state.folder)
+        assertEquals(SortOption.DATE_ADDED, state.filters.sortBy)
     }
 
     @Test
@@ -113,8 +116,9 @@ class LibraryViewModelTest {
             )
         )
 
-        assertEquals(emptyList<MediaType>(), vm.filters.value.mediaTypes)
-        assertEquals(SortOption.DATE_ADDED, vm.filters.value.sortBy)
+        val state = vm.state()
+        assertEquals(emptyList<MediaType>(), state.filters.mediaTypes)
+        assertEquals(SortOption.DATE_ADDED, state.filters.sortBy)
     }
 
     @Test
@@ -129,7 +133,7 @@ class LibraryViewModelTest {
             )
         )
 
-        assertEquals(emptyList<MediaType>(), vm.filters.value.mediaTypes)
+        assertEquals(emptyList<MediaType>(), vm.state().filters.mediaTypes)
     }
 
     @Test
@@ -144,7 +148,7 @@ class LibraryViewModelTest {
             )
         )
 
-        assertEquals(emptyList<MediaType>(), vm.filters.value.mediaTypes)
+        assertEquals(emptyList<MediaType>(), vm.state().filters.mediaTypes)
     }
 
     @Test
@@ -162,7 +166,7 @@ class LibraryViewModelTest {
             )
         )
 
-        assertEquals(listOf(MediaType.MOVIE), vm.filters.value.mediaTypes)
+        assertEquals(listOf(MediaType.MOVIE), vm.state().filters.mediaTypes)
     }
 
     @Test
@@ -179,16 +183,17 @@ class LibraryViewModelTest {
                 sortBy = SortOption.DATE_ADDED.apiValue,
             )
         )
-        assertNotNull(vm.sectionContext.value)
-        assertEquals("Latest Shows", vm.title.value)
-        assertNotNull(vm.selectedFolder.value)
+        assertNotNull(vm.state().sectionContext)
+        assertEquals("Latest Shows", vm.state().title)
+        assertNotNull(vm.state().folder)
 
         vm.clearSectionMode()
 
-        assertNull(vm.sectionContext.value)
-        assertNull(vm.title.value)
-        assertNull(vm.selectedFolder.value)
-        assertEquals(LibraryFilters(), vm.filters.value)
+        val state = vm.state()
+        assertNull(state.sectionContext)
+        assertNull(state.title)
+        assertNull(state.folder)
+        assertEquals(LibraryFilters(), state.filters)
     }
 
     @Test
@@ -196,8 +201,9 @@ class LibraryViewModelTest {
         val vm = createViewModel()
         // Not in section mode — clearing should be a safe no-op.
         vm.clearSectionMode()
-        assertNull(vm.sectionContext.value)
-        assertEquals(LibraryFilters(), vm.filters.value)
+        val state = vm.state()
+        assertNull(state.sectionContext)
+        assertEquals(LibraryFilters(), state.filters)
     }
 
     @Test
@@ -215,7 +221,7 @@ class LibraryViewModelTest {
         // No persistence calls should fire for a synthetic (section) folder.
         coVerify(exactly = 0) { libraryStore.setLibraryFilters(any(), any()) }
         coVerify(exactly = 0) { libraryStore.setDefaultLibrarySortOrder(any(), any()) }
-        assertEquals(SortOption.RATING, vm.filters.value.sortBy)
+        assertEquals(SortOption.RATING, vm.state().filters.sortBy)
     }
 
     @Test
@@ -247,10 +253,24 @@ class LibraryViewModelTest {
         val vm = createViewModel()
         vm.selectFolder(LibraryFolder(id = "lib-1", name = "Movies"))
 
-        assertEquals(listOf(MediaType.MOVIE), vm.filters.value.mediaTypes)
-        assertEquals(SortOption.RATING, vm.filters.value.sortBy)
-        assertEquals(PlayedStatus.UNPLAYED, vm.filters.value.playedStatus)
-        assertEquals(listOf("fav"), vm.filters.value.tags)
+        val filters = vm.state().filters
+        assertEquals(listOf(MediaType.MOVIE), filters.mediaTypes)
+        assertEquals(SortOption.RATING, filters.sortBy)
+        assertEquals(com.raulshma.jellyplay.core.model.PlayedStatus.UNPLAYED, filters.playedStatus)
+        assertEquals(listOf("fav"), filters.tags)
+    }
+
+    @Test
+    fun `selectFolder applies collectionType default view mode with no saved override`() = runTest {
+        // Regression for the divergence the refactor fixes: the old sync
+        // selectFolder() path omitted defaultViewMode(), so a music folder with
+        // no saved view-mode override rendered as a grid instead of a list.
+        every { libraryStore.library } returns MutableStateFlow(
+            LibrarySlice(libraryViewMode = LibraryViewMode.GRID),
+        )
+        val vm = createViewModel()
+        vm.selectFolder(LibraryFolder(id = "lib-music", name = "Music", collectionType = "music"))
+        assertEquals(LibraryViewMode.LIST, vm.state().viewMode)
     }
 
     @Test
@@ -267,8 +287,9 @@ class LibraryViewModelTest {
     @Test
     fun `default tab mode has null title`() = runTest {
         val vm = createViewModel()
-        assertNull(vm.title.value)
-        assertNull(vm.sectionContext.value)
+        val state = vm.state()
+        assertNull(state.title)
+        assertNull(state.sectionContext)
     }
 
     @Test
@@ -289,12 +310,13 @@ class LibraryViewModelTest {
         vm.resetToDefault()
         advanceUntilIdle()
 
-        assertNull(vm.selectedFolder.value)
-        assertEquals(LibraryFilters(), vm.filters.value)
-        assertEquals(1.0f, vm.posterSize.value)
-        assertEquals(GroupBy.NONE, vm.groupBy.value)
+        val state = vm.state()
+        assertNull(state.folder)
+        assertEquals(LibraryFilters(), state.filters)
+        assertEquals(1.0f, state.posterSize)
+        assertEquals(GroupBy.NONE, state.groupBy)
         // Folder is null, so the view mode derives back to the global default.
-        assertEquals(LibraryViewMode.GRID, vm.viewMode.value)
+        assertEquals(LibraryViewMode.GRID, state.viewMode)
 
         coVerify { libraryStore.setLibraryPosterSize(1.0f) }
         coVerify { libraryStore.setLibraryGroupBy(GroupBy.NONE) }
@@ -324,7 +346,39 @@ class LibraryViewModelTest {
 
         coVerify(exactly = 0) { libraryStore.setLibraryFilters(any(), any()) }
         coVerify(exactly = 0) { libraryStore.setDefaultLibrarySortOrder(any(), any()) }
-        assertNull(vm.selectedFolder.value)
-        assertEquals(LibraryFilters(), vm.filters.value)
+        val state = vm.state()
+        assertNull(state.folder)
+        assertEquals(LibraryFilters(), state.filters)
+    }
+
+    @Test
+    fun `section view-mode mutation does not leak into real library prefs`() = runTest {
+        // Issue #113 regression: enter a section ("See All" deep-link), mutate
+        // the view mode while inside it, leave the section, and assert the real
+        // library's per-folder view-mode prefs were never written (the section's
+        // synthetic parentId must never be persisted as a library key).
+        coEvery { libraryStore.setLibraryViewMode(any()) } returns Unit
+        coEvery { libraryStore.setLibraryViewMode(any(), any()) } returns Unit
+
+        val vm = createViewModel()
+        vm.configureSection(
+            LibrarySectionContext(
+                title = "Latest Shows",
+                parentId = "lib-tv",
+                collectionType = "tvshows",
+                sortBy = SortOption.DATE_ADDED.apiValue,
+            )
+        )
+        // Mutate view mode while inside the section.
+        vm.setViewMode(LibraryViewMode.LIST)
+        advanceUntilIdle()
+
+        // The global default write is fine; the per-folder write for the
+        // section's synthetic parentId must NOT happen.
+        coVerify(exactly = 0) { libraryStore.setLibraryViewMode("lib-tv", any()) }
+
+        // Leaving the section restores the default browsing view.
+        vm.clearSectionMode()
+        assertNull(vm.state().sectionContext)
     }
 }

--- a/feature/library/src/test/java/com/raulshma/jellyplay/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/com/raulshma/jellyplay/feature/library/LibraryViewModelTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import com.raulshma.jellyplay.core.model.LibraryFolder
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
@@ -98,9 +99,10 @@ class LibraryViewModelTest {
     }
 
     @Test
-    fun `configureSection for tvshows scopes mediaTypes to EPISODE to match home Latest row`() = runTest {
-        // Matches the home Latest row: a TV library's
-        // /Items/Latest row shows episodes, so "See All" must scope to EPISODE.
+    fun `configureSection for tvshows mirrors the default library view with no mediaType scoping`() = runTest {
+        // Issue #113: "See All" from a home Latest row should mirror the default
+        // library tab (top-level series), sorted by latest — NOT scope to flat
+        // episodes. mediaTypes stays empty so pagedItems queries TOP_LEVEL items.
         val vm = createViewModel()
         vm.configureSection(
             LibrarySectionContext(
@@ -111,11 +113,12 @@ class LibraryViewModelTest {
             )
         )
 
-        assertEquals(listOf(MediaType.EPISODE), vm.filters.value.mediaTypes)
+        assertEquals(emptyList<MediaType>(), vm.filters.value.mediaTypes)
+        assertEquals(SortOption.DATE_ADDED, vm.filters.value.sortBy)
     }
 
     @Test
-    fun `configureSection for movies scopes mediaTypes to MOVIE to match home Latest row`() = runTest {
+    fun `configureSection for movies mirrors the default library view with no mediaType scoping`() = runTest {
         val vm = createViewModel()
         vm.configureSection(
             LibrarySectionContext(
@@ -126,7 +129,7 @@ class LibraryViewModelTest {
             )
         )
 
-        assertEquals(listOf(MediaType.MOVIE), vm.filters.value.mediaTypes)
+        assertEquals(emptyList<MediaType>(), vm.filters.value.mediaTypes)
     }
 
     @Test
@@ -142,6 +145,59 @@ class LibraryViewModelTest {
         )
 
         assertEquals(emptyList<MediaType>(), vm.filters.value.mediaTypes)
+    }
+
+    @Test
+    fun `configureSection honors explicitly-passed mediaTypes over the default`() = runTest {
+        // Explicit ctx.mediaTypes still win (e.g. a future home row that targets
+        // a specific leaf type).
+        val vm = createViewModel()
+        vm.configureSection(
+            LibrarySectionContext(
+                title = "Latest Shows",
+                parentId = "lib-tv",
+                collectionType = "tvshows",
+                sortBy = SortOption.DATE_ADDED.apiValue,
+                mediaTypes = listOf(MediaType.MOVIE),
+            )
+        )
+
+        assertEquals(listOf(MediaType.MOVIE), vm.filters.value.mediaTypes)
+    }
+
+    @Test
+    fun `clearSectionMode resets section state so the Library tab shows its default view`() = runTest {
+        // Issue #113: the VM is shared across the Library tab and the section
+        // deep-link. After a "See All" visit, clearing section mode must restore
+        // the default browsing view (no synthetic folder, no leftover filters).
+        val vm = createViewModel()
+        vm.configureSection(
+            LibrarySectionContext(
+                title = "Latest Shows",
+                parentId = "lib-tv",
+                collectionType = "tvshows",
+                sortBy = SortOption.DATE_ADDED.apiValue,
+            )
+        )
+        assertNotNull(vm.sectionContext.value)
+        assertEquals("Latest Shows", vm.title.value)
+        assertNotNull(vm.selectedFolder.value)
+
+        vm.clearSectionMode()
+
+        assertNull(vm.sectionContext.value)
+        assertNull(vm.title.value)
+        assertNull(vm.selectedFolder.value)
+        assertEquals(LibraryFilters(), vm.filters.value)
+    }
+
+    @Test
+    fun `clearSectionMode is a no-op when not in section mode`() = runTest {
+        val vm = createViewModel()
+        // Not in section mode — clearing should be a safe no-op.
+        vm.clearSectionMode()
+        assertNull(vm.sectionContext.value)
+        assertEquals(LibraryFilters(), vm.filters.value)
     }
 
     @Test

--- a/feature/library/src/test/java/com/raulshma/jellyplay/feature/library/LibraryViewModelTest.kt
+++ b/feature/library/src/test/java/com/raulshma/jellyplay/feature/library/LibraryViewModelTest.kt
@@ -270,4 +270,61 @@ class LibraryViewModelTest {
         assertNull(vm.title.value)
         assertNull(vm.sectionContext.value)
     }
+
+    @Test
+    fun `resetToDefault clears filters folder and layout and persists the defaults`() = runTest {
+        coEvery { libraryStore.setLibraryFilters(any(), any()) } returns Unit
+        coEvery { libraryStore.setDefaultLibrarySortOrder(any(), any()) } returns Unit
+        coEvery { libraryStore.setLibraryPosterSize(any()) } returns Unit
+        coEvery { libraryStore.setLibraryGroupBy(any()) } returns Unit
+
+        val vm = createViewModel()
+        vm.selectFolder(LibraryFolder(id = "lib-1", name = "TV"))
+        vm.updateFilters(LibraryFilters(mediaTypes = listOf(MediaType.MOVIE), sortBy = SortOption.RATING))
+        vm.setPosterSize(1.3f)
+        vm.setGroupBy(GroupBy.GENRE)
+        vm.setViewMode(LibraryViewMode.LIST)
+        advanceUntilIdle()
+
+        vm.resetToDefault()
+        advanceUntilIdle()
+
+        assertNull(vm.selectedFolder.value)
+        assertEquals(LibraryFilters(), vm.filters.value)
+        assertEquals(1.0f, vm.posterSize.value)
+        assertEquals(GroupBy.NONE, vm.groupBy.value)
+        // Folder is null, so the view mode derives back to the global default.
+        assertEquals(LibraryViewMode.GRID, vm.viewMode.value)
+
+        coVerify { libraryStore.setLibraryPosterSize(1.0f) }
+        coVerify { libraryStore.setLibraryGroupBy(GroupBy.NONE) }
+        // The previously selected folder's stale saved filters are overwritten.
+        coVerify { libraryStore.setLibraryFilters("lib-1", any()) }
+        coVerify { libraryStore.setDefaultLibrarySortOrder("lib-1", SortOption.YEAR_DESC.name) }
+    }
+
+    @Test
+    fun `resetToDefault does not persist folder filters in section mode`() = runTest {
+        coEvery { libraryStore.setLibraryPosterSize(any()) } returns Unit
+        coEvery { libraryStore.setLibraryGroupBy(any()) } returns Unit
+
+        val vm = createViewModel()
+        vm.configureSection(
+            LibrarySectionContext(
+                title = "Latest Shows",
+                parentId = "lib-tv",
+                collectionType = "tvshows",
+                sortBy = SortOption.DATE_ADDED.apiValue,
+            )
+        )
+        advanceUntilIdle()
+
+        vm.resetToDefault()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { libraryStore.setLibraryFilters(any(), any()) }
+        coVerify(exactly = 0) { libraryStore.setDefaultLibrarySortOrder(any(), any()) }
+        assertNull(vm.selectedFolder.value)
+        assertEquals(LibraryFilters(), vm.filters.value)
+    }
 }

--- a/feature/livetv/src/main/java/com/raulshma/jellyplay/feature/livetv/recordings/RecordingsScreen.kt
+++ b/feature/livetv/src/main/java/com/raulshma/jellyplay/feature/livetv/recordings/RecordingsScreen.kt
@@ -2,6 +2,7 @@ package com.raulshma.jellyplay.feature.livetv.recordings
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,10 +18,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -77,6 +81,37 @@ fun RecordingsScreen(
         tag = "recordings_init",
     )
 
+    // Delete confirm dialog. Long-press a recording to open it.
+    uiState.pendingDelete?.let { recording ->
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissDeleteDialog() },
+            title = { Text(stringResource(R.string.livetv_delete_recording_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.livetv_delete_recording_body,
+                        recording.name,
+                    ),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.deleteRecording() },
+                    enabled = !uiState.isDeleting,
+                    colors = androidx.compose.material3.ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) { Text(stringResource(R.string.livetv_delete)) }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { viewModel.dismissDeleteDialog() },
+                    enabled = !uiState.isDeleting,
+                ) { Text(stringResource(com.raulshma.jellyplay.core.ui.R.string.core_cancel)) }
+            },
+        )
+    }
+
     when {
         uiState.isLoading && uiState.recordings.isEmpty() -> {
             ScreenLoadingState(modifier = Modifier.fillMaxSize())
@@ -123,6 +158,7 @@ fun RecordingsScreen(
                                         recording = recording,
                                         imageUrl = viewModel.getImageUrl(recording.id, recording.imageTag),
                                         onClick = { onRecordingClick(recording.id) },
+                                        onLongClick = { viewModel.showDeleteDialog(recording) },
                                         modifier = Modifier.weight(1f),
                                     )
                                 }
@@ -157,13 +193,18 @@ private fun RecordingCard(
     recording: LiveTvRecording,
     imageUrl: String,
     onClick: () -> Unit,
+    onLongClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier
             .clip(ShapeCache.smooth12)
             .focusIndicator(ShapeCache.smooth12)
-            .clickable(onClick = onClick)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+                onLongClickLabel = stringResource(R.string.livetv_delete_recording_cd),
+            )
             .padding(4.dp),
     ) {
         Box(

--- a/feature/livetv/src/main/java/com/raulshma/jellyplay/feature/livetv/recordings/RecordingsViewModel.kt
+++ b/feature/livetv/src/main/java/com/raulshma/jellyplay/feature/livetv/recordings/RecordingsViewModel.kt
@@ -13,6 +13,9 @@ data class RecordingsUiState(
     val recordings: List<LiveTvRecording> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
+    /** Recording awaiting a delete confirmation, if any. Null hides the dialog. */
+    val pendingDelete: LiveTvRecording? = null,
+    val isDeleting: Boolean = false,
 )
 
 /**
@@ -48,6 +51,44 @@ class RecordingsViewModel @Inject constructor(
 
     fun getImageUrl(itemId: String, imageTag: String?): String =
         if (imageTag != null) imageUrlProvider.getImageUrl(itemId) else ""
+
+    // ── Delete / cancel affordance ──────────────────────────────────────────
+
+    /** Opens the confirm dialog for deleting [recording] (and cancelling its series timer if set). */
+    fun showDeleteDialog(recording: LiveTvRecording) {
+        _uiState.update { it.copy(pendingDelete = recording) }
+    }
+
+    fun dismissDeleteDialog() {
+        if (!_uiState.value.isDeleting) {
+            _uiState.update { it.copy(pendingDelete = null) }
+        }
+    }
+
+    /**
+     * Deletes the recording pending confirmation. If it has a [LiveTvRecording.seriesTimerId]
+     * the series timer is cancelled first so future episodes aren't recorded,
+     * then the recorded item itself is deleted.
+     */
+    fun deleteRecording() {
+        val recording = _uiState.value.pendingDelete ?: return
+        launch {
+            _uiState.update { it.copy(isDeleting = true) }
+            // Cancel the series timer (best-effort) if one is attached.
+            recording.seriesTimerId?.let { mediaRepository.cancelSeriesTimer(it) }
+            val result = mediaRepository.deleteRecording(recording.id)
+            if (result.isSuccess) {
+                _uiState.update {
+                    it.copy(isDeleting = false, pendingDelete = null, error = null)
+                }
+                load()
+            } else {
+                _uiState.update {
+                    it.copy(isDeleting = false, error = result.exceptionOrNull()?.message)
+                }
+            }
+        }
+    }
 
     private companion object {
         const val LATEST_LIMIT = 24

--- a/feature/livetv/src/main/res/values-de/strings.xml
+++ b/feature/livetv/src/main/res/values-de/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">Serie aufnehmen</string>
     <string name="livetv_cancel_recording">Aufnahme abbrechen</string>
     <string name="livetv_cancel_series">Serie abbrechen</string>
+    <string name="livetv_delete">Löschen</string>
+    <string name="livetv_delete_recording_cd">Aufnahme löschen</string>
+    <string name="livetv_delete_recording_title">Aufnahme löschen?</string>
+    <string name="livetv_delete_recording_body">„%1$s\" löschen? Dies kann nicht rückgängig gemacht werden.</string>
     <string name="livetv_record_success">Aufnahme geplant</string>
     <string name="livetv_record_failed">Aufnahme konnte nicht festgelegt werden</string>
     <string name="livetv_record_canceled">Aufnahme abgebrochen</string>

--- a/feature/livetv/src/main/res/values-es/strings.xml
+++ b/feature/livetv/src/main/res/values-es/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">Grabar serie</string>
     <string name="livetv_cancel_recording">Cancelar grabación</string>
     <string name="livetv_cancel_series">Cancelar serie</string>
+    <string name="livetv_delete">Eliminar</string>
+    <string name="livetv_delete_recording_cd">Eliminar grabación</string>
+    <string name="livetv_delete_recording_title">¿Eliminar grabación?</string>
+    <string name="livetv_delete_recording_body">¿Eliminar \"%1$s\"? Esta acción no se puede deshacer.</string>
     <string name="livetv_record_success">Grabación programada</string>
     <string name="livetv_record_failed">No se pudo programar la grabación</string>
     <string name="livetv_record_canceled">Grabación cancelada</string>

--- a/feature/livetv/src/main/res/values-fr/strings.xml
+++ b/feature/livetv/src/main/res/values-fr/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">Enregistrer la série</string>
     <string name="livetv_cancel_recording">Annuler l\'enregistrement</string>
     <string name="livetv_cancel_series">Annuler la série</string>
+    <string name="livetv_delete">Supprimer</string>
+    <string name="livetv_delete_recording_cd">Supprimer l\'enregistrement</string>
+    <string name="livetv_delete_recording_title">Supprimer l\'enregistrement ?</string>
+    <string name="livetv_delete_recording_body">Supprimer « %1$s » ? Action irréversible.</string>
     <string name="livetv_record_success">Enregistrement programmé</string>
     <string name="livetv_record_failed">Échec de la programmation de l\'enregistrement</string>
     <string name="livetv_record_canceled">Enregistrement annulé</string>

--- a/feature/livetv/src/main/res/values-it/strings.xml
+++ b/feature/livetv/src/main/res/values-it/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">Registra serie</string>
     <string name="livetv_cancel_recording">Annulla registrazione</string>
     <string name="livetv_cancel_series">Annulla serie</string>
+    <string name="livetv_delete">Elimina</string>
+    <string name="livetv_delete_recording_cd">Elimina registrazione</string>
+    <string name="livetv_delete_recording_title">Eliminare la registrazione?</string>
+    <string name="livetv_delete_recording_body">Eliminare \"%1$s\"? Operazione irreversibile.</string>
     <string name="livetv_record_success">Registrazione programmata</string>
     <string name="livetv_record_failed">Impostazione registrazione non riuscita</string>
     <string name="livetv_record_canceled">Registrazione annullata</string>

--- a/feature/livetv/src/main/res/values-ja/strings.xml
+++ b/feature/livetv/src/main/res/values-ja/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">シリーズを録画</string>
     <string name="livetv_cancel_recording">録画をキャンセル</string>
     <string name="livetv_cancel_series">シリーズをキャンセル</string>
+    <string name="livetv_delete">削除</string>
+    <string name="livetv_delete_recording_cd">録画を削除</string>
+    <string name="livetv_delete_recording_title">録画を削除しますか？</string>
+    <string name="livetv_delete_recording_body">「%1$s」を削除しますか？この操作は元に戻せません。</string>
     <string name="livetv_record_success">録画を予約しました</string>
     <string name="livetv_record_failed">録画の設定に失敗しました</string>
     <string name="livetv_record_canceled">録画をキャンセルしました</string>

--- a/feature/livetv/src/main/res/values-ko/strings.xml
+++ b/feature/livetv/src/main/res/values-ko/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">시리즈 녹화</string>
     <string name="livetv_cancel_recording">녹화 취소</string>
     <string name="livetv_cancel_series">시리즈 취소</string>
+    <string name="livetv_delete">삭제</string>
+    <string name="livetv_delete_recording_cd">녹화 삭제</string>
+    <string name="livetv_delete_recording_title">녹화를 삭제하시겠습니까?</string>
+    <string name="livetv_delete_recording_body">\"%1$s\"을(를) 삭제하시겠습니까? 되돌릴 수 없습니다.</string>
     <string name="livetv_record_success">녹화가 예약되었습니다</string>
     <string name="livetv_record_failed">녹화를 설정하지 못했습니다</string>
     <string name="livetv_record_canceled">녹화가 취소되었습니다</string>

--- a/feature/livetv/src/main/res/values-pt/strings.xml
+++ b/feature/livetv/src/main/res/values-pt/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">Gravar série</string>
     <string name="livetv_cancel_recording">Cancelar gravação</string>
     <string name="livetv_cancel_series">Cancelar série</string>
+    <string name="livetv_delete">Excluir</string>
+    <string name="livetv_delete_recording_cd">Excluir gravação</string>
+    <string name="livetv_delete_recording_title">Excluir gravação?</string>
+    <string name="livetv_delete_recording_body">Excluir \"%1$s\"? Isso não pode ser desfeito.</string>
     <string name="livetv_record_success">Gravação agendada</string>
     <string name="livetv_record_failed">Falha ao agendar gravação</string>
     <string name="livetv_record_canceled">Gravação cancelada</string>

--- a/feature/livetv/src/main/res/values-zh/strings.xml
+++ b/feature/livetv/src/main/res/values-zh/strings.xml
@@ -31,6 +31,10 @@
     <string name="livetv_record_series">录制剧集</string>
     <string name="livetv_cancel_recording">取消录像</string>
     <string name="livetv_cancel_series">取消剧集</string>
+    <string name="livetv_delete">删除</string>
+    <string name="livetv_delete_recording_cd">删除录像</string>
+    <string name="livetv_delete_recording_title">删除录像？</string>
+    <string name="livetv_delete_recording_body">删除“%1$s”？此操作无法撤销。</string>
     <string name="livetv_record_success">录像已安排</string>
     <string name="livetv_record_failed">设置录像失败</string>
     <string name="livetv_record_canceled">录像已取消</string>

--- a/feature/livetv/src/main/res/values/strings.xml
+++ b/feature/livetv/src/main/res/values/strings.xml
@@ -30,6 +30,10 @@
     <string name="livetv_record_series">Record Series</string>
     <string name="livetv_cancel_recording">Cancel Recording</string>
     <string name="livetv_cancel_series">Cancel Series</string>
+    <string name="livetv_delete">Delete</string>
+    <string name="livetv_delete_recording_cd">Delete recording</string>
+    <string name="livetv_delete_recording_title">Delete recording?</string>
+    <string name="livetv_delete_recording_body">Delete \"%1$s\"? This cannot be undone.</string>
     <string name="livetv_record_success">Recording scheduled</string>
     <string name="livetv_record_failed">Failed to set recording</string>
     <string name="livetv_record_canceled">Recording canceled</string>

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albums/AlbumsScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albums/AlbumsScreen.kt
@@ -75,7 +75,7 @@ fun AlbumsScreen(
                     modifier = Modifier.then(sortFocusState.focusModifier).tvFocusIndicator(sortFocusState, CircleShape),
                 ) {
                     Text(
-                        text = selectedSort.label,
+                        text = stringResource(selectedSort.labelRes),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
@@ -84,9 +84,9 @@ fun AlbumsScreen(
                     expanded = showSortMenu,
                     onDismissRequest = { showSortMenu = false },
                 ) {
-                    AlbumSortOption.entries.forEach { option ->
+                    MusicSortOption.entries.forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option.label) },
+                            text = { Text(stringResource(option.labelRes)) },
                             onClick = {
                                 viewModel.setSort(option)
                                 showSortMenu = false

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albums/AlbumsViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/albums/AlbumsViewModel.kt
@@ -8,6 +8,7 @@ import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.model.SortOption
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
+import com.raulshma.jellyplay.feature.music.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -17,12 +18,18 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
 
-enum class AlbumSortOption(val option: SortOption, val label: String) {
-    NAME(SortOption.SORT_NAME, "Name"),
-    DATE_ADDED(SortOption.DATE_ADDED, "Date Added"),
-    DATE_PLAYED(SortOption.DATE_PLAYED, "Date Played"),
-    RANDOM(SortOption.RANDOM, "Random"),
-    YEAR(SortOption.YEAR_DESC, "Year"),
+/**
+ * Sort options shared across the music collection screens (albums tab,
+ * artists tab, tracks tab, and the standalone Albums screen). Each entry
+ * pairs a Jellyfin [SortOption] with its localized label resource so the
+ * same enum drives both the query and the menu UI.
+ */
+enum class MusicSortOption(val option: SortOption, val labelRes: Int) {
+    NAME(SortOption.SORT_NAME, R.string.music_sort_name),
+    DATE_ADDED(SortOption.DATE_ADDED, R.string.music_sort_date_added),
+    DATE_PLAYED(SortOption.DATE_PLAYED, R.string.music_sort_date_played),
+    RANDOM(SortOption.RANDOM, R.string.music_sort_random),
+    YEAR(SortOption.YEAR_DESC, R.string.music_sort_year),
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -32,9 +39,9 @@ class AlbumsViewModel @Inject constructor(
     private val imageUrlProvider: ImageUrlProvider,
 ) : JellyPlayViewModel() {
 
-    private val sortFlow = MutableStateFlow(AlbumSortOption.NAME)
+    private val sortFlow = MutableStateFlow(MusicSortOption.NAME)
 
-    val selectedSort: StateFlow<AlbumSortOption> = sortFlow.asStateFlow()
+    val selectedSort: StateFlow<MusicSortOption> = sortFlow.asStateFlow()
 
     val albums: Flow<PagingData<MediaItem>> = sortFlow.flatMapLatest { sort ->
         mediaRepository.getMediaItemsPaged(
@@ -44,7 +51,7 @@ class AlbumsViewModel @Inject constructor(
         )
     }.cachedIn(scope)
 
-    fun setSort(sort: AlbumSortOption) {
+    fun setSort(sort: MusicSortOption) {
         sortFlow.value = sort
     }
 

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artists/ArtistsScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artists/ArtistsScreen.kt
@@ -46,6 +46,7 @@ import com.raulshma.jellyplay.core.ui.tv.tvFocusIndicator
 import com.raulshma.jellyplay.core.ui.util.safeItemKey
 import com.composables.icons.tabler.Tabler
 import com.composables.icons.tabler.outline.*
+import com.raulshma.jellyplay.feature.music.albums.MusicSortOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,7 +75,7 @@ fun ArtistsScreen(
                     modifier = Modifier.then(sortFocusState.focusModifier).tvFocusIndicator(sortFocusState, CircleShape),
                 ) {
                     Text(
-                        text = viewModel.selectedSort.label,
+                        text = stringResource(viewModel.selectedSort.labelRes),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
@@ -83,9 +84,14 @@ fun ArtistsScreen(
                     expanded = showSortMenu,
                     onDismissRequest = { showSortMenu = false },
                 ) {
-                    ArtistSortOption.entries.forEach { option ->
+                    listOf(
+                        MusicSortOption.NAME,
+                        MusicSortOption.DATE_ADDED,
+                        MusicSortOption.DATE_PLAYED,
+                        MusicSortOption.RANDOM,
+                    ).forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option.label) },
+                            text = { Text(stringResource(option.labelRes)) },
                             onClick = {
                                 viewModel.setSort(option)
                                 showSortMenu = false

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artists/ArtistsViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/artists/ArtistsViewModel.kt
@@ -6,21 +6,14 @@ import com.raulshma.jellyplay.core.data.repository.MediaRepository
 import com.raulshma.jellyplay.core.data.util.ImageUrlProvider
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
-import com.raulshma.jellyplay.core.model.SortOption
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
+import com.raulshma.jellyplay.feature.music.albums.MusicSortOption
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
-
-enum class ArtistSortOption(val option: SortOption, val label: String) {
-    NAME(SortOption.SORT_NAME, "Name"),
-    DATE_ADDED(SortOption.DATE_ADDED, "Date Added"),
-    DATE_PLAYED(SortOption.DATE_PLAYED, "Date Played"),
-    RANDOM(SortOption.RANDOM, "Random"),
-}
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -29,8 +22,8 @@ class ArtistsViewModel @Inject constructor(
     private val imageUrlProvider: ImageUrlProvider,
 ) : JellyPlayViewModel() {
 
-    private val _selectedSort = composeState(ArtistSortOption.NAME)
-    val selectedSort: ArtistSortOption get() = _selectedSort.value
+    private val _selectedSort = composeState(MusicSortOption.NAME)
+    val selectedSort: MusicSortOption get() = _selectedSort.value
 
     private val sortFlow = MutableStateFlow(_selectedSort.value)
 
@@ -42,7 +35,7 @@ class ArtistsViewModel @Inject constructor(
         )
     }.cachedIn(scope)
 
-    fun setSort(sort: ArtistSortOption) {
+    fun setSort(sort: MusicSortOption) {
         _selectedSort.value = sort
         sortFlow.value = sort
     }

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/browse/MusicBrowseScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/browse/MusicBrowseScreen.kt
@@ -4,22 +4,31 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -27,6 +36,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.raulshma.jellyplay.feature.music.R
+import com.raulshma.jellyplay.feature.music.albums.MusicSortOption
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -41,6 +51,8 @@ import com.raulshma.jellyplay.feature.music.components.PagedGrid
 import com.raulshma.jellyplay.core.ui.components.ScreenLoadingState
 import com.raulshma.jellyplay.core.ui.tv.LocalTvMode
 import com.raulshma.jellyplay.core.ui.tv.TvFocusableGrid
+import com.raulshma.jellyplay.core.ui.tv.rememberTvFocusState
+import com.raulshma.jellyplay.core.ui.tv.tvFocusIndicator
 import com.raulshma.jellyplay.core.ui.util.safeItemKey
 import com.raulshma.jellyplay.feature.music.components.AlbumCard
 import com.raulshma.jellyplay.feature.music.components.ArtistCard
@@ -124,21 +136,30 @@ private fun ArtistsPage(
     spacing: Dp = 12.dp,
 ) {
     val artists = viewModel.artists.collectAsLazyPagingItems()
-    PagedGrid(
-        items = artists,
-        itemKey = { it.id },
-        contentPad = contentPad,
-        gridMin = gridMin,
-        spacing = spacing,
-    ) { artist, itemModifier ->
-        val imageUrl = remember(artist.id) { viewModel.getImageUrl(artist.id) }
-        ArtistCard(
-            name = artist.name,
-            imageUrl = imageUrl,
-            onClick = { onItemClick(artist.id) },
-            modifier = itemModifier,
-            blurHash = artist.blurHashes.primary,
+    val sort by viewModel.artistSort.collectAsStateWithLifecycle()
+    Column(modifier = Modifier.fillMaxSize()) {
+        SortMenuRow(
+            selected = sort,
+            options = listOf(MusicSortOption.NAME, MusicSortOption.DATE_ADDED, MusicSortOption.RANDOM),
+            onSelect = viewModel::setArtistSort,
+            contentPad = contentPad,
         )
+        PagedGrid(
+            items = artists,
+            itemKey = { it.id },
+            contentPad = contentPad,
+            gridMin = gridMin,
+            spacing = spacing,
+        ) { artist, itemModifier ->
+            val imageUrl = remember(artist.id) { viewModel.getImageUrl(artist.id) }
+            ArtistCard(
+                name = artist.name,
+                imageUrl = imageUrl,
+                onClick = { onItemClick(artist.id) },
+                modifier = itemModifier,
+                blurHash = artist.blurHashes.primary,
+            )
+        }
     }
 }
 
@@ -151,23 +172,32 @@ private fun AlbumsPage(
     spacing: Dp = 12.dp,
 ) {
     val albums = viewModel.albums.collectAsLazyPagingItems()
-    PagedGrid(
-        items = albums,
-        itemKey = { it.id },
-        contentPad = contentPad,
-        gridMin = gridMin,
-        spacing = spacing,
-    ) { album, itemModifier ->
-        val imageUrl = remember(album.id) { viewModel.getImageUrl(album.id) }
-        AlbumCard(
-            name = album.name,
-            artist = album.albumArtist,
-            year = album.year,
-            imageUrl = imageUrl,
-            onClick = { onItemClick(album.id) },
-            modifier = itemModifier,
-            blurHash = album.blurHashes.primary,
+    val sort by viewModel.albumSort.collectAsStateWithLifecycle()
+    Column(modifier = Modifier.fillMaxSize()) {
+        SortMenuRow(
+            selected = sort,
+            options = MusicSortOption.entries,
+            onSelect = viewModel::setAlbumSort,
+            contentPad = contentPad,
         )
+        PagedGrid(
+            items = albums,
+            itemKey = { it.id },
+            contentPad = contentPad,
+            gridMin = gridMin,
+            spacing = spacing,
+        ) { album, itemModifier ->
+            val imageUrl = remember(album.id) { viewModel.getImageUrl(album.id) }
+            AlbumCard(
+                name = album.name,
+                artist = album.albumArtist,
+                year = album.year,
+                imageUrl = imageUrl,
+                onClick = { onItemClick(album.id) },
+                modifier = itemModifier,
+                blurHash = album.blurHashes.primary,
+            )
+        }
     }
 }
 
@@ -178,46 +208,102 @@ private fun TracksPage(
     contentPad: Dp = 16.dp,
 ) {
     val tracks = viewModel.tracks.collectAsLazyPagingItems()
-    Box(modifier = Modifier.fillMaxSize()) {
-        when (val refreshState = tracks.loadState.refresh) {
-            is LoadState.Loading -> ScreenLoadingState()
-            is LoadState.Error -> ErrorScreen(
-                message = refreshState.error.localizedMessage ?: stringResource(R.string.music_failed_load_tracks),
-                onRetry = { tracks.refresh() },
-            )
-            is LoadState.NotLoading -> {
-                if (tracks.itemCount == 0) {
-                    ScreenEmptyState(
-                        icon = Tabler.Outline.Music,
-                        title = stringResource(R.string.music_no_tracks_found),
-                    )
-                } else {
-                    LazyColumn(
-                        contentPadding = PaddingValues(horizontal = contentPad, vertical = 8.dp),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
-                        modifier = Modifier.fillMaxSize(),
-                    ) {
-                        items(
-                            count = tracks.itemCount,
-                            key = tracks.safeItemKey { it.id },
-                            contentType = { "mediaItem" },
-                        ) { index ->
-                            val track = tracks[index] ?: return@items
-                            val imageUrl = remember(track.id) { viewModel.getImageUrl(track.id) }
-                            TrackRow(
-                                name = track.name,
-                                artist = track.albumArtist,
-                                album = track.album,
-                                duration = track.runTimeTicks?.let { ticks ->
-                                    com.raulshma.jellyplay.core.ui.components.formatDurationMs(ticks / 10_000)
-                                },
-                                imageUrl = imageUrl,
-                                onClick = { onItemClick(track.id) },
-                                blurHash = track.blurHashes.primary,
-                            )
+    val sort by viewModel.trackSort.collectAsStateWithLifecycle()
+    Column(modifier = Modifier.fillMaxSize()) {
+        SortMenuRow(
+            selected = sort,
+            options = listOf(MusicSortOption.NAME, MusicSortOption.DATE_ADDED, MusicSortOption.DATE_PLAYED, MusicSortOption.RANDOM),
+            onSelect = viewModel::setTrackSort,
+            contentPad = contentPad,
+        )
+        Box(modifier = Modifier.fillMaxSize()) {
+            when (val refreshState = tracks.loadState.refresh) {
+                is LoadState.Loading -> ScreenLoadingState()
+                is LoadState.Error -> ErrorScreen(
+                    message = refreshState.error.localizedMessage ?: stringResource(R.string.music_failed_load_tracks),
+                    onRetry = { tracks.refresh() },
+                )
+                is LoadState.NotLoading -> {
+                    if (tracks.itemCount == 0) {
+                        ScreenEmptyState(
+                            icon = Tabler.Outline.Music,
+                            title = stringResource(R.string.music_no_tracks_found),
+                        )
+                    } else {
+                        LazyColumn(
+                            contentPadding = PaddingValues(horizontal = contentPad, vertical = 8.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                            modifier = Modifier.fillMaxSize(),
+                        ) {
+                            items(
+                                count = tracks.itemCount,
+                                key = tracks.safeItemKey { it.id },
+                                contentType = { "mediaItem" },
+                            ) { index ->
+                                val track = tracks[index] ?: return@items
+                                val imageUrl = remember(track.id) { viewModel.getImageUrl(track.id) }
+                                TrackRow(
+                                    name = track.name,
+                                    artist = track.albumArtist,
+                                    album = track.album,
+                                    duration = track.runTimeTicks?.let { ticks ->
+                                        com.raulshma.jellyplay.core.ui.components.formatDurationMs(ticks / 10_000)
+                                    },
+                                    imageUrl = imageUrl,
+                                    onClick = { onItemClick(track.id) },
+                                    blurHash = track.blurHashes.primary,
+                                )
+                            }
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Compact sort control placed above a browse grid/list. Shows the active
+ * option's label and opens a dropdown of the allowed [options].
+ */
+@Composable
+private fun SortMenuRow(
+    selected: MusicSortOption,
+    options: List<MusicSortOption>,
+    onSelect: (MusicSortOption) -> Unit,
+    contentPad: Dp,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(end = contentPad, top = 4.dp, bottom = 4.dp),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val focusState = rememberTvFocusState()
+        IconButton(
+            onClick = { expanded = true },
+            modifier = Modifier.then(focusState.focusModifier).tvFocusIndicator(focusState, CircleShape),
+        ) {
+            Text(
+                text = stringResource(selected.labelRes),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            options.forEach { option ->
+                DropdownMenuItem(
+                    text = { Text(stringResource(option.labelRes)) },
+                    onClick = {
+                        onSelect(option)
+                        expanded = false
+                    },
+                )
             }
         }
     }

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/browse/MusicBrowseViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/browse/MusicBrowseViewModel.kt
@@ -9,30 +9,55 @@ import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
 import com.raulshma.jellyplay.core.model.Playlist
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
+import com.raulshma.jellyplay.feature.music.albums.MusicSortOption
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class MusicBrowseViewModel @Inject constructor(
     private val mediaRepository: MediaRepository,
     private val imageUrlProvider: ImageUrlProvider,
 ) : JellyPlayViewModel() {
 
-    val artists: Flow<PagingData<MediaItem>> = mediaRepository.getMediaItemsPaged(
-        mediaTypes = listOf(MediaType.ARTIST),
-        sortBy = "SortName",
-    ).cachedIn(scope)
+    // Per-tab sort state. Each starts on NAME (the previous hard-coded default).
+    private val artistSortFlow = MutableStateFlow(MusicSortOption.NAME)
+    private val albumSortFlow = MutableStateFlow(MusicSortOption.NAME)
+    private val trackSortFlow = MutableStateFlow(MusicSortOption.NAME)
 
-    val albums: Flow<PagingData<MediaItem>> = mediaRepository.getMediaItemsPaged(
-        mediaTypes = listOf(MediaType.ALBUM),
-        sortBy = "SortName",
-    ).cachedIn(scope)
+    val artistSort: StateFlow<MusicSortOption> = artistSortFlow.asStateFlow()
+    val albumSort: StateFlow<MusicSortOption> = albumSortFlow.asStateFlow()
+    val trackSort: StateFlow<MusicSortOption> = trackSortFlow.asStateFlow()
 
-    val tracks: Flow<PagingData<MediaItem>> = mediaRepository.getMediaItemsPaged(
-        mediaTypes = listOf(MediaType.AUDIO),
-        sortBy = "SortName",
-    ).cachedIn(scope)
+    val artists: Flow<PagingData<MediaItem>> = artistSortFlow.flatMapLatest { sort ->
+        mediaRepository.getMediaItemsPaged(
+            mediaTypes = listOf(MediaType.ARTIST),
+            sortBy = sort.option.apiValue,
+            sortOrder = sort.option.sortOrder,
+        )
+    }.cachedIn(scope)
+
+    val albums: Flow<PagingData<MediaItem>> = albumSortFlow.flatMapLatest { sort ->
+        mediaRepository.getMediaItemsPaged(
+            mediaTypes = listOf(MediaType.ALBUM),
+            sortBy = sort.option.apiValue,
+            sortOrder = sort.option.sortOrder,
+        )
+    }.cachedIn(scope)
+
+    val tracks: Flow<PagingData<MediaItem>> = trackSortFlow.flatMapLatest { sort ->
+        mediaRepository.getMediaItemsPaged(
+            mediaTypes = listOf(MediaType.AUDIO),
+            sortBy = sort.option.apiValue,
+            sortOrder = sort.option.sortOrder,
+        )
+    }.cachedIn(scope)
 
     private val _genres = stateFlow<List<Genre>>(emptyList())
     val genres = _genres.flow
@@ -50,6 +75,10 @@ class MusicBrowseViewModel @Inject constructor(
                 .onSuccess { _playlists.set(it) }
         }
     }
+
+    fun setArtistSort(sort: MusicSortOption) { artistSortFlow.value = sort }
+    fun setAlbumSort(sort: MusicSortOption) { albumSortFlow.value = sort }
+    fun setTrackSort(sort: MusicSortOption) { trackSortFlow.value = sort }
 
     fun getImageUrl(itemId: String): String =
         imageUrlProvider.getImageUrl(itemId, maxWidth = ImageUrlProvider.MUSIC_MAX_WIDTH)

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailScreen.kt
@@ -166,6 +166,8 @@ fun PlaylistDetailScreen(
                                 },
                                 onAddToQueue = if (isVideo) null else { { viewModel.addToQueue(item) } },
                                 onRemoveFromPlaylist = { viewModel.removeFromPlaylist(item) },
+                                onMoveUp = if (index > 0) { { viewModel.moveItem(item, index - 1) } } else null,
+                                onMoveDown = if (index < viewModel.items.lastIndex) { { viewModel.moveItem(item, index + 1) } } else null,
                             )
                         }
                     }
@@ -196,6 +198,8 @@ private fun PlaylistTrackRow(
     onClick: () -> Unit,
     onAddToQueue: (() -> Unit)? = null,
     onRemoveFromPlaylist: (() -> Unit)? = null,
+    onMoveUp: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -274,6 +278,31 @@ private fun PlaylistTrackRow(
                         )
                     },
                 )
+                // Reorder entries — works on touch + D-pad.
+                if (onMoveUp != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.music_move_up)) },
+                        onClick = {
+                            onMoveUp()
+                            showMenu = false
+                        },
+                        leadingIcon = {
+                            Icon(Tabler.Outline.ArrowUp, contentDescription = null)
+                        },
+                    )
+                }
+                if (onMoveDown != null) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.music_move_down)) },
+                        onClick = {
+                            onMoveDown()
+                            showMenu = false
+                        },
+                        leadingIcon = {
+                            Icon(Tabler.Outline.ArrowDown, contentDescription = null)
+                        },
+                    )
+                }
                 if (onRemoveFromPlaylist != null) {
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.music_remove_from_playlist), color = MaterialTheme.colorScheme.error) },

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/playlists/PlaylistDetailViewModel.kt
@@ -123,4 +123,36 @@ class PlaylistDetailViewModel @Inject constructor(
     fun clearError() {
         _error.value = null
     }
+
+    /**
+     * Reorders the playlist: moves [item] from its current position to
+     * [newIndex]. Applies the swap optimistically so the list reacts instantly,
+     * then persists it via [MediaRepository.movePlaylistItem]. On failure the
+     * list is reloaded from the server so it reflects the true order.
+     */
+    fun moveItem(item: PlaylistItem, newIndex: Int) {
+        val entryId = item.playlistItemId ?: return
+        val currentId = playlistId
+        if (currentId.isEmpty()) return
+        val current = _items.value
+        val fromIndex = current.indexOfFirst { it.playlistItemId == entryId }
+        if (fromIndex == -1 || fromIndex == newIndex) return
+        // Optimistic in-place reorder.
+        val reordered = current.toMutableList().apply {
+            val moved = removeAt(fromIndex)
+            add(newIndex.coerceIn(0, size), moved)
+        }
+        _items.value = reordered
+        launch {
+            _isMutating.value = true
+            _error.value = null
+            mediaRepository.movePlaylistItem(currentId, entryId, newIndex)
+                .onFailure {
+                    _error.value = it.message ?: "Failed to reorder playlist"
+                    // Roll back to the server's authoritative order.
+                    load(currentId, playlistName)
+                }
+            _isMutating.value = false
+        }
+    }
 }

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/tracks/TracksScreen.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/tracks/TracksScreen.kt
@@ -49,6 +49,7 @@ import com.raulshma.jellyplay.core.ui.tv.tvFocusRestorer
 import com.raulshma.jellyplay.core.ui.util.safeItemKey
 import com.composables.icons.tabler.Tabler
 import com.composables.icons.tabler.outline.*
+import com.raulshma.jellyplay.feature.music.albums.MusicSortOption
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -86,7 +87,7 @@ fun TracksScreen(
                     modifier = Modifier.then(sortFocusState.focusModifier).tvFocusIndicator(sortFocusState, CircleShape),
                 ) {
                     Text(
-                        text = viewModel.selectedSort.label,
+                        text = stringResource(viewModel.selectedSort.labelRes),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
@@ -95,9 +96,14 @@ fun TracksScreen(
                     expanded = showSortMenu,
                     onDismissRequest = { showSortMenu = false },
                 ) {
-                    TrackSortOption.entries.forEach { option ->
+                    listOf(
+                        MusicSortOption.NAME,
+                        MusicSortOption.DATE_ADDED,
+                        MusicSortOption.DATE_PLAYED,
+                        MusicSortOption.RANDOM,
+                    ).forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option.label) },
+                            text = { Text(stringResource(option.labelRes)) },
                             onClick = {
                                 viewModel.setSort(option)
                                 showSortMenu = false

--- a/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/tracks/TracksViewModel.kt
+++ b/feature/music/src/main/java/com/raulshma/jellyplay/feature/music/tracks/TracksViewModel.kt
@@ -8,21 +8,14 @@ import com.raulshma.jellyplay.core.data.repository.MediaRepository
 import com.raulshma.jellyplay.core.data.util.ImageUrlProvider
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.MediaType
-import com.raulshma.jellyplay.core.model.SortOption
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
+import com.raulshma.jellyplay.feature.music.albums.MusicSortOption
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
-
-enum class TrackSortOption(val option: SortOption, val label: String) {
-    NAME(SortOption.SORT_NAME, "Name"),
-    DATE_ADDED(SortOption.DATE_ADDED, "Date Added"),
-    DATE_PLAYED(SortOption.DATE_PLAYED, "Date Played"),
-    RANDOM(SortOption.RANDOM, "Random"),
-}
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
@@ -32,8 +25,8 @@ class TracksViewModel @Inject constructor(
     val audioPlaybackManager: AudioPlaybackManager,
 ) : JellyPlayViewModel() {
 
-    private val _selectedSort = composeState(TrackSortOption.NAME)
-    val selectedSort: TrackSortOption get() = _selectedSort.value
+    private val _selectedSort = composeState(MusicSortOption.NAME)
+    val selectedSort: MusicSortOption get() = _selectedSort.value
 
     private val sortFlow = MutableStateFlow(_selectedSort.value)
 
@@ -45,7 +38,7 @@ class TracksViewModel @Inject constructor(
         )
     }.cachedIn(scope)
 
-    fun setSort(sort: TrackSortOption) {
+    fun setSort(sort: MusicSortOption) {
         _selectedSort.value = sort
         sortFlow.value = sort
     }

--- a/feature/music/src/main/res/values-de/strings.xml
+++ b/feature/music/src/main/res/values-de/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">Alle wiedergeben</string>
     <string name="music_shuffle">Zufall</string>
     <string name="music_add_to_queue">Zur Warteschlange hinzufügen</string>
+    <string name="music_move_up">Nach oben</string>
+    <string name="music_move_down">Nach unten</string>
     <string name="music_instant_mix">Sofortiger Mix</string>
     <string name="music_creating_mix">Mix wird erstellt…</string>
     <string name="music_now_playing">Wird wiedergegeben</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">Zuletzt hinzugefügt</string>
     <string name="music_smart_playlist_unplayed">Ungespielte Titel</string>
     <string name="music_smart_playlist_favorites">Favoriten</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">Name</string>
+    <string name="music_sort_date_added">Hinzugefügt am</string>
+    <string name="music_sort_date_played">Abgespielt am</string>
+    <string name="music_sort_random">Zufällig</string>
+    <string name="music_sort_year">Jahr</string>
 </resources>

--- a/feature/music/src/main/res/values-es/strings.xml
+++ b/feature/music/src/main/res/values-es/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">Reproducir todo</string>
     <string name="music_shuffle">Aleatorio</string>
     <string name="music_add_to_queue">Añadir a la cola</string>
+    <string name="music_move_up">Subir</string>
+    <string name="music_move_down">Bajar</string>
     <string name="music_instant_mix">Mix instantáneo</string>
     <string name="music_creating_mix">Creando mix…</string>
     <string name="music_now_playing">Reproduciendo ahora</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">Añadidas recientemente</string>
     <string name="music_smart_playlist_unplayed">Pistas no reproducidas</string>
     <string name="music_smart_playlist_favorites">Favoritos</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">Nombre</string>
+    <string name="music_sort_date_added">Añadido</string>
+    <string name="music_sort_date_played">Reproducido</string>
+    <string name="music_sort_random">Aleatorio</string>
+    <string name="music_sort_year">Año</string>
 </resources>

--- a/feature/music/src/main/res/values-fr/strings.xml
+++ b/feature/music/src/main/res/values-fr/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">Tout lire</string>
     <string name="music_shuffle">Aléatoire</string>
     <string name="music_add_to_queue">Ajouter à la file</string>
+    <string name="music_move_up">Monter</string>
+    <string name="music_move_down">Descendre</string>
     <string name="music_instant_mix">Mix instantané</string>
     <string name="music_creating_mix">Création du mix…</string>
     <string name="music_now_playing">Lecture en cours</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">Ajoutées récemment</string>
     <string name="music_smart_playlist_unplayed">Pistes non lues</string>
     <string name="music_smart_playlist_favorites">Favoris</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">Nom</string>
+    <string name="music_sort_date_added">Date d\'ajout</string>
+    <string name="music_sort_date_played">Date de lecture</string>
+    <string name="music_sort_random">Aléatoire</string>
+    <string name="music_sort_year">Année</string>
 </resources>

--- a/feature/music/src/main/res/values-it/strings.xml
+++ b/feature/music/src/main/res/values-it/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">Riproduci tutto</string>
     <string name="music_shuffle">Casuale</string>
     <string name="music_add_to_queue">Aggiungi alla coda</string>
+    <string name="music_move_up">Sposta su</string>
+    <string name="music_move_down">Sposta giù</string>
     <string name="music_instant_mix">Mix istantaneo</string>
     <string name="music_creating_mix">Creazione del mix…</string>
     <string name="music_now_playing">In riproduzione</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">Aggiunte di recente</string>
     <string name="music_smart_playlist_unplayed">Brani non riprodotti</string>
     <string name="music_smart_playlist_favorites">Preferiti</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">Nome</string>
+    <string name="music_sort_date_added">Aggiunto</string>
+    <string name="music_sort_date_played">Riprodotto</string>
+    <string name="music_sort_random">Casuale</string>
+    <string name="music_sort_year">Anno</string>
 </resources>

--- a/feature/music/src/main/res/values-ja/strings.xml
+++ b/feature/music/src/main/res/values-ja/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">すべて再生</string>
     <string name="music_shuffle">シャッフル</string>
     <string name="music_add_to_queue">キューに追加</string>
+    <string name="music_move_up">上に移動</string>
+    <string name="music_move_down">下に移動</string>
     <string name="music_instant_mix">インスタントミックス</string>
     <string name="music_creating_mix">ミックスを作成中…</string>
     <string name="music_now_playing">再生中</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">最近追加</string>
     <string name="music_smart_playlist_unplayed">未再生トラック</string>
     <string name="music_smart_playlist_favorites">お気に入り</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">名前</string>
+    <string name="music_sort_date_added">追加日</string>
+    <string name="music_sort_date_played">再生日</string>
+    <string name="music_sort_random">ランダム</string>
+    <string name="music_sort_year">年</string>
 </resources>

--- a/feature/music/src/main/res/values-ko/strings.xml
+++ b/feature/music/src/main/res/values-ko/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">모두 재생</string>
     <string name="music_shuffle">셔플</string>
     <string name="music_add_to_queue">대기열에 추가</string>
+    <string name="music_move_up">위로 이동</string>
+    <string name="music_move_down">아래로 이동</string>
     <string name="music_instant_mix">인스턴트 믹스</string>
     <string name="music_creating_mix">믹스 만드는 중…</string>
     <string name="music_now_playing">재생 중</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">최근 추가</string>
     <string name="music_smart_playlist_unplayed">재생하지 않은 곡</string>
     <string name="music_smart_playlist_favorites">즐겨찾기</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">이름</string>
+    <string name="music_sort_date_added">추가일</string>
+    <string name="music_sort_date_played">재생일</string>
+    <string name="music_sort_random">무작위</string>
+    <string name="music_sort_year">연도</string>
 </resources>

--- a/feature/music/src/main/res/values-pt/strings.xml
+++ b/feature/music/src/main/res/values-pt/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">Reproduzir tudo</string>
     <string name="music_shuffle">Aleatório</string>
     <string name="music_add_to_queue">Adicionar à fila</string>
+    <string name="music_move_up">Mover para cima</string>
+    <string name="music_move_down">Mover para baixo</string>
     <string name="music_instant_mix">Mix instantâneo</string>
     <string name="music_creating_mix">Criando mix…</string>
     <string name="music_now_playing">Reproduzindo agora</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">Adicionadas recentemente</string>
     <string name="music_smart_playlist_unplayed">Faixas não reproduzidas</string>
     <string name="music_smart_playlist_favorites">Favoritos</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">Nome</string>
+    <string name="music_sort_date_added">Adicionado</string>
+    <string name="music_sort_date_played">Reproduzido</string>
+    <string name="music_sort_random">Aleatório</string>
+    <string name="music_sort_year">Ano</string>
 </resources>

--- a/feature/music/src/main/res/values-zh/strings.xml
+++ b/feature/music/src/main/res/values-zh/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">全部播放</string>
     <string name="music_shuffle">随机播放</string>
     <string name="music_add_to_queue">加入队列</string>
+    <string name="music_move_up">上移</string>
+    <string name="music_move_down">下移</string>
     <string name="music_instant_mix">即时混音</string>
     <string name="music_creating_mix">正在创建混音…</string>
     <string name="music_now_playing">正在播放</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">最近添加</string>
     <string name="music_smart_playlist_unplayed">未播放曲目</string>
     <string name="music_smart_playlist_favorites">收藏</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">名称</string>
+    <string name="music_sort_date_added">添加日期</string>
+    <string name="music_sort_date_played">播放日期</string>
+    <string name="music_sort_random">随机</string>
+    <string name="music_sort_year">年份</string>
 </resources>

--- a/feature/music/src/main/res/values/strings.xml
+++ b/feature/music/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="music_play_all">Play All</string>
     <string name="music_shuffle">Shuffle</string>
     <string name="music_add_to_queue">Add to Queue</string>
+    <string name="music_move_up">Move Up</string>
+    <string name="music_move_down">Move Down</string>
     <string name="music_instant_mix">Instant Mix</string>
     <string name="music_creating_mix">Creating Mix…</string>
     <string name="music_now_playing">Now Playing</string>
@@ -106,4 +108,11 @@
     <string name="music_smart_playlist_recently_added">Recently Added</string>
     <string name="music_smart_playlist_unplayed">Unplayed Tracks</string>
     <string name="music_smart_playlist_favorites">Favorites</string>
+
+    <!-- Album / track sort labels -->
+    <string name="music_sort_name">Name</string>
+    <string name="music_sort_date_added">Date Added</string>
+    <string name="music_sort_date_played">Date Played</string>
+    <string name="music_sort_random">Random</string>
+    <string name="music_sort_year">Year</string>
 </resources>

--- a/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterScreen.kt
+++ b/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterScreen.kt
@@ -3,10 +3,21 @@ package com.raulshma.jellyplay.feature.newsletter
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -14,14 +25,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.raulshma.jellyplay.core.model.MediaItem
+import com.raulshma.jellyplay.core.ui.components.ConfirmDialog
 import com.raulshma.jellyplay.core.ui.components.JellyPlayScreenScaffold
 import com.raulshma.jellyplay.core.ui.components.ScreenEmptyState
 import com.raulshma.jellyplay.core.ui.components.ScreenLoadingState
 import com.raulshma.jellyplay.core.ui.components.rememberScreenBackgroundColor
+import com.raulshma.jellyplay.core.ui.feedback.asString
 import com.raulshma.jellyplay.core.ui.tv.TvGrabInitialFocus
 import com.raulshma.jellyplay.core.ui.tv.tvFocusRestorer
 import com.raulshma.jellyplay.feature.newsletter.R
 import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.DotsVertical
 import com.composables.icons.tabler.outline.Mail
 
 @OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
@@ -51,46 +65,116 @@ fun NewsletterScreen(
         tag = "newsletter_init",
     )
 
+    val snackbarHostState = remember { SnackbarHostState() }
+    val sendResultText = state.sendResult?.asString()
+    LaunchedEffect(sendResultText) {
+        if (sendResultText != null) {
+            snackbarHostState.showSnackbar(sendResultText)
+            viewModel.onEvent(NewsletterUiEvent.DismissSendResult)
+        }
+    }
+
     JellyPlayScreenScaffold(
         title = stringResource(R.string.newsletter_title),
         onBack = onBack,
         backgroundColor = backgroundColor,
+        actions = {
+            if (state.isAdmin) {
+                NewsletterAdminActions(viewModel = viewModel, isSending = state.isSending)
+            }
+        },
     ) { paddingValues ->
-        PullToRefreshBox(
-            isRefreshing = state.isRefreshing,
-            onRefresh = { viewModel.onEvent(NewsletterUiEvent.PullToRefresh) },
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
-        ) {
-            when {
-                state.isLoading && !hasAnyData -> {
-                    ScreenLoadingState(
-                        message = stringResource(R.string.newsletter_preparing_digest),
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-                state.error != null && !hasAnyData -> {
-                    ScreenEmptyState(
-                        icon = Tabler.Outline.Mail,
-                        title = stringResource(R.string.newsletter_could_not_load),
-                        description = state.error,
-                        actionLabel = stringResource(com.raulshma.jellyplay.core.ui.R.string.core_retry),
-                        onAction = { viewModel.onEvent(NewsletterUiEvent.Refresh) },
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-                else -> {
-                    NewsletterContent(
-                        state = state,
-                        viewModel = viewModel,
-                        onItemClick = onItemClick,
-                        onPlayClick = onPlayClick,
-                        onViewAllFreshPicks = onViewAllFreshPicks,
-                        listFocusRequester = listFocusRequester,
-                    )
+        Box(modifier = Modifier.fillMaxSize()) {
+            PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = { viewModel.onEvent(NewsletterUiEvent.PullToRefresh) },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+            ) {
+                when {
+                    state.isLoading && !hasAnyData -> {
+                        ScreenLoadingState(
+                            message = stringResource(R.string.newsletter_preparing_digest),
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                    state.error != null && !hasAnyData -> {
+                        ScreenEmptyState(
+                            icon = Tabler.Outline.Mail,
+                            title = stringResource(R.string.newsletter_could_not_load),
+                            description = state.error,
+                            actionLabel = stringResource(com.raulshma.jellyplay.core.ui.R.string.core_retry),
+                            onAction = { viewModel.onEvent(NewsletterUiEvent.Refresh) },
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
+                    else -> {
+                        NewsletterContent(
+                            state = state,
+                            viewModel = viewModel,
+                            onItemClick = onItemClick,
+                            onPlayClick = onPlayClick,
+                            onViewAllFreshPicks = onViewAllFreshPicks,
+                            listFocusRequester = listFocusRequester,
+                        )
+                    }
                 }
             }
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.padding(paddingValues),
+            ) { data -> Snackbar(snackbarData = data) }
+        }
+    }
+
+    state.pendingSendAction?.let { action ->
+        val isSendNow = action == NewsletterSendAction.SEND_NOW
+        ConfirmDialog(
+            title = stringResource(R.string.newsletter_send_confirm_title),
+            message = stringResource(R.string.newsletter_send_confirm_body),
+            confirmText = stringResource(
+                if (isSendNow) R.string.newsletter_send_now else R.string.newsletter_send_test
+            ),
+            dismissText = stringResource(com.raulshma.jellyplay.core.ui.R.string.core_cancel),
+            onConfirm = { viewModel.onEvent(NewsletterUiEvent.ConfirmSend) },
+            onDismiss = { viewModel.onEvent(NewsletterUiEvent.DismissSendDialog) },
+            isDestructive = false,
+        )
+    }
+}
+
+@Composable
+private fun NewsletterAdminActions(
+    viewModel: NewsletterViewModel,
+    isSending: Boolean,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { menuExpanded = true }, enabled = !isSending) {
+            Icon(
+                imageVector = Tabler.Outline.DotsVertical,
+                contentDescription = stringResource(R.string.newsletter_send_admin_only),
+            )
+        }
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.newsletter_send_now)) },
+                onClick = {
+                    menuExpanded = false
+                    viewModel.onEvent(NewsletterUiEvent.SendNow)
+                },
+            )
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.newsletter_send_test)) },
+                onClick = {
+                    menuExpanded = false
+                    viewModel.onEvent(NewsletterUiEvent.SendTest)
+                },
+            )
         }
     }
 }

--- a/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterUiEvent.kt
+++ b/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterUiEvent.kt
@@ -4,4 +4,9 @@ sealed interface NewsletterUiEvent {
     data object Refresh : NewsletterUiEvent
     data object PullToRefresh : NewsletterUiEvent
     data object Dismiss : NewsletterUiEvent
+    data object SendNow : NewsletterUiEvent
+    data object SendTest : NewsletterUiEvent
+    data object ConfirmSend : NewsletterUiEvent
+    data object DismissSendDialog : NewsletterUiEvent
+    data object DismissSendResult : NewsletterUiEvent
 }

--- a/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterUiState.kt
+++ b/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterUiState.kt
@@ -5,6 +5,7 @@ import com.raulshma.jellyplay.core.model.ActivityLogEntry
 import com.raulshma.jellyplay.core.model.ItemCounts
 import com.raulshma.jellyplay.core.model.MediaItem
 import com.raulshma.jellyplay.core.model.NewsletterSectionType
+import com.raulshma.jellyplay.core.ui.feedback.UiText
 
 @Immutable
 data class NewsletterUiState(
@@ -19,4 +20,10 @@ data class NewsletterUiState(
     val isLoading: Boolean = true,
     val isRefreshing: Boolean = false,
     val error: String? = null,
+    val isAdmin: Boolean = false,
+    val isSending: Boolean = false,
+    val sendResult: UiText? = null,
+    val pendingSendAction: NewsletterSendAction? = null,
 )
+
+enum class NewsletterSendAction { SEND_NOW, SEND_TEST }

--- a/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterViewModel.kt
+++ b/feature/newsletter/src/main/java/com/raulshma/jellyplay/feature/newsletter/NewsletterViewModel.kt
@@ -1,11 +1,15 @@
 package com.raulshma.jellyplay.feature.newsletter
 
+import com.raulshma.jellyplay.core.data.repository.AuthRepository
 import com.raulshma.jellyplay.core.data.repository.MediaRepository
 import com.raulshma.jellyplay.core.data.util.ImageUrlProvider
 import com.raulshma.jellyplay.core.datastore.notification.NotificationStore
 import com.raulshma.jellyplay.core.model.NewsletterSectionType
+import com.raulshma.jellyplay.core.ui.feedback.UiText
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import com.raulshma.jellyplay.feature.newsletter.R
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
@@ -15,6 +19,7 @@ class NewsletterViewModel @Inject constructor(
     private val mediaRepository: MediaRepository,
     private val imageUrlProvider: ImageUrlProvider,
     private val notificationStore: NotificationStore,
+    authRepository: AuthRepository,
 ) : JellyPlayViewModel() {
 
     private val _uiState = stateFlow(NewsletterUiState())
@@ -22,6 +27,13 @@ class NewsletterViewModel @Inject constructor(
 
     init {
         loadData()
+        launch {
+            authRepository.currentUser
+                .distinctUntilChangedBy { it?.isAdmin }
+                .collect { user ->
+                    _uiState.update { it.copy(isAdmin = user?.isAdmin == true) }
+                }
+        }
     }
 
     fun onEvent(event: NewsletterUiEvent) {
@@ -29,6 +41,15 @@ class NewsletterViewModel @Inject constructor(
             NewsletterUiEvent.Refresh -> loadData()
             NewsletterUiEvent.PullToRefresh -> loadData(isPullToRefresh = true)
             NewsletterUiEvent.Dismiss -> markViewed()
+            NewsletterUiEvent.SendNow ->
+                _uiState.update { it.copy(pendingSendAction = NewsletterSendAction.SEND_NOW) }
+            NewsletterUiEvent.SendTest ->
+                _uiState.update { it.copy(pendingSendAction = NewsletterSendAction.SEND_TEST) }
+            NewsletterUiEvent.ConfirmSend -> performSend()
+            NewsletterUiEvent.DismissSendDialog ->
+                _uiState.update { it.copy(pendingSendAction = null) }
+            NewsletterUiEvent.DismissSendResult ->
+                _uiState.update { it.copy(sendResult = null) }
         }
     }
 
@@ -95,6 +116,35 @@ class NewsletterViewModel @Inject constructor(
     private fun markViewed() {
         launch {
             notificationStore.setNewsletterLastViewed(System.currentTimeMillis())
+        }
+    }
+
+    private fun performSend() {
+        val action = _uiState.value.pendingSendAction ?: return
+        _uiState.update {
+            it.copy(pendingSendAction = null, isSending = true, sendResult = null)
+        }
+        launch {
+            val result = when (action) {
+                NewsletterSendAction.SEND_NOW -> mediaRepository.sendNewsletter()
+                NewsletterSendAction.SEND_TEST -> mediaRepository.sendTestNewsletter()
+            }
+            _uiState.update {
+                it.copy(
+                    isSending = false,
+                    sendResult = if (result.isSuccess) {
+                        UiText.Resource(
+                            if (action == NewsletterSendAction.SEND_NOW) {
+                                R.string.newsletter_send_success
+                            } else {
+                                R.string.newsletter_test_sent
+                            }
+                        )
+                    } else {
+                        UiText.Resource(R.string.newsletter_send_failed)
+                    },
+                )
+            }
         }
     }
 }

--- a/feature/newsletter/src/main/res/values-de/strings.xml
+++ b/feature/newsletter/src/main/res/values-de/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">Newsletter konnte nicht geladen werden</string>
     <string name="newsletter_preparing_digest">Deine Zusammenfassung wird vorbereitet\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">Jetzt senden</string>
+    <string name="newsletter_send_test">Test senden</string>
+    <string name="newsletter_send_confirm_title">Newsletter senden?</string>
+    <string name="newsletter_send_confirm_body">Dadurch wird der Newsletter an alle Abonnenten gesendet.</string>
+    <string name="newsletter_send_success">Newsletter gesendet</string>
+    <string name="newsletter_send_failed">Newsletter konnte nicht gesendet werden</string>
+    <string name="newsletter_test_sent">Test-Newsletter gesendet</string>
+    <string name="newsletter_send_admin_only">Nur Admin</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">Newsletter</string>
     <string name="newsletter_activity_digest">Aktivitätsverlauf</string>

--- a/feature/newsletter/src/main/res/values-es/strings.xml
+++ b/feature/newsletter/src/main/res/values-es/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">No se pudo cargar el boletín</string>
     <string name="newsletter_preparing_digest">Preparando tu resumen\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">Enviar ahora</string>
+    <string name="newsletter_send_test">Enviar prueba</string>
+    <string name="newsletter_send_confirm_title">¿Enviar boletín?</string>
+    <string name="newsletter_send_confirm_body">Esto enviará el boletín a todos los suscriptores.</string>
+    <string name="newsletter_send_success">Boletín enviado</string>
+    <string name="newsletter_send_failed">No se pudo enviar el boletín</string>
+    <string name="newsletter_test_sent">Boletín de prueba enviado</string>
+    <string name="newsletter_send_admin_only">Solo admin</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">Boletín</string>
     <string name="newsletter_activity_digest">Resumen de actividad</string>

--- a/feature/newsletter/src/main/res/values-fr/strings.xml
+++ b/feature/newsletter/src/main/res/values-fr/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">Impossible de charger la newsletter</string>
     <string name="newsletter_preparing_digest">Préparation de votre récapitulatif\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">Envoyer maintenant</string>
+    <string name="newsletter_send_test">Envoyer test</string>
+    <string name="newsletter_send_confirm_title">Envoyer la newsletter ?</string>
+    <string name="newsletter_send_confirm_body">Ceci enverra la newsletter à tous les abonnés.</string>
+    <string name="newsletter_send_success">Newsletter envoyée</string>
+    <string name="newsletter_send_failed">Échec de l\'envoi de la newsletter</string>
+    <string name="newsletter_test_sent">Newsletter de test envoyée</string>
+    <string name="newsletter_send_admin_only">Admin uniquement</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">Newsletter</string>
     <string name="newsletter_activity_digest">Flux d\'activité</string>

--- a/feature/newsletter/src/main/res/values-it/strings.xml
+++ b/feature/newsletter/src/main/res/values-it/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">Impossibile caricare la newsletter</string>
     <string name="newsletter_preparing_digest">Preparazione del riepilogo\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">Invia ora</string>
+    <string name="newsletter_send_test">Invia test</string>
+    <string name="newsletter_send_confirm_title">Inviare la newsletter?</string>
+    <string name="newsletter_send_confirm_body">Questo invierà la newsletter a tutti gli iscritti.</string>
+    <string name="newsletter_send_success">Newsletter inviata</string>
+    <string name="newsletter_send_failed">Invio della newsletter non riuscito</string>
+    <string name="newsletter_test_sent">Newsletter di test inviata</string>
+    <string name="newsletter_send_admin_only">Solo admin</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">Newsletter</string>
     <string name="newsletter_activity_digest">Riepilogo attività</string>

--- a/feature/newsletter/src/main/res/values-ja/strings.xml
+++ b/feature/newsletter/src/main/res/values-ja/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">ニュースレターを読み込めませんでした</string>
     <string name="newsletter_preparing_digest">ダイジェストを準備中\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">今すぐ送信</string>
+    <string name="newsletter_send_test">テスト送信</string>
+    <string name="newsletter_send_confirm_title">ニュースレターを送信しますか？</string>
+    <string name="newsletter_send_confirm_body">すべての購読者にニュースレターが送信されます。</string>
+    <string name="newsletter_send_success">ニュースレターを送信しました</string>
+    <string name="newsletter_send_failed">ニュースレターを送信できませんでした</string>
+    <string name="newsletter_test_sent">テストニュースレターを送信しました</string>
+    <string name="newsletter_send_admin_only">管理者のみ</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">ニュースレター</string>
     <string name="newsletter_activity_digest">アクティビティの要約</string>

--- a/feature/newsletter/src/main/res/values-ko/strings.xml
+++ b/feature/newsletter/src/main/res/values-ko/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">뉴스레터를 불러올 수 없습니다</string>
     <string name="newsletter_preparing_digest">다이제스트 준비 중\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">지금 보내기</string>
+    <string name="newsletter_send_test">테스트 발송</string>
+    <string name="newsletter_send_confirm_title">뉴스레터를 보낼까요?</string>
+    <string name="newsletter_send_confirm_body">모든 구독자에게 뉴스레터가 발송됩니다.</string>
+    <string name="newsletter_send_success">뉴스레터를 보냈습니다</string>
+    <string name="newsletter_send_failed">뉴스레터 발송에 실패했습니다</string>
+    <string name="newsletter_test_sent">테스트 뉴스레터를 보냈습니다</string>
+    <string name="newsletter_send_admin_only">관리자 전용</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">뉴스레터</string>
     <string name="newsletter_activity_digest">활동 요약</string>

--- a/feature/newsletter/src/main/res/values-pt/strings.xml
+++ b/feature/newsletter/src/main/res/values-pt/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">Não foi possível carregar o boletim</string>
     <string name="newsletter_preparing_digest">A preparar o seu resumo\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">Enviar agora</string>
+    <string name="newsletter_send_test">Enviar teste</string>
+    <string name="newsletter_send_confirm_title">Enviar boletim?</string>
+    <string name="newsletter_send_confirm_body">Isto enviará o boletim a todos os subscritores.</string>
+    <string name="newsletter_send_success">Boletim enviado</string>
+    <string name="newsletter_send_failed">Falha ao enviar o boletim</string>
+    <string name="newsletter_test_sent">Boletim de teste enviado</string>
+    <string name="newsletter_send_admin_only">Apenas admin</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">Boletim</string>
     <string name="newsletter_activity_digest">Resumo de atividade</string>

--- a/feature/newsletter/src/main/res/values-zh/strings.xml
+++ b/feature/newsletter/src/main/res/values-zh/strings.xml
@@ -4,6 +4,16 @@
     <string name="newsletter_could_not_load">无法加载简报</string>
     <string name="newsletter_preparing_digest">正在为你准备摘要\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">立即发送</string>
+    <string name="newsletter_send_test">发送测试</string>
+    <string name="newsletter_send_confirm_title">发送通讯？</string>
+    <string name="newsletter_send_confirm_body">这会将通讯发送给所有订阅者。</string>
+    <string name="newsletter_send_success">通讯已发送</string>
+    <string name="newsletter_send_failed">发送通讯失败</string>
+    <string name="newsletter_test_sent">测试通讯已发送</string>
+    <string name="newsletter_send_admin_only">仅管理员</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">通讯</string>
     <string name="newsletter_activity_digest">活动摘要</string>

--- a/feature/newsletter/src/main/res/values/strings.xml
+++ b/feature/newsletter/src/main/res/values/strings.xml
@@ -3,6 +3,16 @@
     <string name="newsletter_could_not_load">Could not load newsletter</string>
     <string name="newsletter_preparing_digest">Preparing your digest\u2026</string>
 
+    <!-- Newsletter send actions (admin-gated; backend route required) -->
+    <string name="newsletter_send_now">Send now</string>
+    <string name="newsletter_send_test">Send test</string>
+    <string name="newsletter_send_confirm_title">Send newsletter?</string>
+    <string name="newsletter_send_confirm_body">This will send the newsletter to all subscribers.</string>
+    <string name="newsletter_send_success">Newsletter sent</string>
+    <string name="newsletter_send_failed">Failed to send newsletter</string>
+    <string name="newsletter_test_sent">Test newsletter sent</string>
+    <string name="newsletter_send_admin_only">Admin only</string>
+
     <!-- Newsletter screens & sections -->
     <string name="newsletter_title">Newsletter</string>
     <string name="newsletter_activity_digest">Activity Digest</string>

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerControls.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerControls.kt
@@ -1,5 +1,6 @@
 package com.raulshma.jellyplay.feature.player.audio
 
+import android.view.HapticFeedbackConstants
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -39,6 +40,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalView
 import com.composables.icons.tabler.Tabler
 import com.composables.icons.tabler.filled.*
 import com.composables.icons.tabler.outline.*
@@ -353,6 +355,7 @@ internal fun PixelPlayPauseButton(
     focusRequester: FocusRequester? = null,
 ) {
     val focusState = rememberTvFocusState()
+    val view = LocalView.current
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(
@@ -377,6 +380,14 @@ internal fun PixelPlayPauseButton(
     val buttonBg = MaterialTheme.colorScheme.primaryContainer
     val iconColor = MaterialTheme.colorScheme.onPrimaryContainer
 
+    // Light confirmation haptic on play/pause toggle (matches video player).
+    val hapticOnClick: () -> Unit = remember(onClick, view) {
+        {
+            onClick()
+            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+        }
+    }
+
     Box(
         modifier = Modifier
             .then(sharedModifier)
@@ -387,11 +398,11 @@ internal fun PixelPlayPauseButton(
             .tvFocusIndicator(focusState, ShapeCache.smooth20)
             .clip(ShapeCache.smooth20)
             .background(buttonBg)
-            
+
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
-                onClick = onClick,
+                onClick = hapticOnClick,
             ),
         contentAlignment = Alignment.Center,
     ) {
@@ -422,6 +433,7 @@ private fun IconButtonWithPressAnimation(
     modifier: Modifier = Modifier,
 ) {
     val focusState = rememberTvFocusState()
+    val view = LocalView.current
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(
@@ -430,8 +442,17 @@ private fun IconButtonWithPressAnimation(
         label = "transportScale",
     )
 
+    // Light confirmation haptic on every transport tap (consistent with the
+    // video player). Respects the system haptic setting.
+    val hapticOnClick: () -> Unit = remember(onClick, view) {
+        {
+            onClick()
+            view.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+        }
+    }
+
     IconButton(
-        onClick = onClick,
+        onClick = hapticOnClick,
         modifier = modifier
             .size(size)
             .graphicsLayer { scaleX = scale; scaleY = scale }

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerScreen.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -39,6 +40,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.Brush
@@ -375,6 +377,7 @@ fun AudioPlayerScreen(
                     onNightModeClick = { showMenu = false; viewModel.toggleNightMode() },
                     onNightModeStrengthChange = { viewModel.setNightModeStrength(it) },
                     onAmbientClick = { showMenu = false; onAmbientClick(uiState.albumArtUrl.ifBlank { null }, uiState.title, uiState.artist) },
+                    onAddToPlaylistClick = { showMenu = false; viewModel.openPlaylistPicker() },
                     sleepTimerActive = sleepTimer.active,
                     sleepTimerEndOfEpisode = sleepTimer.endOfEpisode,
                     sleepTimerRemainingFlow = viewModel.sleepTimerRemainingMs,
@@ -742,6 +745,64 @@ fun AudioPlayerScreen(
             onCancel = { viewModel.cancelSleepTimer() },
             onDismiss = { showSleepTimer = false },
         )
+    }
+
+    // Add-to-playlist picker.
+    if (uiState.showPlaylistPicker) {
+        com.raulshma.jellyplay.core.ui.components.PlayerModalBottomSheet(
+            onDismissRequest = { viewModel.dismissPlaylistPicker() },
+            sheetState = androidx.compose.material3.rememberModalBottomSheetState(),
+        ) {
+            androidx.compose.foundation.layout.Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 32.dp),
+            ) {
+                androidx.compose.material3.Text(
+                    stringResource(R.string.audio_playlist_picker_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 24.dp),
+                )
+                androidx.compose.foundation.layout.Spacer(Modifier.height(16.dp))
+                when {
+                    uiState.isLoadingPlaylists -> {
+                        androidx.compose.foundation.layout.Box(
+                            modifier = Modifier.fillMaxWidth().padding(24.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            com.raulshma.jellyplay.core.ui.components.JellyPlayCircularProgressIndicator()
+                        }
+                    }
+                    uiState.playlists.isEmpty() -> {
+                        androidx.compose.foundation.layout.Box(
+                            modifier = Modifier.fillMaxWidth().padding(24.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            androidx.compose.material3.Text(
+                                stringResource(R.string.audio_no_playlists),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                    else -> {
+                        androidx.compose.foundation.layout.Column {
+                            uiState.playlists.forEach { playlist ->
+                                androidx.compose.material3.ListItem(
+                                    headlineContent = { Text(playlist.name) },
+                                    supportingContent = playlist.itemCount.takeIf { it > 0 }?.let { count ->
+                                        { Text(stringResource(R.string.audio_playlist_items_count, count)) }
+                                    },
+                                    modifier = Modifier.clickable {
+                                        viewModel.addToPlaylist(playlist)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     if (showEffectsSheet) {

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerTopBar.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerTopBar.kt
@@ -54,6 +54,7 @@ internal fun PixelPlayerTopBar(
     onNightModeClick: () -> Unit,
     onNightModeStrengthChange: (com.raulshma.jellyplay.core.model.EffectStrength) -> Unit,
     onAmbientClick: () -> Unit,
+    onAddToPlaylistClick: () -> Unit = {},
     sleepTimerActive: Boolean = false,
     sleepTimerEndOfEpisode: Boolean = false,
     sleepTimerRemainingFlow: StateFlow<Long> = MutableStateFlow(0L),
@@ -175,6 +176,12 @@ internal fun PixelPlayerTopBar(
                         text = { Text(stringResource(R.string.audio_menu_ambient_mode)) },
                         onClick = onAmbientClick,
                         leadingIcon = { Icon(Tabler.Outline.MoonStars, null) },
+                        colors = itemColors,
+                    )
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.audio_menu_add_to_playlist)) },
+                        onClick = { onAddToPlaylistClick(); onMenuToggle(false) },
+                        leadingIcon = { Icon(Tabler.Outline.PlaylistAdd, null) },
                         colors = itemColors,
                     )
                     DropdownMenuItem(

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerUiState.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerUiState.kt
@@ -3,6 +3,7 @@ package com.raulshma.jellyplay.feature.player.audio
 import androidx.compose.runtime.Immutable
 import com.raulshma.jellyplay.core.data.playback.AudioQueueItem
 import com.raulshma.jellyplay.core.model.AudioNormalizationMode
+import com.raulshma.jellyplay.core.model.Playlist
 import com.raulshma.jellyplay.core.model.EffectStrength
 import com.raulshma.jellyplay.core.model.EqualizerPreset
 import com.raulshma.jellyplay.core.model.EqualizerSettings
@@ -41,6 +42,12 @@ data class AudioPlayerUiState(
     val lyrics: LyricsState = LyricsState(),
     val sleepTimer: SleepTimerState = SleepTimerState(),
     val queue: QueueState = QueueState(),
+    // "Add to playlist" picker.
+    val showPlaylistPicker: Boolean = false,
+    val playlists: List<Playlist> = emptyList(),
+    val isLoadingPlaylists: Boolean = false,
+    val isAddingToPlaylist: Boolean = false,
+    val playlistMessage: String? = null,
 )
 
 @Immutable

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerViewModel.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/AudioPlayerViewModel.kt
@@ -704,6 +704,60 @@ class AudioPlayerViewModel @Inject constructor(
     val currentPlayingItemId: String?
         get() = audioPlaybackManager.currentPlayingItemId.value
 
+    // ── Add to playlist ─────────────────────────────────────────────────────
+
+    /** Opens the playlist picker and loads the user's editable playlists. */
+    fun openPlaylistPicker() {
+        if (currentPlayingItemId == null) return
+        _uiState.update { it.copy(showPlaylistPicker = true, isLoadingPlaylists = true) }
+        launch {
+            mediaRepository.getPlaylists(limit = 100)
+                .onSuccess { all ->
+                    val editable = all.filter { it.canEdit }
+                    _uiState.update {
+                        it.copy(playlists = editable, isLoadingPlaylists = false)
+                    }
+                }
+                .onFailure {
+                    _uiState.update { it.copy(isLoadingPlaylists = false) }
+                }
+        }
+    }
+
+    fun dismissPlaylistPicker() {
+        if (!_uiState.value.isAddingToPlaylist) {
+            _uiState.update { it.copy(showPlaylistPicker = false, playlists = emptyList(), playlistMessage = null) }
+        }
+    }
+
+    /** Adds the current track to [playlist]; clears the message after a beat. */
+    fun addToPlaylist(playlist: com.raulshma.jellyplay.core.model.Playlist) {
+        val itemId = currentPlayingItemId ?: return
+        _uiState.update { it.copy(isAddingToPlaylist = true) }
+        launch {
+            mediaRepository.addItemsToPlaylist(playlist.id, listOf(itemId))
+                .onSuccess {
+                    _uiState.update {
+                        it.copy(
+                            isAddingToPlaylist = false,
+                            showPlaylistPicker = false,
+                            playlists = emptyList(),
+                            playlistMessage = playlist.name,
+                        )
+                    }
+                }
+                .onFailure { err ->
+                    _uiState.update {
+                        it.copy(isAddingToPlaylist = false, playlistMessage = err.message)
+                    }
+                }
+        }
+    }
+
+    fun clearPlaylistMessage() {
+        _uiState.update { it.copy(playlistMessage = null) }
+    }
+
     fun setKaraokeModeEnabled(enabled: Boolean) {
         karaokeMode = enabled
         _uiState.update { it.copy(lyrics = it.lyrics.copy(karaokeMode = enabled)) }

--- a/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/sheets/QueueSheet.kt
+++ b/feature/player/audio/src/main/java/com/raulshma/jellyplay/feature/player/audio/sheets/QueueSheet.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -34,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.composables.icons.tabler.Tabler
+import com.composables.icons.tabler.outline.PlayerPlay
 import com.composables.icons.tabler.outline.Trash
 import com.raulshma.jellyplay.core.data.playback.AudioQueueItem
 import com.raulshma.jellyplay.core.ui.components.PlayerModalBottomSheet
@@ -57,13 +59,32 @@ internal fun QueueSheet(
                 .fillMaxWidth()
                 .padding(bottom = 32.dp),
         ) {
-            Text(
-                stringResource(R.string.audio_queue_title),
-                style = MaterialTheme.typography.titleLarge.copy(
-                    fontWeight = FontWeight.Bold,
-                ),
-                modifier = Modifier.padding(horizontal = 24.dp),
-            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    stringResource(R.string.audio_queue_title),
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        fontWeight = FontWeight.Bold,
+                    ),
+                )
+                // Queue position of the currently-playing track (1-based).
+                if (currentIndex in queue.indices) {
+                    Text(
+                        stringResource(
+                            R.string.audio_queue_position,
+                            currentIndex + 1,
+                            queue.size,
+                        ),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
             Spacer(Modifier.height(20.dp))
             LazyColumn(
                 contentPadding = PaddingValues(vertical = 4.dp),
@@ -194,10 +215,10 @@ private fun QueueItemContent(
             )
         }
         if (isCurrentItem) {
-            Text(
-                "\u25B6",
-                color = MaterialTheme.colorScheme.primary,
-                style = MaterialTheme.typography.labelSmall,
+            Icon(
+                imageVector = Tabler.Outline.PlayerPlay,
+                contentDescription = stringResource(R.string.audio_topbar_now_playing),
+                tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(end = 8.dp),
             )
         }

--- a/feature/player/audio/src/main/res/values-de/strings.xml
+++ b/feature/player/audio/src/main/res/values-de/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">Nachtmodus</string>
     <string name="audio_menu_night_mode_with_strength">Nachtmodus · %1$s</string>
     <string name="audio_menu_ambient_mode">Ambient-Modus</string>
+    <string name="audio_menu_add_to_playlist">Zur Playlist hinzufügen</string>
     <string name="audio_menu_sleep_timer">Einschlaftimer</string>
     <string name="audio_menu_sleep_timer_active">Einschlaftimer · %1$s</string>
     <string name="audio_menu_karaoke_mode">Karaoke-Modus</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">Warteschlange</string>
     <string name="audio_queue_remove">Aus Warteschlange entfernen</string>
+    <string name="audio_queue_position">%1$d von %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">Zur Playlist hinzufügen</string>
+    <string name="audio_added_to_playlist">Zu „%1$s\" hinzugefügt</string>
+    <string name="audio_no_playlists">Noch keine Playlists</string>
+    <string name="audio_playlist_items_count">%1$d Titel</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">Wiedergabegeschwindigkeit</string>

--- a/feature/player/audio/src/main/res/values-es/strings.xml
+++ b/feature/player/audio/src/main/res/values-es/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">Modo nocturno</string>
     <string name="audio_menu_night_mode_with_strength">Modo nocturno · %1$s</string>
     <string name="audio_menu_ambient_mode">Modo ambiente</string>
+    <string name="audio_menu_add_to_playlist">Añadir a lista de reproducción</string>
     <string name="audio_menu_sleep_timer">Temporizador de sueño</string>
     <string name="audio_menu_sleep_timer_active">Temporizador de sueño · %1$s</string>
     <string name="audio_menu_karaoke_mode">Modo karaoke</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">Cola</string>
     <string name="audio_queue_remove">Quitar de la cola</string>
+    <string name="audio_queue_position">%1$d de %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">Añadir a lista de reproducción</string>
+    <string name="audio_added_to_playlist">Añadido a \"%1$s\"</string>
+    <string name="audio_no_playlists">Aún no hay listas</string>
+    <string name="audio_playlist_items_count">%1$d elementos</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">Velocidad de reproducción</string>

--- a/feature/player/audio/src/main/res/values-fr/strings.xml
+++ b/feature/player/audio/src/main/res/values-fr/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">Mode nuit</string>
     <string name="audio_menu_night_mode_with_strength">Mode nuit · %1$s</string>
     <string name="audio_menu_ambient_mode">Mode ambiant</string>
+    <string name="audio_menu_add_to_playlist">Ajouter à la playlist</string>
     <string name="audio_menu_sleep_timer">Minuteur de veille</string>
     <string name="audio_menu_sleep_timer_active">Minuteur de veille · %1$s</string>
     <string name="audio_menu_karaoke_mode">Mode karaoké</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">File d\'attente</string>
     <string name="audio_queue_remove">Retirer de la file</string>
+    <string name="audio_queue_position">%1$d sur %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">Ajouter à la playlist</string>
+    <string name="audio_added_to_playlist">Ajouté à « %1$s »</string>
+    <string name="audio_no_playlists">Aucune playlist pour le moment</string>
+    <string name="audio_playlist_items_count">%1$d titres</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">Vitesse de lecture</string>

--- a/feature/player/audio/src/main/res/values-it/strings.xml
+++ b/feature/player/audio/src/main/res/values-it/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">Modalità notturna</string>
     <string name="audio_menu_night_mode_with_strength">Modalità notturna · %1$s</string>
     <string name="audio_menu_ambient_mode">Modalità ambiente</string>
+    <string name="audio_menu_add_to_playlist">Aggiungi a playlist</string>
     <string name="audio_menu_sleep_timer">Timer di spegnimento</string>
     <string name="audio_menu_sleep_timer_active">Timer di spegnimento · %1$s</string>
     <string name="audio_menu_karaoke_mode">Modalità karaoke</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">Coda</string>
     <string name="audio_queue_remove">Rimuovi dalla coda</string>
+    <string name="audio_queue_position">%1$d di %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">Aggiungi a playlist</string>
+    <string name="audio_added_to_playlist">Aggiunto a \"%1$s\"</string>
+    <string name="audio_no_playlists">Nessuna playlist</string>
+    <string name="audio_playlist_items_count">%1$d elementi</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">Velocità di riproduzione</string>

--- a/feature/player/audio/src/main/res/values-ja/strings.xml
+++ b/feature/player/audio/src/main/res/values-ja/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">ナイトモード</string>
     <string name="audio_menu_night_mode_with_strength">ナイトモード · %1$s</string>
     <string name="audio_menu_ambient_mode">アンビエントモード</string>
+    <string name="audio_menu_add_to_playlist">プレイリストに追加</string>
     <string name="audio_menu_sleep_timer">スリープタイマー</string>
     <string name="audio_menu_sleep_timer_active">スリープタイマー · %1$s</string>
     <string name="audio_menu_karaoke_mode">カラオケモード</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">キュー</string>
     <string name="audio_queue_remove">キューから削除</string>
+    <string name="audio_queue_position">%1$d / %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">プレイリストに追加</string>
+    <string name="audio_added_to_playlist">「%1$s」に追加しました</string>
+    <string name="audio_no_playlists">プレイリストがまだありません</string>
+    <string name="audio_playlist_items_count">%1$d 件</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">再生速度</string>

--- a/feature/player/audio/src/main/res/values-ko/strings.xml
+++ b/feature/player/audio/src/main/res/values-ko/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">나이트 모드</string>
     <string name="audio_menu_night_mode_with_strength">나이트 모드 · %1$s</string>
     <string name="audio_menu_ambient_mode">앰비언트 모드</string>
+    <string name="audio_menu_add_to_playlist">재생목록에 추가</string>
     <string name="audio_menu_sleep_timer">슬립 타이머</string>
     <string name="audio_menu_sleep_timer_active">슬립 타이머 · %1$s</string>
     <string name="audio_menu_karaoke_mode">가라오케 모드</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">대기열</string>
     <string name="audio_queue_remove">대기열에서 제거</string>
+    <string name="audio_queue_position">%1$d / %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">재생목록에 추가</string>
+    <string name="audio_added_to_playlist">\"%1$s\"에 추가됨</string>
+    <string name="audio_no_playlists">재생목록이 없습니다</string>
+    <string name="audio_playlist_items_count">%1$d곡</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">재생 속도</string>

--- a/feature/player/audio/src/main/res/values-pt/strings.xml
+++ b/feature/player/audio/src/main/res/values-pt/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">Modo noturno</string>
     <string name="audio_menu_night_mode_with_strength">Modo noturno · %1$s</string>
     <string name="audio_menu_ambient_mode">Modo ambiente</string>
+    <string name="audio_menu_add_to_playlist">Adicionar à playlist</string>
     <string name="audio_menu_sleep_timer">Temporizador de suspensão</string>
     <string name="audio_menu_sleep_timer_active">Temporizador de suspensão · %1$s</string>
     <string name="audio_menu_karaoke_mode">Modo karaoke</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">Fila</string>
     <string name="audio_queue_remove">Remover da fila</string>
+    <string name="audio_queue_position">%1$d de %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">Adicionar à playlist</string>
+    <string name="audio_added_to_playlist">Adicionado a \"%1$s\"</string>
+    <string name="audio_no_playlists">Nenhuma playlist ainda</string>
+    <string name="audio_playlist_items_count">%1$d itens</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">Velocidade de reprodução</string>

--- a/feature/player/audio/src/main/res/values-zh/strings.xml
+++ b/feature/player/audio/src/main/res/values-zh/strings.xml
@@ -36,6 +36,7 @@
     <string name="audio_menu_night_mode">夜间模式</string>
     <string name="audio_menu_night_mode_with_strength">夜间模式 · %1$s</string>
     <string name="audio_menu_ambient_mode">氛围模式</string>
+    <string name="audio_menu_add_to_playlist">添加到播放列表</string>
     <string name="audio_menu_sleep_timer">睡眠定时器</string>
     <string name="audio_menu_sleep_timer_active">睡眠定时器 · %1$s</string>
     <string name="audio_menu_karaoke_mode">卡拉OK 模式</string>
@@ -96,6 +97,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">队列</string>
     <string name="audio_queue_remove">从队列中移除</string>
+    <string name="audio_queue_position">%1$d / %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">添加到播放列表</string>
+    <string name="audio_added_to_playlist">已添加到“%1$s”</string>
+    <string name="audio_no_playlists">暂无播放列表</string>
+    <string name="audio_playlist_items_count">%1$d 项</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">播放速度</string>

--- a/feature/player/audio/src/main/res/values/strings.xml
+++ b/feature/player/audio/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="audio_menu_night_mode">Night Mode</string>
     <string name="audio_menu_night_mode_with_strength">Night Mode · %1$s</string>
     <string name="audio_menu_ambient_mode">Ambient Mode</string>
+    <string name="audio_menu_add_to_playlist">Add to Playlist</string>
     <string name="audio_menu_sleep_timer">Sleep Timer</string>
     <string name="audio_menu_sleep_timer_active">Sleep Timer · %1$s</string>
     <string name="audio_menu_karaoke_mode">Karaoke Mode</string>
@@ -95,6 +96,13 @@
     <!-- Queue sheet -->
     <string name="audio_queue_title">Queue</string>
     <string name="audio_queue_remove">Remove from queue</string>
+    <string name="audio_queue_position">%1$d of %2$d</string>
+
+    <!-- Add to playlist picker -->
+    <string name="audio_playlist_picker_title">Add to playlist</string>
+    <string name="audio_added_to_playlist">Added to \"%1$s\"</string>
+    <string name="audio_no_playlists">No playlists yet</string>
+    <string name="audio_playlist_items_count">%1$d items</string>
 
     <!-- Speed picker -->
     <string name="audio_speed_title">Playback Speed</string>

--- a/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/LivePlayerScreen.kt
+++ b/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/LivePlayerScreen.kt
@@ -322,6 +322,7 @@ fun LivePlayerScreen(
                         channels = state.channels,
                         currentChannelId = state.currentChannel?.id,
                         favorites = state.favorites,
+                        lastChannelId = state.lastChannelId,
                         logoUrlFor = viewModel::logoUrlFor,
                         onChannelSelected = { id ->
                             viewModel.selectChannelById(id)

--- a/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/LiveTvPlayerUiState.kt
+++ b/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/LiveTvPlayerUiState.kt
@@ -27,6 +27,7 @@ data class LiveTvPlayerUiState(
     val errorDetail: String? = null,
     val isSwitchingChannel: Boolean = false,
     val favorites: Set<String> = emptySet(),
+    val lastChannelId: String? = null,
     val isMuted: Boolean = false,
     val liveStreamOption: LiveStreamOption = LiveStreamOption.AUTO,
     /** Delivery method in use for the current stream (Direct Stream /

--- a/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/LiveTvPlayerViewModel.kt
+++ b/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/LiveTvPlayerViewModel.kt
@@ -132,6 +132,10 @@ class LiveTvPlayerViewModel @Inject constructor(
                 )
             }
             .launchIn(viewModelScope)
+
+        lastChannelStore.observeLastChannelId()
+            .onEach { id -> _state.value = _state.value.copy(lastChannelId = id) }
+            .launchIn(viewModelScope)
     }
 
     /**

--- a/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/components/LiveChannelListSheet.kt
+++ b/feature/player/live/src/main/java/com/raulshma/jellyplay/feature/player/live/components/LiveChannelListSheet.kt
@@ -53,6 +53,7 @@ import com.raulshma.jellyplay.feature.player.live.R
 fun LiveChannelListSheet(
     channels: List<LiveTvChannel>,
     currentChannelId: String?,
+    lastChannelId: String? = null,
     favorites: Set<String>,
     logoUrlFor: (LiveTvChannel) -> String?,
     onChannelSelected: (String) -> Unit,
@@ -72,10 +73,24 @@ fun LiveChannelListSheet(
             channels.sortedByDescending { it.id in favorites }
         }
 
+        // Pinned last-watched channel. Skipped when it is the currently-playing
+        // channel — no point pinning what's already live.
+        val lastWatchedChannel = remember(channels, lastChannelId, currentChannelId) {
+            val lw = lastChannelId?.let { id -> channels.firstOrNull { it.id == id } }
+            if (lw != null && lw.id != currentChannelId) lw else null
+        }
+        val displayChannels = remember(sortedChannels, lastWatchedChannel) {
+            if (lastWatchedChannel != null) sortedChannels.filter { it.id != lastWatchedChannel.id }
+            else sortedChannels
+        }
+
         // Scroll the current channel into view and focus its row on open.
-        LaunchedEffect(sortedChannels, currentChannelId) {
-            val index = sortedChannels.indexOfFirst { it.id == currentChannelId }.coerceAtLeast(0)
-            listState.scrollToItem(index)
+        // The pinned last-watched section (header + row) sits above the list,
+        // so account for its 2-item height in the target index.
+        LaunchedEffect(displayChannels, currentChannelId, lastWatchedChannel) {
+            val baseIndex = displayChannels.indexOfFirst { it.id == currentChannelId }.coerceAtLeast(0)
+            val headerOffset = if (lastWatchedChannel != null) 2 else 0
+            listState.scrollToItem(baseIndex + headerOffset)
             currentRequester.tryRequestFocus()
         }
 
@@ -84,7 +99,35 @@ fun LiveChannelListSheet(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            items(items = sortedChannels, key = { it.id }) { channel ->
+            val lastWatched = lastWatchedChannel
+            if (lastWatched != null) {
+                item(key = "last_watched_header") {
+                    Text(
+                        text = stringResource(R.string.livetv_last_watched_section),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
+                item(key = "last_watched_${lastWatched.id}") {
+                    val rowFocusRequester = remember(lastWatched.id) { FocusRequester() }
+                    val onClick = remember(lastWatched.id) {
+                        { onChannelSelected(lastWatched.id); onDismiss() }
+                    }
+                    val onToggleFavorite = remember(lastWatched.id) { { onToggleFavorite(lastWatched.id) } }
+                    ChannelRow(
+                        channel = lastWatched,
+                        logoUrl = logoUrlFor(lastWatched),
+                        isCurrent = false,
+                        isFavorite = lastWatched.id in favorites,
+                        focusRequester = rowFocusRequester,
+                        onClick = onClick,
+                        onToggleFavorite = onToggleFavorite,
+                    )
+                }
+            }
+            items(items = displayChannels, key = { it.id }) { channel ->
                 // FocusRequester must always be produced unconditionally so
                 // positional memoization holds for the whole items() block;
                 // pick the shared requester for the current channel, otherwise
@@ -192,9 +235,9 @@ private fun ChannelRow(
         }
         if (isCurrent) {
             Text(
-                text = "▶",
+                text = stringResource(R.string.live_now_playing_short),
                 color = MaterialTheme.colorScheme.primary,
-                style = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.labelSmall,
             )
         }
     }

--- a/feature/player/live/src/main/res/values-de/strings.xml
+++ b/feature/player/live/src/main/res/values-de/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">Server auswählen lassen (direkter Stream, wenn möglich)</string>
     <string name="live_option_direct_desc">Den offenen Tuner direkt auslesen (beste Qualität)</string>
     <string name="live_option_transcode_desc">Auf dem Server neu codieren (geringere Bandbreite)</string>
+    <string name="live_now_playing_short">Läuft gerade</string>
+    <string name="livetv_last_watched_section">Zuletzt gesehen</string>
 </resources>

--- a/feature/player/live/src/main/res/values-es/strings.xml
+++ b/feature/player/live/src/main/res/values-es/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">Dejar que el servidor elija (transmisión directa cuando sea posible)</string>
     <string name="live_option_direct_desc">Leer el sintonizador abierto directamente (mejor calidad)</string>
     <string name="live_option_transcode_desc">Recodificar en el servidor (menor ancho de banda)</string>
+    <string name="live_now_playing_short">Reproduciendo</string>
+    <string name="livetv_last_watched_section">Visto recientemente</string>
 </resources>

--- a/feature/player/live/src/main/res/values-fr/strings.xml
+++ b/feature/player/live/src/main/res/values-fr/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">Laisser le serveur choisir (flux direct si possible)</string>
     <string name="live_option_direct_desc">Lire directement le tuner ouvert (meilleure qualité)</string>
     <string name="live_option_transcode_desc">Recompresser sur le serveur (bande passante réduite)</string>
+    <string name="live_now_playing_short">En cours</string>
+    <string name="livetv_last_watched_section">Dernière chaîne</string>
 </resources>

--- a/feature/player/live/src/main/res/values-it/strings.xml
+++ b/feature/player/live/src/main/res/values-it/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">Lascia scegliere al server (flusso diretto quando possibile)</string>
     <string name="live_option_direct_desc">Leggi direttamente il tuner aperto (qualità migliore)</string>
     <string name="live_option_transcode_desc">Ricodifica sul server (minore larghezza di banda)</string>
+    <string name="live_now_playing_short">In riproduzione</string>
+    <string name="livetv_last_watched_section">Visto di recente</string>
 </resources>

--- a/feature/player/live/src/main/res/values-ja/strings.xml
+++ b/feature/player/live/src/main/res/values-ja/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">サーバーに選択させる（可能な場合はダイレクトストリーム）</string>
     <string name="live_option_direct_desc">開いているチューナーを直接読み取る（最高品質）</string>
     <string name="live_option_transcode_desc">サーバーで再エンコード（帯域幅を低減）</string>
+    <string name="live_now_playing_short">再生中</string>
+    <string name="livetv_last_watched_section">最近見たチャンネル</string>
 </resources>

--- a/feature/player/live/src/main/res/values-ko/strings.xml
+++ b/feature/player/live/src/main/res/values-ko/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">서버가 선택하도록 허용 (가능하면 다이렉트 스트림)</string>
     <string name="live_option_direct_desc">열린 튜너를 직접 읽기 (최고 화질)</string>
     <string name="live_option_transcode_desc">서버에서 재인코딩 (대역폭 절약)</string>
+    <string name="live_now_playing_short">재생 중</string>
+    <string name="livetv_last_watched_section">최근 시청</string>
 </resources>

--- a/feature/player/live/src/main/res/values-pt/strings.xml
+++ b/feature/player/live/src/main/res/values-pt/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">Deixar o servidor escolher (transmissão direta quando possível)</string>
     <string name="live_option_direct_desc">Ler o sintonizador aberto diretamente (melhor qualidade)</string>
     <string name="live_option_transcode_desc">Recodificar no servidor (menor largura de banda)</string>
+    <string name="live_now_playing_short">Reproduzindo</string>
+    <string name="livetv_last_watched_section">Visto recentemente</string>
 </resources>

--- a/feature/player/live/src/main/res/values-zh/strings.xml
+++ b/feature/player/live/src/main/res/values-zh/strings.xml
@@ -46,4 +46,6 @@
     <string name="live_option_auto_desc">由服务器选择（可能时使用直连串流）</string>
     <string name="live_option_direct_desc">直接读取已打开的调谐器（最佳画质）</string>
     <string name="live_option_transcode_desc">在服务器上重新编码（更低带宽）</string>
+    <string name="live_now_playing_short">正在播放</string>
+    <string name="livetv_last_watched_section">最近观看</string>
 </resources>

--- a/feature/player/live/src/main/res/values/strings.xml
+++ b/feature/player/live/src/main/res/values/strings.xml
@@ -55,4 +55,7 @@
     <string name="live_option_auto_desc">Let the server pick (direct stream when possible)</string>
     <string name="live_option_direct_desc">Read the open tuner directly (best quality)</string>
     <string name="live_option_transcode_desc">Re-encode on the server (lower bandwidth)</string>
+    <!-- Short "now playing" marker shown next to the current channel in the list. -->
+    <string name="live_now_playing_short">Now Playing</string>
+    <string name="livetv_last_watched_section">Last watched</string>
 </resources>

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
@@ -77,6 +77,8 @@ import androidx.compose.ui.input.key.NativeKeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -1140,6 +1142,21 @@ fun VideoPlayerScreen(
                             .graphicsLayer {
                                 scaleX = effectiveZoom
                                 scaleY = effectiveZoom
+                            }
+                            // Track the surface's window bounds so the Activity can
+                            // supply a source-rect hint for a seamless PiP enter
+                            // animation. Stop tracking once in PiP (the system
+                            // renders the window then).
+                            .onGloballyPositioned { coords ->
+                                if (!isInPipMode) {
+                                    val r = coords.boundsInWindow()
+                                    viewModel.updatePipSourceRect(
+                                        android.graphics.Rect(
+                                            r.left.toInt(), r.top.toInt(),
+                                            r.right.toInt(), r.bottom.toInt(),
+                                        )
+                                    )
+                                }
                             },
                     )
 

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
@@ -113,6 +113,7 @@ import com.raulshma.jellyplay.core.ui.tv.components.rememberDpadSeekState
 import com.raulshma.jellyplay.core.ui.tv.input.onDpadKeyEvent
 import com.raulshma.jellyplay.core.ui.tv.tryRequestFocus
 import com.raulshma.jellyplay.feature.player.video.R
+import com.raulshma.jellyplay.feature.player.video.state.GestureSeekController
 import com.raulshma.jellyplay.feature.player.video.components.AspectRatio
 import com.raulshma.jellyplay.feature.player.video.components.AspectRatioSheet
 import com.raulshma.jellyplay.feature.player.video.components.AVSyncSheet
@@ -164,8 +165,6 @@ import androidx.media3.ui.AspectRatioFrameLayout
 // Named so the tuning is discoverable instead of scattered as bare literals.
 /** How long the gesture-seek ripple/indicator lingers after the last seek input. */
 private const val GESTURE_SEEK_LINGER_MS = 800L
-/** How long the brightness/volume gesture bars stay visible after the gesture ends. */
-private const val GESTURE_BARS_DISMISS_MS = 800L
 /** How long the AutoAspectRatio / Zoom badge is shown before auto-dismissing. */
 private const val ASPECT_BADGE_DURATION_MS = 5_000L
 /** How long the zoom badge is shown before auto-dismissing. */
@@ -298,21 +297,9 @@ fun VideoPlayerScreen(
     val keyboardFocusRequester = remember { FocusRequester() }
     var userInteractionCount by rememberSaveable { mutableIntStateOf(0) }
 
-    var brightnessOverlay by rememberSaveable { mutableFloatStateOf(-1f) }
-    var initialBrightnessOnGestureStart by rememberSaveable { mutableFloatStateOf(-1f) }
-    var volumeOverlay by rememberSaveable { mutableFloatStateOf(-1f) }
-    var gestureSeekPositionMs by rememberSaveable { mutableLongStateOf(0L) }
-    var gestureStartPositionMs by rememberSaveable { mutableLongStateOf(0L) }
-    var gestureDeltaMs by rememberSaveable { mutableLongStateOf(0L) }
-    var isGestureSeeking by rememberSaveable { mutableStateOf(false) }
-    var gestureTrickplayVisible by rememberSaveable { mutableStateOf(false) }
-
     LaunchedEffect(showControls) {
         viewModel.setControlsVisible(showControls)
     }
-
-    var volumeGestureAccumulator by rememberSaveable { mutableFloatStateOf(0f) }
-    var overlayDismissJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
 
     val isScreenLocked = uiState.isScreenLocked
 
@@ -350,6 +337,7 @@ fun VideoPlayerScreen(
 
     var seekTrickplayBitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
     var gestureTrickplayBitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    var gestureTrickplayVisible by remember { mutableStateOf(false) }
     var tvTrickplayBitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
 
     LaunchedEffect(itemId) {
@@ -767,6 +755,67 @@ fun VideoPlayerScreen(
         getDurationMs = { viewModel.playerEngineRef?.durationMs ?: 0L },
         onCommit = { doSeekTo(it) },
     )
+    // Gesture-seek / volume / brightness controller. Owns the overlay state and
+    // the commit-vs-cancel asymmetry that used to be ~120 lines of inline screen
+    // logic with zero test coverage. Android I/O (Window, AudioManager) moves
+    // behind lambdas; the pure math lives in GestureSeekMath. Gestures don't
+    // survive config changes by design (a half-finished swipe already behaves
+    // poorly across rotation), so the controller's StateFlows are in-memory.
+    val gestureController = remember(
+        scope,
+        engine,
+        uiState.swipeSeekMaxMs,
+        isCastConnected,
+        castVolume,
+        doSeekTo,
+    ) {
+        GestureSeekController(
+            scope = scope,
+            getEngine = { engine },
+            getSwipeSeekMaxMs = { uiState.swipeSeekMaxMs },
+            isCastConnected = { isCastConnected },
+            getCastVolume = { castVolume },
+            readWindowBrightness = { activity?.window?.attributes?.screenBrightness ?: -1f },
+            writeWindowBrightness = { newBrightness ->
+                activity?.let { act ->
+                    val layout = act.window.attributes
+                    layout.screenBrightness = newBrightness
+                    act.window.attributes = layout
+                }
+            },
+            restoreWindowBrightness = { restored ->
+                activity?.let { act ->
+                    if (!act.isDestroyed && !act.isFinishing) {
+                        val layout = act.window.attributes
+                        layout.screenBrightness =
+                            if (restored >= 0f) restored
+                            else android.view.WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
+                        act.window.attributes = layout
+                    }
+                }
+            },
+            readStreamVolume = {
+                val am = context.getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager
+                if (am != null) {
+                    am.getStreamVolume(android.media.AudioManager.STREAM_MUSIC) to
+                        am.getStreamMaxVolume(android.media.AudioManager.STREAM_MUSIC)
+                } else 0 to 0
+            },
+            writeStreamVolume = { newVol ->
+                val am = context.getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager
+                am?.setStreamVolume(android.media.AudioManager.STREAM_MUSIC, newVol, 0)
+            },
+            doSeekTo = doSeekTo,
+            saveBrightness = viewModel::saveBrightness,
+            saveVolume = viewModel::saveVolume,
+            setCastVolume = viewModel::setCastVolume,
+        )
+    }
+    val brightnessOverlay by gestureController.brightnessOverlay.collectAsStateWithLifecycle()
+    val volumeOverlay by gestureController.volumeOverlay.collectAsStateWithLifecycle()
+    val gestureSeekPositionMs by gestureController.seekPositionMs.collectAsStateWithLifecycle()
+    val gestureDeltaMs by gestureController.deltaMs.collectAsStateWithLifecycle()
+    val isGestureSeeking by gestureController.isSeeking.collectAsStateWithLifecycle()
     val dismissSheet: () -> Unit = remember { { currentSheet = PlayerSheet.None } }
 
     // Shared confirmation haptic for discrete player actions (seek commit,
@@ -1183,101 +1232,13 @@ fun VideoPlayerScreen(
                 indicatorSide = uiState.gestureIndicatorSide,
                 gesturesEnabled = uiState.gesturesEnabled && !isScreenLocked,
                 swipeSeekMaxMs = uiState.swipeSeekMaxMs,
-                onSeekGesture = remember(engine) {
-                    { totalDeltaMs ->
-                        engine?.let { eng ->
-                            if (!isGestureSeeking) {
-                                gestureStartPositionMs = eng.currentPositionMs
-                                isGestureSeeking = true
-                            }
-                            gestureDeltaMs = totalDeltaMs
-                            val durationMs = eng.durationMs.coerceAtLeast(0)
-                            // For live streams durationMs is 0, so the upper
-                            // clamp is skipped. To avoid showing a trickplay
-                            // thumbnail + time label for a position that doesn't
-                            // For live streams durationMs is 0, so the upper
-                            // clamp is skipped. To avoid showing a trickplay
-                            // thumbnail + time label for a position that doesn't
-                            // exist, cap the *per-gesture* delta by the
-                            gestureSeekPositionMs = if (durationMs <= 0L) {
-                                val capped = totalDeltaMs.coerceIn(-uiState.swipeSeekMaxMs, uiState.swipeSeekMaxMs)
-                                (gestureStartPositionMs + capped).coerceAtLeast(0L)
-                            } else {
-                                (gestureStartPositionMs + totalDeltaMs).coerceIn(0L, durationMs)
-                            }
-                        }
-                    }
-                },
-                onBrightnessGesture = remember(activity) {
-                    { delta ->
-                        activity?.let { act ->
-                            val window = act.window
-                            val layout = window.attributes
-                            val current = layout.screenBrightness
-                            val newBrightness = (current + delta).coerceIn(0f, 1f)
-                            layout.screenBrightness = newBrightness
-                            window.attributes = layout
-                            brightnessOverlay = newBrightness
-                        }
-                    }
-                },
-                onVolumeGesture = remember(context, isCastConnected, castVolume) {
-                    { delta ->
-                        if (isCastConnected) {
-                            // Cast volume used to scale by 0.02, requiring
-                            // ~50 full-height swipes for the full range. Use the
-                            // accumulator pattern from the local path so one
-                            // full-height swipe moves ~0.5 of the range.
-                            val currentNorm = castVolume
-                            volumeGestureAccumulator += delta
-                            val newVolume = (currentNorm + volumeGestureAccumulator).coerceIn(0f, 1f)
-                            volumeOverlay = newVolume
-                            viewModel.setCastVolume(newVolume)
-                        } else {
-                            val am = context.getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager
-                            am?.let { amRef ->
-                                val max = amRef.getStreamMaxVolume(android.media.AudioManager.STREAM_MUSIC)
-                                val current = amRef.getStreamVolume(android.media.AudioManager.STREAM_MUSIC)
-                                val currentNorm = current.toFloat() / max.toFloat()
-                                val stepThreshold = 1f / max.toFloat()
-                                volumeGestureAccumulator += delta
-                                volumeOverlay = (currentNorm + volumeGestureAccumulator).coerceIn(0f, 1f)
-                                val steps = (volumeGestureAccumulator / stepThreshold).toInt()
-                                if (steps != 0) {
-                                    volumeGestureAccumulator -= steps * stepThreshold
-                                    val newVol = (current + steps).coerceIn(0, max)
-                                    amRef.setStreamVolume(android.media.AudioManager.STREAM_MUSIC, newVol, 0)
-                                }
-                            }
-                        }
-                    }
-                },
-                onClearOverlays = remember(doSeekTo, scope) {
+                onSeekGesture = remember(gestureController) { { totalDeltaMs -> gestureController.onSeekGesture(totalDeltaMs) } },
+                onBrightnessGesture = remember(gestureController) { { delta -> gestureController.onBrightnessGesture(delta) } },
+                onVolumeGesture = remember(gestureController) { { delta -> gestureController.onVolumeGesture(delta) } },
+                onClearOverlays = remember(gestureController, seekState) {
                     {
-                        if (isGestureSeeking) {
-                            doSeekTo(gestureSeekPositionMs)
-                        }
-                        if (brightnessOverlay in 0f..1f) {
-                            viewModel.saveBrightness(brightnessOverlay)
-                        }
-                        if (volumeOverlay in 0f..1f) {
-                            val am = context.getSystemService(android.content.Context.AUDIO_SERVICE)
-                                as? android.media.AudioManager
-                            if (am != null) {
-                                val max = am.getStreamMaxVolume(android.media.AudioManager.STREAM_MUSIC)
-                                val cur = am.getStreamVolume(android.media.AudioManager.STREAM_MUSIC)
-                                if (max > 0) viewModel.saveVolume(cur.toFloat() / max)
-                            }
-                        }
+                        gestureController.onClearOverlays()
                         seekState.reset()
-                        volumeGestureAccumulator = 0f
-                        isGestureSeeking = false
-                        overlayDismissJob?.cancel()
-                        overlayDismissJob = scope.launch {
-                            delay(GESTURE_BARS_DISMISS_MS)
-                            brightnessOverlay = -1f
-                            volumeOverlay = -1f
-                        }
                     }
                 },
                 showControls = showControls,
@@ -1305,35 +1266,10 @@ fun VideoPlayerScreen(
                         }
                     }
                 },
-                onStartGesture = remember(activity) {
+                onStartGesture = remember(gestureController) { { gestureController.onStartGesture() } },
+                onCancelOverlays = remember(gestureController, seekState) {
                     {
-                        initialBrightnessOnGestureStart = activity?.window?.attributes?.screenBrightness ?: -1f
-                    }
-                },
-                onCancelOverlays = remember(activity) {
-                    {
-                        activity?.let { act ->
-                            if (!act.isDestroyed && !act.isFinishing) {
-                                val layout = act.window.attributes
-                                if (initialBrightnessOnGestureStart >= 0f) {
-                                    layout.screenBrightness = initialBrightnessOnGestureStart
-                                } else {
-                                    layout.screenBrightness = android.view.WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE
-                                }
-                                act.window.attributes = layout
-                            }
-                        }
-                        // Cancel any pending dismiss job from a prior gesture so it
-                        // doesn't fire redundantly after we've already cleared the
-                        // overlays here. (The job only hides the visual indicators;
-                        // it does not persist brightness/volume, which onClearOverlays
-                        // does synchronously — so cancelling it here is safe.)
-                        overlayDismissJob?.cancel()
-                        overlayDismissJob = null
-                        brightnessOverlay = -1f
-                        volumeOverlay = -1f
-                        volumeGestureAccumulator = 0f
-                        isGestureSeeking = false
+                        gestureController.onCancelOverlays()
                         seekState.reset()
                     }
                 },

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerScreen.kt
@@ -1094,6 +1094,26 @@ fun VideoPlayerScreen(
                             },
                     )
 
+                    // Audio-only: keep the surface mounted (playback
+                    // uninterrupted) but cover it with a black panel + label.
+                    if (uiState.audioOnly) {
+                        Surface(
+                            color = Color.Black,
+                            modifier = Modifier.fillMaxSize(),
+                        ) {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.player_audio_only_on),
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                        }
+                    }
+
                     // ── Zoom/crop-safe subtitles ──
                     //
                     // The engine declares its zoom-safe subtitle strategy via
@@ -1745,6 +1765,8 @@ fun VideoPlayerScreen(
                 onAbRepeatSetA = { viewModel.setAbRepeatPointA() },
                 onAbRepeatSetB = { viewModel.setAbRepeatPointB() },
                 onAbRepeatClear = { viewModel.clearAbRepeat() },
+                audioOnly = uiState.audioOnly,
+                onToggleAudioOnly = { viewModel.toggleAudioOnly() },
                 onLockClick = onLockClick,
                 onControlsFocusChange = onControlsFocusChange,
                 onOverflowMenuChange = onOverflowMenuChange,
@@ -2000,7 +2022,7 @@ private fun BoxScope.AutoAspectRatioBadge(
 
     PlayerBadge(
         show = showBadge,
-        text = "Auto: ${detectedAspectRatio?.displayName ?: ""}",
+        text = stringResource(R.string.player_video_aspect_auto, detectedAspectRatio?.displayName ?: ""),
         topPadding = 60.dp,
     )
 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerUiState.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerUiState.kt
@@ -267,6 +267,14 @@ data class VideoPlayerUiState(
      * silently transcodes high-bitrate sources even on AUTO quality.
      */
     val isConnectionMetered: Boolean = false,
+    /**
+     * In-player "Audio only" toggle: hides the video surface (see the
+     * AndroidView mount in VideoPlayerScreen) while keeping playback alive via
+     * the existing media session. ExoPlayer audio is independent of the surface,
+     * so collapsing the view does not interrupt the engine. Purely a UI/surface
+     * gate — does NOT touch the engine or PlayerLifecycleManager.
+     */
+    val audioOnly: Boolean = false,
 ) {
 
     // ── Cohesive sub-state projections ────────────────────────────────────

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -780,32 +780,13 @@ class VideoPlayerViewModel @Inject constructor(
     init {
         castManager.acquireConsumer()
         // Register the PiP transport bridge so the Activity can dispatch PiP
-        // remote-action intents (play/pause/skip/next) to the active engine
-        //. Cleared on reset() when playback ends.
-        pipController.pipTransport = PipTransport { action ->
-            val engine = playerSessionManager.engine
-            if (engine == null) {
-                // PiP bypasses the MediaSession entirely (broadcast -> PipTransport
-                // -> engine), so this silently no-ops when no engine is bound.
-                // Log so a stale transport is diagnosable instead of dead-buttons.
-                Log.w(TAG, "PiP action $action dropped: no active player engine")
-                return@PipTransport
-            }
-            Log.d(TAG, "PiP action $action -> engine")
-            when (action) {
-                PipAction.PLAY -> engine.play()
-                PipAction.PAUSE -> engine.pause()
-                PipAction.SKIP_FORWARD -> {
-                    val skip = _uiState.value.seekDurationMs
-                    seekTo((engine.currentPositionMs + skip).coerceAtLeast(0L))
-                }
-                PipAction.SKIP_BACKWARD -> {
-                    val skip = _uiState.value.seekDurationMs
-                    seekTo((engine.currentPositionMs - skip).coerceAtLeast(0L))
-                }
-                PipAction.NEXT -> playNextEpisode()
-            }
-        }
+        // remote-action intents (play/pause/skip/next) to the active engine.
+        // Also re-armed in initializeInternal(): this VM is Activity-scoped
+        // (Nav3 has no per-entry ViewModelStore here) and is reused across media,
+        // and release() from the screen's onDispose runs pipController.reset()
+        // which nulls the transport — but init never re-runs on the reused
+        // instance, so every load must re-arm it or PiP controls go dead.
+        registerPipTransport()
         launch {
             aggregateStore.aggregate.collect { agg ->
                 val oldAggregate = cachedAggregate
@@ -1204,6 +1185,42 @@ class VideoPlayerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Arms the PiP transport bridge so the Activity can dispatch PiP remote-action
+     * intents (play/pause/skip/next) to the active engine. Idempotent and safe to
+     * call repeatedly: [release] → [performRelease] → [PipController.reset] nulls
+     * the transport, and because this VM is Activity-scoped (Nav3 has no per-entry
+     * ViewModelStore here) `init` does not re-run on the reused instance — so
+     * [initializeInternal] must re-arm it on every load or PiP controls go dead
+     * after the first media close.
+     */
+    private fun registerPipTransport() {
+        pipController.pipTransport = PipTransport { action ->
+            val engine = playerSessionManager.engine
+            if (engine == null) {
+                // PiP bypasses the MediaSession entirely (broadcast -> PipTransport
+                // -> engine), so this silently no-ops when no engine is bound.
+                // Log so a stale transport is diagnosable instead of dead-buttons.
+                Log.w(TAG, "PiP action $action dropped: no active player engine")
+                return@PipTransport
+            }
+            Log.d(TAG, "PiP action $action -> engine")
+            when (action) {
+                PipAction.PLAY -> engine.play()
+                PipAction.PAUSE -> engine.pause()
+                PipAction.SKIP_FORWARD -> {
+                    val skip = _uiState.value.seekDurationMs
+                    seekTo((engine.currentPositionMs + skip).coerceAtLeast(0L))
+                }
+                PipAction.SKIP_BACKWARD -> {
+                    val skip = _uiState.value.seekDurationMs
+                    seekTo((engine.currentPositionMs - skip).coerceAtLeast(0L))
+                }
+                PipAction.NEXT -> playNextEpisode()
+            }
+        }
+    }
+
     val playerEngineRef: com.raulshma.jellyplay.feature.player.video.engine.MediaEngine? get() = playerSessionManager.engine
 
     /**
@@ -1342,6 +1359,10 @@ class VideoPlayerViewModel @Inject constructor(
         allowCinemaMode: Boolean,
     ) {
         released = false
+        // Re-arm the PiP transport: the previous media's onDispose ran release()
+        // → pipController.reset() which nulled it. init only ran once (this VM is
+        // Activity-scoped and reused), so a new load must re-register it.
+        registerPipTransport()
         autoplayController.resetForNewItem()
         _uiState.update { it.copy(autoplayCancelled = false) }
         lastSeekPositionMs = null
@@ -2924,11 +2945,12 @@ class VideoPlayerViewModel @Inject constructor(
         playerSessionManager.release()
         playerLifecycleManager.reset()
         // Clear per-item PiP mirrors but KEEP pipTransport: it is a VM-owned
-        // bridge registered once in init and read by the Activity's PiP
-        // BroadcastReceiver. Nulling it here (as reset() does) would deaden
-        // every PiP control, because initialize() calls releaseInternals() on
-        // every item load and the transport is never re-registered. Full
-        // reset() (transport included) runs in performRelease() on teardown.
+        // bridge re-armed in init AND initializeInternal (because release() from
+        // the screen's onDispose runs pipController.reset(), nulling it). Nulling
+        // it here would deaden PiP controls mid-session, since initialize() calls
+        // releaseInternals() on every item load. The full reset() (transport
+        // included) runs in performRelease() on teardown, and the next load
+        // re-arms it.
         pipController.setPlaying(false)
         pipController.pipHasNext = false
         trickplayManager.clear()

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
+import android.util.Rational
 import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -63,6 +64,7 @@ import com.raulshma.jellyplay.core.ui.feedback.UserMessageBus
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import com.raulshma.jellyplay.feature.player.video.R
 import com.raulshma.jellyplay.feature.player.video.components.AspectRatio
+import com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState
 import com.raulshma.jellyplay.feature.player.video.engine.EngineVideoStats
 import com.raulshma.jellyplay.feature.player.video.engine.SegmentCalculator
 import com.raulshma.jellyplay.feature.player.video.engine.SegmentCalculatorInput
@@ -1017,19 +1019,27 @@ class VideoPlayerViewModel @Inject constructor(
                             } }
                             launch { engine.playbackState.collect { state ->
                                 val stateInt = when (state) {
-                                    com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.IDLE -> 1
-                                    com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.BUFFERING -> 2
-                                    com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.READY -> 3
-                                    com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.ENDED -> 4
-                                    com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.ERROR -> 1
+                                    EnginePlaybackState.IDLE -> 1
+                                    EnginePlaybackState.BUFFERING -> 2
+                                    EnginePlaybackState.READY -> 3
+                                    EnginePlaybackState.ENDED -> 4
+                                    EnginePlaybackState.ERROR -> 1
                                 }
                                 syncPlayBridge.onPlaybackStateChanged(stateInt)
-                                val buffering = state == com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.BUFFERING
+                                val buffering = state == EnginePlaybackState.BUFFERING
                                 _uiState.update { s ->
                                     if (s.isBuffering == buffering) s else s.copy(isBuffering = buffering)
                                 }
-                                if (state == com.raulshma.jellyplay.feature.player.video.engine.EnginePlaybackState.ENDED) {
+                                if (state == EnginePlaybackState.ENDED) {
                                     handlePlaybackEnded()
+                                }
+                                // Auto-exit PiP when playback ends or errors so the
+                                // window does not linger on a frozen frame. Pause is
+                                // intentionally excluded — users pause to read.
+                                if (pipController.isInPipMode.value &&
+                                    (state == EnginePlaybackState.ENDED || state == EnginePlaybackState.ERROR)
+                                ) {
+                                    pipController.requestAutoExitPip()
                                 }
                             } }
                             launch { engine.availableTracks.collect { trackSelectionHelper.updateTracksFromEngine() } }
@@ -1874,6 +1884,32 @@ class VideoPlayerViewModel @Inject constructor(
             val detected = detectAspectRatio(_uiState.value.mediaStreams)
             _uiState.update { it.copy(detectedAspectRatio = detected) }
         }
+        // The PiP aspect ratio always tracks the underlying media, independent
+        // of the in-app resize mode, so it does not need re-deriving here.
+    }
+
+    /**
+     * Pushes the server-reported video stream dimensions into [PipController] as
+     * a `Rational` so the PiP window matches the content (16:9, 4:3, 21:9, …)
+     * instead of always letterboxing to 16:9. Falls back to `null` (→ 16:9 in
+     * the Activity) when the stream or its dimensions are unknown.
+     */
+    private fun updatePipAspectRatio(streams: List<com.raulshma.jellyplay.core.model.MediaStream>) {
+        val video = streams.firstOrNull { it.type == com.raulshma.jellyplay.core.model.StreamType.VIDEO }
+        val w = video?.width
+        val h = video?.height
+        pipController.setPipAspectRatio(
+            if (w != null && h != null && h != 0) Rational(w, h) else null
+        )
+    }
+
+    /**
+     * Forwards the video surface's window bounds to [PipController] as the PiP
+     * source-rect hint. Thin wrapper so the screen does not reach through the
+     * ViewModel into the controller.
+     */
+    fun updatePipSourceRect(rect: android.graphics.Rect?) {
+        pipController.updatePipSourceRect(rect)
     }
 
     fun setSubtitleStyle(style: SubtitleStyle) {
@@ -2721,6 +2757,7 @@ class VideoPlayerViewModel @Inject constructor(
             mediaStreams = streams,
             detectedAspectRatio = detectAspectRatio(streams),
         ) }
+        updatePipAspectRatio(streams)
         // Rebuild the audio/subtitle track options from the refreshed server
         // streams. A subtitle download/upload attaches a new MediaStream server-
         // side, but the engine's availableTracks flow only re-emits on an engine-

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -2762,6 +2762,10 @@ class VideoPlayerViewModel @Inject constructor(
         playerSessionManager.engine?.setVideoStatsEnabled(newValue)
     }
 
+    fun toggleAudioOnly() {
+        _uiState.update { it.copy(audioOnly = !it.audioOnly) }
+    }
+
     fun toggleMute() {
         val engine = playerSessionManager.engine ?: return
         val currentlyMuted = _uiState.value.isMuted

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -118,6 +118,16 @@ private const val SAVED_KEY_PLAY_SESSION_ID = "video_player.saved_play_session_i
 private const val SAVED_KEY_POSITION_PERSISTED_AT = "video_player.saved_position_persisted_at"
 private const val POSITION_PERSIST_MIN_INTERVAL_MS = 5_000L
 /**
+ * Quiet-period for coalescing the *offline-mirror* DB write during rapid
+ * scrubbing: [seekTo] fires one per seek gesture, and the immediate
+ * `recordProgress` launches would queue against Room's executor. Only the DB
+ * mirror is coalesced — the SavedStateHandle writes stay immediate so explicit
+ * seek positions still survive process death. The position tick's throttled
+ * mirror write (`persistPlaybackPosition(force=false)`) catches up within
+ * seconds, so a dropped coalesced write is never lost for long.
+ */
+private const val SEEK_PROGRESS_COALESCE_MS = 500L
+/**
  * A persisted position older than this is treated as stale on a process-death
  * restore and ignored: the user backgrounded the app long enough that
  * auto-resuming mid-stream (potentially on an episode they auto-advanced past)
@@ -381,6 +391,11 @@ class VideoPlayerViewModel @Inject constructor(
     private var playSessionId: String = java.util.UUID.randomUUID().toString()
     // Last position (ms) written to savedStateHandle; used to throttle writes.
     private var lastPersistedPositionMs: Long = Long.MIN_VALUE
+    /**
+     * Single-flight coalescing job for the offline-mirror DB write during seek
+     * scrubbing. Cancelled+relaunched per [seekTo]; see [scheduleCoalescedSeekProgress].
+     */
+    private var pendingSeekProgressJob: Job? = null
 
     /**
      * Single resolved playback-session id. The server issues its own id
@@ -565,8 +580,21 @@ class VideoPlayerViewModel @Inject constructor(
         _currentPositionMs.value = positionMs
         playerSessionManager.engine?.seekTo(positionMs)
         // Explicit seeks are the most important position to survive process
-        // death; persist immediately rather than waiting for the throttle.
-        persistPlaybackPosition(positionMs, force = true)
+        // death; persist the SavedStateHandle snapshot immediately rather than
+        // waiting for the throttle.
+        val itemId = playerSessionManager.sessionState.value.currentItemId
+        if (itemId != null) {
+            lastPersistedPositionMs = positionMs
+            savedStateHandle[SAVED_KEY_ITEM_ID] = itemId
+            savedStateHandle[SAVED_KEY_POSITION_MS] = positionMs
+            savedStateHandle[SAVED_KEY_PLAY_SESSION_ID] = currentPlaySessionId
+            savedStateHandle[SAVED_KEY_POSITION_PERSISTED_AT] = System.currentTimeMillis()
+            // The DB mirror is coalesced: rapid scrubbing no longer queues one
+            // recordProgress per seek. SavedStateHandle above is already
+            // immediate, and the throttled tick mirror catches up regardless.
+            val durationMs = playerSessionManager.engine?.durationMs ?: 0L
+            scheduleCoalescedSeekProgress(itemId, positionMs, durationMs)
+        }
     }
 
     /**
@@ -1274,6 +1302,27 @@ class VideoPlayerViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Coalesces the offline-mirror DB write during seek scrubbing: cancels any
+     * in-flight pending write and schedules a fresh one [SEEK_PROGRESS_COALESCE_MS]
+     * later, so rapid seeks emit at most one `recordProgress` per quiet window.
+     * The SavedStateHandle snapshot is already written synchronously by [seekTo],
+     * and the throttled position tick (`persistPlaybackPosition(force=false)`)
+     * re-writes the mirror every [POSITION_PERSIST_MIN_INTERVAL_MS], so a dropped
+     * coalesced write is recovered within seconds.
+     */
+    private fun scheduleCoalescedSeekProgress(itemId: String, positionMs: Long, durationMs: Long) {
+        pendingSeekProgressJob?.cancel()
+        pendingSeekProgressJob = launch {
+            delay(SEEK_PROGRESS_COALESCE_MS)
+            val positionTicks = positionMs * 10_000L // ms → ticks
+            val percentage = if (durationMs > 0L) {
+                (positionMs.toDouble() / durationMs.toDouble() * 100.0).coerceIn(0.0, 100.0)
+            } else 0.0
+            offlinePlaybackFacade.recordProgress(itemId, positionTicks, percentage, isPlayed = false)
+        }
+    }
+
     private fun initializeInternal(
         itemId: String,
         mediaSourceId: String?,
@@ -1379,6 +1428,8 @@ class VideoPlayerViewModel @Inject constructor(
             java.util.UUID.randomUUID().toString()
         }
         lastPersistedPositionMs = Long.MIN_VALUE
+        pendingSeekProgressJob?.cancel()
+        pendingSeekProgressJob = null
         trickplayManager.clear()
 
         if (wasInSyncPlay) {
@@ -2964,6 +3015,16 @@ class VideoPlayerViewModel @Inject constructor(
         pipController.reset()
         castManager.releaseConsumer()
         activePlayerController.clearEngine()
+        // Belt-and-suspenders: flush a pending coalesced seek-mirror write so the
+        // offline store doesn't lag the final position on release. The write is
+        // moved onto the release scope (IO + NonCancellable) so it survives the
+        // viewModelScope being cancelled on clear().
+        val pendingSeek = pendingSeekProgressJob
+        if (pendingSeek != null && itemId != null) {
+            releaseScope.launch(NonCancellable) {
+                pendingSeek.join()
+            }
+        }
         // Skip the second Stop if reportCurrentPlaybackStopped already
         // sent one for this session — duplicate Stop reports confuse the
         // server's resume/progress bookkeeping.

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/VideoPlayerViewModel.kt
@@ -3,6 +3,7 @@ package com.raulshma.jellyplay.feature.player.video
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -752,7 +753,15 @@ class VideoPlayerViewModel @Inject constructor(
         // remote-action intents (play/pause/skip/next) to the active engine
         //. Cleared on reset() when playback ends.
         pipController.pipTransport = PipTransport { action ->
-            val engine = playerSessionManager.engine ?: return@PipTransport
+            val engine = playerSessionManager.engine
+            if (engine == null) {
+                // PiP bypasses the MediaSession entirely (broadcast -> PipTransport
+                // -> engine), so this silently no-ops when no engine is bound.
+                // Log so a stale transport is diagnosable instead of dead-buttons.
+                Log.w(TAG, "PiP action $action dropped: no active player engine")
+                return@PipTransport
+            }
+            Log.d(TAG, "PiP action $action -> engine")
             when (action) {
                 PipAction.PLAY -> engine.play()
                 PipAction.PAUSE -> engine.pause()
@@ -2998,5 +3007,9 @@ class VideoPlayerViewModel @Inject constructor(
             // re-derive "is this item part of a series?" at the call site.
             mediaRepository.invalidateUserDataCaches(itemId)
         }
+    }
+
+    private companion object {
+        const val TAG = "VideoPlayerViewModel"
     }
 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/ChapterPickerSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/ChapterPickerSheet.kt
@@ -79,28 +79,32 @@ internal fun ChapterPickerSheet(
                 modifier = Modifier.padding(horizontal = 24.dp),
             )
             Spacer(Modifier.height(12.dp))
+            // Resolve the current chapter once in an O(n) pass instead of an
+            // O(n^2) re-scan (chapters.none { chapters.indexOf(it) }) per row,
+            // per position tick — the sheet re-lambdas at ~4 Hz while open.
+            val currentChapterIndex = remember(chapters, currentPositionMs) {
+                var found = -1
+                for (i in chapters.indices) {
+                    val chapterMs = chapters[i].startPositionTicks / 10_000
+                    val nextMs = if (i < chapters.lastIndex) {
+                        chapters[i + 1].startPositionTicks / 10_000
+                    } else {
+                        Long.MAX_VALUE
+                    }
+                    if (currentPositionMs >= chapterMs && currentPositionMs < nextMs) {
+                        found = i
+                        break
+                    }
+                }
+                found
+            }
+            // The focus target is the current chapter, or the first row when no
+            // chapter matches the position (mirrors the prior .none{} fallback).
+            val focusTargetIndex = if (currentChapterIndex >= 0) currentChapterIndex else 0
             LazyColumn(modifier = Modifier.verticalWrapAround()) {
                 itemsIndexed(chapters, key = { index, chapter -> "${index}_${chapter.startPositionTicks}" }, contentType = { _, _ -> "chapter" }) { index, chapter ->
-                    val isCurrentChapter = {
-                        val chapterMs = chapter.startPositionTicks / 10_000
-                        if (index < chapters.lastIndex) {
-                            val nextChapterMs = chapters[index + 1].startPositionTicks / 10_000
-                            currentPositionMs in chapterMs until nextChapterMs
-                        } else {
-                            currentPositionMs >= chapterMs
-                        }
-                    }()
-                    val isFirst = index == 0
-                    val isTarget = isCurrentChapter || (chapters.none {
-                        val chapterMs = it.startPositionTicks / 10_000
-                        val idx = chapters.indexOf(it)
-                        if (idx < chapters.lastIndex) {
-                            val nextChapterMs = chapters[idx + 1].startPositionTicks / 10_000
-                            currentPositionMs in chapterMs until nextChapterMs
-                        } else {
-                            currentPositionMs >= chapterMs
-                        }
-                    } && isFirst)
+                    val isCurrentChapter = index == currentChapterIndex
+                    val isTarget = index == focusTargetIndex
 
                     ChapterItem(
                         chapter = chapter,

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/EpisodePickerSheet.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/EpisodePickerSheet.kt
@@ -192,6 +192,13 @@ internal fun EpisodePickerSheet(
                     }
                 }
 
+                // Resolve the current episode once in an O(n) pass instead of an
+                // O(n^2) re-scan (episodes.none { it.id == ... }) per row.
+                val currentEpisodeIndex = remember(episodes, currentEpisodeId) {
+                    episodes.indexOfFirst { it.id == currentEpisodeId }
+                }
+                val focusTargetIndex = if (currentEpisodeIndex >= 0) currentEpisodeIndex else 0
+
                 LazyColumn {
                     itemsIndexed(
                         episodes,
@@ -199,12 +206,15 @@ internal fun EpisodePickerSheet(
                         contentType = { _, _ -> "episode" },
                     ) { index, episode ->
                         val isCurrent = episode.id == currentEpisodeId
-                        val isFirstOrCurrent = isCurrent || (episodes.none { it.id == currentEpisodeId } && index == 0)
+                        val isFirstOrCurrent = index == focusTargetIndex
+                        // Memoize the thumbnail URL per episode id so it isn't
+                        // rebuilt for every visible row on each recomposition.
+                        val imageUrl = remember(episode.id) { getImageUrl(episode.id) }
 
                         EpisodeRow(
                             episode = episode,
                             isCurrent = isCurrent,
-                            imageUrl = getImageUrl(episode.id),
+                            imageUrl = imageUrl,
                             onClick = { onEpisodeSelect(episode) },
                             modifier = Modifier.ifElse(isFirstOrCurrent, Modifier.focusRequester(episodeFocusRequester))
                         )

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerControls.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerControls.kt
@@ -225,6 +225,8 @@ internal fun PlayerControls(
     onAbRepeatSetA: () -> Unit = {},
     onAbRepeatSetB: () -> Unit = {},
     onAbRepeatClear: () -> Unit = {},
+    audioOnly: Boolean = false,
+    onToggleAudioOnly: () -> Unit = {},
     onLockClick: () -> Unit = {},
     onControlsFocusChange: (Boolean) -> Unit = {},
     onOverflowMenuChange: (Boolean) -> Unit = {},
@@ -818,6 +820,11 @@ internal fun PlayerControls(
             onAbRepeatClear = {
                 showOverflow = false
                 onAbRepeatClear()
+            },
+            audioOnly = audioOnly,
+            onToggleAudioOnly = {
+                showOverflow = false
+                onToggleAudioOnly()
             },
         )
     }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerOverflowMenu.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/PlayerOverflowMenu.kt
@@ -114,6 +114,8 @@ internal fun BoxScope.PlayerOverflowMenu(
     onAbRepeatSetA: () -> Unit = {},
     onAbRepeatSetB: () -> Unit = {},
     onAbRepeatClear: () -> Unit = {},
+    audioOnly: Boolean = false,
+    onToggleAudioOnly: () -> Unit = {},
 ) {
     if (!expanded) return
     var showDialogueBoostSubmenu by remember { mutableStateOf(false) }
@@ -475,6 +477,13 @@ internal fun BoxScope.PlayerOverflowMenu(
                     onClick = onAbRepeatClear,
                 )
             }
+            OverflowMenuItem(
+                icon = Tabler.Outline.Volume,
+                label = if (audioOnly) stringResource(R.string.player_audio_only_on)
+                    else stringResource(R.string.player_audio_only),
+                onClick = onToggleAudioOnly,
+                tint = if (audioOnly) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+            )
         }
     }
 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/SubtitleSyncPreview.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/components/SubtitleSyncPreview.kt
@@ -350,9 +350,12 @@ private fun formatTimestamp(ms: Long): String {
     return "%02d:%02d.%03d".format(minutes, seconds, millis)
 }
 
+/** Compiled once; [parseTimestampMs] runs per keystroke via remember(timestampText). */
+private val TIMESTAMP_REGEX = Regex("(\\d+):(\\d{1,2})(?:\\.(\\d{1,3}))?")
+
 /** Parses an mm:ss.mmm string to milliseconds; returns 0 on parse failure. */
 private fun parseTimestampMs(text: String): Long {
-    val match = Regex("(\\d+):(\\d{1,2})(?:\\.(\\d{1,3}))?").find(text.trim()) ?: return 0L
+    val match = TIMESTAMP_REGEX.find(text.trim()) ?: return 0L
     val minutes = match.groupValues[1].toLongOrNull() ?: return 0L
     val seconds = match.groupValues[2].toLongOrNull() ?: return 0L
     val millis = match.groupValues[3].takeIf { it.isNotBlank() }?.padEnd(3, '0').orEmpty()

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
@@ -92,8 +92,13 @@ import okhttp3.OkHttpClient
  * Default subtitle text size for the embedded-style path. A fixed SP value keeps
  * captions stable across orientation changes (a height-fraction scales against the
  * view height, which grows dramatically in portrait).
+ *
+ * Sourced from [com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.EXOPLAYER_OVERRIDE]
+ * — ExoPlayer's documented divergence from the shared 24sp default. See that
+ * override's KDoc for why ExoPlayer keeps a distinct size/edge here.
  */
-private const val DEFAULT_SUBTITLE_SIZE_SP = 18f
+private val DEFAULT_SUBTITLE_SIZE_SP =
+    com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.EXOPLAYER_OVERRIDE.fontSizeSp.toFloat()
 private const val TAG = "ExoPlayerEngine"
 
 class ExoPlayerEngine(
@@ -1054,12 +1059,21 @@ class ExoPlayerEngine(
                 // captions become huge, while mpv (libass, sizes against the video
                 // frame) stays correct.
                 sv.setApplyEmbeddedFontSizes(false)
+                // ExoPlayer's default branch uses the engine's documented divergence
+                // from the shared table (SubtitleRenderDefaults.EXOPLAYER_OVERRIDE):
+                // 18sp + DROP_SHADOW rather than the 24sp + OUTLINE other engines use.
+                // The divergence is a conscious Media3-specific choice (see the
+                // override's KDoc), not silent drift.
                 sv.setStyle(
                     CaptionStyleCompat(
                         Color.WHITE,
                         Color.TRANSPARENT,
                         Color.TRANSPARENT,
-                        CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW,
+                        when (com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.EXOPLAYER_OVERRIDE.edgeType) {
+                            com.raulshma.jellyplay.core.model.SubtitleEdgeType.DROP_SHADOW -> CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW
+                            com.raulshma.jellyplay.core.model.SubtitleEdgeType.OUTLINE -> CaptionStyleCompat.EDGE_TYPE_OUTLINE
+                            else -> CaptionStyleCompat.EDGE_TYPE_NONE
+                        },
                         Color.BLACK,
                         android.graphics.Typeface.SANS_SERIF
                     )

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/ExoPlayerEngine.kt
@@ -58,6 +58,8 @@ import com.raulshma.jellyplay.core.model.ExoFrameRateStrategy
 import com.raulshma.jellyplay.core.model.ExoPlayerEngineConfig
 import com.raulshma.jellyplay.core.model.ExoVideoScalingMode
 import com.raulshma.jellyplay.core.model.PlayerType
+import com.raulshma.jellyplay.core.model.SubtitleEdgeType
+import com.raulshma.jellyplay.core.model.SubtitleRenderDefaults
 import com.raulshma.jellyplay.core.model.SubtitleStyle
 import com.raulshma.jellyplay.core.model.TrackType
 import com.raulshma.jellyplay.feature.player.video.subtitle.AssSupport
@@ -93,12 +95,12 @@ import okhttp3.OkHttpClient
  * captions stable across orientation changes (a height-fraction scales against the
  * view height, which grows dramatically in portrait).
  *
- * Sourced from [com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.EXOPLAYER_OVERRIDE]
+ * Sourced from [SubtitleRenderDefaults.EXOPLAYER_OVERRIDE]
  * — ExoPlayer's documented divergence from the shared 24sp default. See that
  * override's KDoc for why ExoPlayer keeps a distinct size/edge here.
  */
 private val DEFAULT_SUBTITLE_SIZE_SP =
-    com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.EXOPLAYER_OVERRIDE.fontSizeSp.toFloat()
+    SubtitleRenderDefaults.EXOPLAYER_OVERRIDE.fontSizeSp.toFloat()
 private const val TAG = "ExoPlayerEngine"
 
 class ExoPlayerEngine(
@@ -1069,9 +1071,9 @@ class ExoPlayerEngine(
                         Color.WHITE,
                         Color.TRANSPARENT,
                         Color.TRANSPARENT,
-                        when (com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.EXOPLAYER_OVERRIDE.edgeType) {
-                            com.raulshma.jellyplay.core.model.SubtitleEdgeType.DROP_SHADOW -> CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW
-                            com.raulshma.jellyplay.core.model.SubtitleEdgeType.OUTLINE -> CaptionStyleCompat.EDGE_TYPE_OUTLINE
+                        when (SubtitleRenderDefaults.EXOPLAYER_OVERRIDE.edgeType) {
+                            SubtitleEdgeType.DROP_SHADOW -> CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW
+                            SubtitleEdgeType.OUTLINE -> CaptionStyleCompat.EDGE_TYPE_OUTLINE
                             else -> CaptionStyleCompat.EDGE_TYPE_NONE
                         },
                         Color.BLACK,

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/LibVlcSubtitleStyleMapping.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/LibVlcSubtitleStyleMapping.kt
@@ -4,7 +4,6 @@ import com.raulshma.jellyplay.core.model.SubtitleBorderStyle
 import com.raulshma.jellyplay.core.model.SubtitleEdgeType
 import com.raulshma.jellyplay.core.model.SubtitleStyle
 import com.raulshma.jellyplay.feature.player.video.subtitle.SubtitleColorResolver
-import com.raulshma.jellyplay.feature.player.video.subtitle.SubtitleDefaults
 
 /**
  * Pure FreeType typography mapping, the single source for LibVLC's `:freetype-*`
@@ -29,23 +28,28 @@ internal object LibVlcSubtitleStyleMapping {
         if (style.applyCustomStyle) colorOptions(style) else defaultOptions()
 
     /**
-     * LibVLC's native default caption style, matching the other engines'
-     * bundled-default reference (white text, transparent background, black
-     * outline + shadow, 24px reference size). Emitted when the user has not
-     * enabled a custom subtitle style.
+     * LibVLC's native default caption style, sourced from the shared
+     * [com.raulshma.jellyplay.core.model.SubtitleRenderDefaults] table (white
+     * text, transparent background, black outline + shadow, 24px reference size)
+     * so it cannot drift from the other engines. The thickness/shadow-opacity
+     * magnitudes are LibVLC-specific FreeType format translations of the shared
+     * edge-type/opacity, not independent defaults.
      */
-    fun defaultOptions(): List<String> = listOf(
-        ":freetype-color=${WHITE_RGB}", // White (0xFFFFFF)
-        ":freetype-background-color=0", // Black/transparent
-        ":freetype-background-opacity=0", // Transparent
-        ":freetype-outline-color=0", // Black
-        ":freetype-outline-thickness=2",
-        ":freetype-shadow-opacity=255",
-        // Absolute pixel size, matching the other engines' bundled-default
-        // reference size (24sp). :freetype-rel-fontsize would clamp/ignore
-        // 24 here — it is a relative-size enum, not a pixel value.
-        ":freetype-fontsize=${SubtitleDefaults.REFERENCE_FONT_SIZE}",
-    )
+    fun defaultOptions(): List<String> {
+        val d = com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.DEFAULT
+        return listOf(
+            ":freetype-color=${d.fontColor and 0x00FFFFFF}", // White (0xFFFFFF)
+            ":freetype-background-color=0", // Black/transparent
+            ":freetype-background-opacity=0", // Transparent
+            ":freetype-outline-color=0", // Black
+            ":freetype-outline-thickness=2",
+            ":freetype-shadow-opacity=255",
+            // Absolute pixel size, matching the other engines' bundled-default
+            // reference size (24sp). :freetype-rel-fontsize would clamp/ignore
+            // 24 here — it is a relative-size enum, not a pixel value.
+            ":freetype-fontsize=${d.fontSizeSp}",
+        )
+    }
 
     fun typefaceOptions(style: SubtitleStyle, bundledFallbackPath: String): List<String> = if (style.applyCustomStyle) {
         listOf(
@@ -111,7 +115,4 @@ internal object LibVlcSubtitleStyleMapping {
         val margin = (style.verticalPosition.coerceIn(0f, 0.4f) * frameHeight).toInt()
         return ":sub-margin=$margin"
     }
-
-    /** White as a decimal RGB int (FreeType wants RGB, alpha stripped). */
-    private const val WHITE_RGB: Int = 0xFFFFFF
 }

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/LibVlcSubtitleStyleMapping.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/LibVlcSubtitleStyleMapping.kt
@@ -2,6 +2,7 @@ package com.raulshma.jellyplay.feature.player.video.engine
 
 import com.raulshma.jellyplay.core.model.SubtitleBorderStyle
 import com.raulshma.jellyplay.core.model.SubtitleEdgeType
+import com.raulshma.jellyplay.core.model.SubtitleRenderDefaults
 import com.raulshma.jellyplay.core.model.SubtitleStyle
 import com.raulshma.jellyplay.feature.player.video.subtitle.SubtitleColorResolver
 
@@ -29,14 +30,14 @@ internal object LibVlcSubtitleStyleMapping {
 
     /**
      * LibVLC's native default caption style, sourced from the shared
-     * [com.raulshma.jellyplay.core.model.SubtitleRenderDefaults] table (white
+     * [SubtitleRenderDefaults] table (white
      * text, transparent background, black outline + shadow, 24px reference size)
      * so it cannot drift from the other engines. The thickness/shadow-opacity
      * magnitudes are LibVLC-specific FreeType format translations of the shared
      * edge-type/opacity, not independent defaults.
      */
     fun defaultOptions(): List<String> {
-        val d = com.raulshma.jellyplay.core.model.SubtitleRenderDefaults.DEFAULT
+        val d = SubtitleRenderDefaults.DEFAULT
         return listOf(
             ":freetype-color=${d.fontColor and 0x00FFFFFF}", // White (0xFFFFFF)
             ":freetype-background-color=0", // Black/transparent

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvStyleMapping.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/engine/MpvStyleMapping.kt
@@ -2,10 +2,11 @@ package com.raulshma.jellyplay.feature.player.video.engine
 
 import com.raulshma.jellyplay.core.model.AssOverrideMode
 import com.raulshma.jellyplay.core.model.SubtitleBorderStyle
+import com.raulshma.jellyplay.core.model.SubtitleColor
 import com.raulshma.jellyplay.core.model.SubtitleEdgeType
+import com.raulshma.jellyplay.core.model.SubtitleRenderDefaults
 import com.raulshma.jellyplay.core.model.SubtitleStyle
 import com.raulshma.jellyplay.feature.player.video.subtitle.SubtitleColorResolver
-import com.raulshma.jellyplay.feature.player.video.subtitle.SubtitleDefaults
 
 /**
  * Pure, testable mapping from [SubtitleStyle] to mpv `sub-*` property key/value
@@ -23,26 +24,27 @@ import com.raulshma.jellyplay.feature.player.video.subtitle.SubtitleDefaults
 internal object MpvStyleMapping {
 
     /**
-     * mpv/libass native caption defaults — the **single source** for every
-     * default value this object emits. Both the mpv property-string reset
-     * ([defaultEntries], [defaultBorderSize], [defaultShadowOffset],
-     * [defaultScale]) and the Compose-overlay resolver ([defaultResolvedValues])
-     * derive from these constants, so the native reset path and the zoomed
-     * Compose overlay cannot drift apart (the old bug: three hand-mirrored
-     * copies of "white text, 3.0 black outline, 24px").
+     * mpv/libass native caption defaults. Color/edge/font-size/bold/italic read
+     * from the shared [SubtitleRenderDefaults] table so they cannot drift from
+     * the other engines; mpv keeps a **documented override** for border (3.0)
+     * and shadow (0.0) — libass's native outline look, thicker than the model
+     * default. Both the mpv property-string reset ([defaultEntries],
+     * [defaultBorderSize], [defaultShadowOffset], [defaultScale]) and the
+     * Compose-overlay resolver ([defaultResolvedValues]) derive from these, so
+     * the native reset path and the zoomed Compose overlay cannot drift apart.
      */
     private object DEFAULTS {
-        const val TEXT_COLOR_ARGB: Int = 0xFFFFFFFF.toInt() // white
-        const val BACKGROUND_COLOR_ARGB: Int = 0xFF000000.toInt() // black
-        const val BACKGROUND_ALPHA: Float = 0f // transparent
-        const val EDGE_COLOR_ARGB: Int = 0xFF000000.toInt() // black
-        val EDGE_TYPE: SubtitleEdgeType = SubtitleEdgeType.OUTLINE
-        const val BORDER_WIDTH: Float = 3.0f
-        const val SHADOW_OFFSET: Float = 0.0f
-        const val FONT_SIZE: Int = SubtitleDefaults.REFERENCE_FONT_SIZE
+        val TEXT_COLOR_ARGB: Int get() = SubtitleColor.WHITE.value
+        val BACKGROUND_COLOR_ARGB: Int get() = SubtitleRenderDefaults.DEFAULT.backgroundColor
+        val BACKGROUND_ALPHA: Float get() = SubtitleRenderDefaults.DEFAULT.backgroundAlpha
+        val EDGE_COLOR_ARGB: Int get() = SubtitleRenderDefaults.DEFAULT.edgeColor
+        val EDGE_TYPE: SubtitleEdgeType get() = SubtitleRenderDefaults.DEFAULT.edgeType
+        const val BORDER_WIDTH: Float = 3.0f // mpv/libass override (model default is 2.0)
+        const val SHADOW_OFFSET: Float = 0.0f // mpv/libass override (model default is 1.0)
+        val FONT_SIZE: Int get() = SubtitleRenderDefaults.REFERENCE_FONT_SIZE
         const val SCALE: Double = 1.0
-        const val BOLD: Boolean = false
-        const val ITALIC: Boolean = false
+        val BOLD: Boolean get() = SubtitleRenderDefaults.DEFAULT.bold
+        val ITALIC: Boolean get() = SubtitleRenderDefaults.DEFAULT.italic
     }
 
     /**

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekController.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekController.kt
@@ -1,0 +1,201 @@
+package com.raulshma.jellyplay.feature.player.video.state
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Owns the gesture-seek / volume / brightness overlay state and the
+ * commit-vs-cancel asymmetry, extracted out of `VideoPlayerScreen`.
+ *
+ * Unlike [TrackSelectionHelper]/[SubtitleManager] (which read/write the VM's
+ * `_uiState`), the gesture state is composable-local and touches Android
+ * `Window`/`AudioManager` directly — it does not flow through `VideoPlayerUiState`
+ * (which has no seekPositionMs/isGestureSeeking fields). So this controller is a
+ * plain `class` constructed in the screen via `remember`, holding the gesture
+ * state internally and exposing [StateFlow]s for the overlay to observe.
+ *
+ * Android I/O (`Window`, `AudioManager`) moves behind small injected lambdas —
+ * real in prod, fake in tests. The pure math lives in [GestureSeekMath].
+ *
+ * **Saveability:** the previous screen-local state was `rememberSaveable` to
+ * survive config changes. The controller's `StateFlow`s are in-memory, so an
+ * in-flight gesture resets on rotation. This is intentional: a half-finished
+ * swipe already behaves poorly across rotation, and the simplification is the
+ * point of the extraction. (Gestures don't span config changes by design.)
+ *
+ * **Critical asymmetry** (pinned by `GestureSeekControllerTest`):
+ *  - [onClearOverlays] **commits** — seeks, persists brightness/volume.
+ *  - [onCancelOverlays] **discards** — restores the pre-gesture brightness and
+ *    seeks nowhere. Multi-touch (pinch-zoom) cancels.
+ *
+ * **Cast-volume fix:** [onClearOverlays] branches on [isCastConnected] so a cast
+ * session persists [volumeOverlay] via [saveVolume] (the old code re-read
+ * `AudioManager` for a cast session, which was a no-op re-read and never
+ * persisted the cast volume). Flagged as a behavior fix.
+ */
+internal class GestureSeekController(
+    private val scope: CoroutineScope,
+    private val getEngine: () -> com.raulshma.jellyplay.feature.player.video.engine.MediaEngine?,
+    private val getSwipeSeekMaxMs: () -> Long,
+    private val isCastConnected: () -> Boolean,
+    private val getCastVolume: () -> Float,
+    // I/O seams (real in prod, fake in test):
+    private val readWindowBrightness: () -> Float,
+    private val writeWindowBrightness: (Float) -> Unit,
+    private val restoreWindowBrightness: (Float) -> Unit,
+    private val readStreamVolume: () -> Pair<Int, Int>,          // (current, max)
+    private val writeStreamVolume: (Int) -> Unit,
+    // Side-effect callbacks into the VM:
+    private val doSeekTo: (Long) -> Unit,
+    private val saveBrightness: (Float) -> Unit,
+    private val saveVolume: (Float) -> Unit,
+    private val setCastVolume: (Float) -> Unit,
+    private val dismissDelayMs: Long = GESTURE_BARS_DISMISS_MS,
+) {
+    private val _brightnessOverlay = MutableStateFlow(-1f)
+    val brightnessOverlay: StateFlow<Float> = _brightnessOverlay.asStateFlow()
+
+    private val _volumeOverlay = MutableStateFlow(-1f)
+    val volumeOverlay: StateFlow<Float> = _volumeOverlay.asStateFlow()
+
+    private val _seekPositionMs = MutableStateFlow(0L)
+    val seekPositionMs: StateFlow<Long> = _seekPositionMs.asStateFlow()
+
+    private val _deltaMs = MutableStateFlow(0L)
+    val deltaMs: StateFlow<Long> = _deltaMs.asStateFlow()
+
+    private val _isSeeking = MutableStateFlow(false)
+    val isSeeking: StateFlow<Boolean> = _isSeeking.asStateFlow()
+
+    // Internal gesture state (not exposed to the overlay — not visual).
+    private var startPositionMs: Long = 0L
+    private var initialBrightnessOnGestureStart: Float = -1f
+    private var volumeGestureAccumulator: Float = 0f
+    private var overlayDismissJob: Job? = null
+
+    /** Capture the pre-gesture window brightness so cancel can restore it. */
+    fun onStartGesture() {
+        initialBrightnessOnGestureStart = readWindowBrightness()
+    }
+
+    fun onSeekGesture(totalDeltaMs: Long) {
+        val eng = getEngine() ?: return
+        if (!_isSeeking.value) {
+            startPositionMs = eng.currentPositionMs
+            _isSeeking.value = true
+        }
+        _deltaMs.value = totalDeltaMs
+        val durationMs = eng.durationMs.coerceAtLeast(0)
+        _seekPositionMs.value = GestureSeekMath.seekTarget(
+            startPositionMs = startPositionMs,
+            totalDeltaMs = totalDeltaMs,
+            durationMs = durationMs,
+            swipeSeekMaxMs = getSwipeSeekMaxMs(),
+        )
+    }
+
+    fun onBrightnessGesture(delta: Float) {
+        val current = readWindowBrightness()
+        val target = GestureSeekMath.brightnessTarget(current, delta)
+        writeWindowBrightness(target)
+        _brightnessOverlay.value = target
+    }
+
+    fun onVolumeGesture(delta: Float) {
+        if (isCastConnected()) {
+            // Cast volume: continuous float, applied immediately via setCastVolume.
+            val currentNorm = getCastVolume()
+            volumeGestureAccumulator += delta
+            val newVolume = GestureSeekMath.castVolumeTarget(currentNorm, volumeGestureAccumulator)
+            _volumeOverlay.value = newVolume
+            setCastVolume(newVolume)
+        } else {
+            // Local volume: quantize to discrete hardware steps.
+            val (current, max) = readStreamVolume()
+            if (max <= 0) return
+            val currentNorm = current.toFloat() / max.toFloat()
+            val stepThreshold = 1f / max.toFloat()
+            volumeGestureAccumulator += delta
+            _volumeOverlay.value = (currentNorm + volumeGestureAccumulator).coerceIn(0f, 1f)
+            val (steps, remainder) = GestureSeekMath.localVolumeStep(
+                accumulator = volumeGestureAccumulator,
+                stepThreshold = stepThreshold,
+                maxSteps = max,
+            )
+            if (steps != 0) {
+                volumeGestureAccumulator = remainder
+                val newVol = (current + steps).coerceIn(0, max)
+                writeStreamVolume(newVol)
+            }
+        }
+    }
+
+    /**
+     * Commit path (normal gesture release). Seeks to the clamped target, persists
+     * brightness/volume, then schedules a delayed hide of the visual indicators.
+     */
+    fun onClearOverlays() {
+        if (_isSeeking.value) {
+            doSeekTo(_seekPositionMs.value)
+        }
+        val brightness = _brightnessOverlay.value
+        if (brightness in 0f..1f) {
+            saveBrightness(brightness)
+        }
+        val volume = _volumeOverlay.value
+        if (volume in 0f..1f) {
+            if (isCastConnected()) {
+                // Behavior fix: persist the cast session's volumeOverlay directly.
+                // The old code re-read AudioManager here even on a cast session,
+                // which was a no-op re-read and never persisted the cast volume.
+                saveVolume(volume)
+            } else {
+                val (current, max) = readStreamVolume()
+                if (max > 0) saveVolume(current.toFloat() / max)
+            }
+        }
+        resetGestureState()
+        // Hide the visual indicators after a short delay (persist already happened
+        // synchronously above). Cancels any prior pending dismiss job first.
+        overlayDismissJob?.cancel()
+        overlayDismissJob = scope.launch {
+            delay(dismissDelayMs)
+            _brightnessOverlay.value = -1f
+            _volumeOverlay.value = -1f
+        }
+    }
+
+    /**
+     * Cancel path (multi-touch / pinch-zoom). Discards the in-flight change:
+     * seeks nowhere and restores the pre-gesture window brightness.
+     */
+    fun onCancelOverlays() {
+        // Restore brightness captured at gesture start (or the system default).
+        restoreWindowBrightness(initialBrightnessOnGestureStart)
+        // Cancel any pending dismiss job from a prior gesture so it doesn't fire
+        // redundantly after we've already cleared the overlays here.
+        overlayDismissJob?.cancel()
+        overlayDismissJob = null
+        _brightnessOverlay.value = -1f
+        _volumeOverlay.value = -1f
+        volumeGestureAccumulator = 0f
+        _isSeeking.value = false
+        startPositionMs = 0L
+    }
+
+    private fun resetGestureState() {
+        volumeGestureAccumulator = 0f
+        _isSeeking.value = false
+        startPositionMs = 0L
+    }
+
+    companion object {
+        /** Delay before the gesture bars auto-hide after a commit. */
+        const val GESTURE_BARS_DISMISS_MS: Long = 800L
+    }
+}

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekMath.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekMath.kt
@@ -1,0 +1,53 @@
+package com.raulshma.jellyplay.feature.player.video.state
+
+/**
+ * Pure decision logic for the gesture-seek/volume/brightness overlays, split out
+ * of `VideoPlayerScreen` so it can be unit-tested with zero Android deps.
+ *
+ * This is the logic that previously had **no test coverage** and is the highest
+ * regression risk: the live-stream delta cap, the local-volume step quantize,
+ * and the commit-vs-cancel asymmetry. See [GestureSeekController] for the
+ * stateful wrapper that drives these functions.
+ */
+internal object GestureSeekMath {
+
+    /**
+     * Clamp the live seek delta into a target position.
+     *
+     * VOD clamps to `[0, durationMs]`. Live streams (`durationMs <= 0`) cap the
+     * *per-gesture* delta to `±swipeSeekMaxMs` so a swipe can't jump to a
+     * position that doesn't exist, then floor at 0 (no negative position).
+     */
+    fun seekTarget(
+        startPositionMs: Long,
+        totalDeltaMs: Long,
+        durationMs: Long,
+        swipeSeekMaxMs: Long,
+    ): Long = if (durationMs <= 0L) {
+        val capped = totalDeltaMs.coerceIn(-swipeSeekMaxMs, swipeSeekMaxMs)
+        (startPositionMs + capped).coerceAtLeast(0L)
+    } else {
+        (startPositionMs + totalDeltaMs).coerceIn(0L, durationMs)
+    }
+
+    /**
+     * Local-volume step: quantize the accumulated delta into discrete hardware
+     * steps and return the remainder so fractional motion carries across events.
+     *
+     * Returns `(stepsToApply, remainingAccumulator)`. `steps` is clamped to
+     * `±maxSteps` so a huge single delta can't overshoot the stream range.
+     */
+    fun localVolumeStep(accumulator: Float, stepThreshold: Float, maxSteps: Int): Pair<Int, Float> {
+        if (stepThreshold <= 0f) return 0 to accumulator
+        val steps = (accumulator / stepThreshold).toInt().coerceIn(-maxSteps, maxSteps)
+        return steps to (accumulator - steps * stepThreshold)
+    }
+
+    /** Cast-volume: continuous float, just clamp to `[0,1]`. */
+    fun castVolumeTarget(currentNorm: Float, accumulator: Float): Float =
+        (currentNorm + accumulator).coerceIn(0f, 1f)
+
+    /** Brightness: add the delta, clamp to `[0,1]`. */
+    fun brightnessTarget(current: Float, delta: Float): Float =
+        (current + delta).coerceIn(0f, 1f)
+}

--- a/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/subtitle/SubtitlePreviewRepository.kt
+++ b/feature/player/video/src/main/java/com/raulshma/jellyplay/feature/player/video/subtitle/SubtitlePreviewRepository.kt
@@ -25,7 +25,10 @@ import javax.inject.Singleton
  *  - Image subs (PGS/VOBSUB/DVB) — not text-parseable.
  *
  * Results are memoized per [SubtitleSource.url] for the process lifetime; the
- * caller clears the cache when the active track changes via [clearCache].
+ * caller clears the cache when the active track changes via [clearCache]. The
+ * memo is bounded to [MAX_CACHED_SUBTITLE_TRACKS] entries (access-order LRU) so
+ * previewing many tracks over a long session can't grow it unbounded — an
+ * evicted entry is simply re-parsed on next access (it's network/file-backed).
  */
 @Singleton
 @UnstableApi
@@ -33,7 +36,15 @@ class SubtitlePreviewRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val okHttpClient: OkHttpClient,
 ) {
-    private val cache = mutableMapOf<String, List<TimedCue>>()
+    // Access-order LinkedHashMap: reads (get) re-order to MRU, and
+    // removeEldestEntry evicts the LRU once the cap is exceeded. All access is
+    // confined to withContext(Dispatchers.IO) / clearCache, matching the prior
+    // mutableMapOf concurrency model.
+    private val cache: MutableMap<String, List<TimedCue>> =
+        object : LinkedHashMap<String, List<TimedCue>>(MAX_CACHED_SUBTITLE_TRACKS, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, List<TimedCue>>?): Boolean =
+                size > MAX_CACHED_SUBTITLE_TRACKS
+        }
 
     /**
      * Resolves [source] to its bytes, maps its codec/extension to a MIME type,
@@ -115,6 +126,9 @@ class SubtitlePreviewRepository @Inject constructor(
 
     private companion object {
         const val TAG = "SubtitlePreviewRepo"
+
+        /** Max parsed-track lists held in the memo; LRU-evicted beyond this. */
+        const val MAX_CACHED_SUBTITLE_TRACKS = 8
 
         /** Codec / file-extension names → Media3 text MIME types. */
         val TEXT_MIME_BY_FORMAT = mapOf(

--- a/feature/player/video/src/main/res/values-de/strings.xml
+++ b/feature/player/video/src/main/res/values-de/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">A-Punkt setzen</string>
     <string name="player_video_set_b_point">B-Punkt setzen</string>
     <string name="player_video_clear_ab_repeat">A/B-Wiederholung löschen</string>
+    <string name="player_audio_only">Nur Audio</string>
+    <string name="player_audio_only_on">Nur Audio an — Video ausgeblendet</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">Helligkeit</string>

--- a/feature/player/video/src/main/res/values-es/strings.xml
+++ b/feature/player/video/src/main/res/values-es/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">Definir punto A</string>
     <string name="player_video_set_b_point">Definir punto B</string>
     <string name="player_video_clear_ab_repeat">Borrar repetición A/B</string>
+    <string name="player_audio_only">Solo audio</string>
+    <string name="player_audio_only_on">Solo audio — video oculto</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">Brillo</string>

--- a/feature/player/video/src/main/res/values-fr/strings.xml
+++ b/feature/player/video/src/main/res/values-fr/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">Définir le point A</string>
     <string name="player_video_set_b_point">Définir le point B</string>
     <string name="player_video_clear_ab_repeat">Effacer la répétition A/B</string>
+    <string name="player_audio_only">Audio uniquement</string>
+    <string name="player_audio_only_on">Audio seul — vidéo masquée</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">Luminosité</string>

--- a/feature/player/video/src/main/res/values-it/strings.xml
+++ b/feature/player/video/src/main/res/values-it/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">Imposta punto A</string>
     <string name="player_video_set_b_point">Imposta punto B</string>
     <string name="player_video_clear_ab_repeat">Cancella ripetizione A/B</string>
+    <string name="player_audio_only">Solo audio</string>
+    <string name="player_audio_only_on">Solo audio — video nascosto</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">Luminosità</string>

--- a/feature/player/video/src/main/res/values-ja/strings.xml
+++ b/feature/player/video/src/main/res/values-ja/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">A ポイントを設定</string>
     <string name="player_video_set_b_point">B ポイントを設定</string>
     <string name="player_video_clear_ab_repeat">A/B リピートをクリア</string>
+    <string name="player_audio_only">音声のみ</string>
+    <string name="player_audio_only_on">音声のみ — 動画非表示</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">明るさ</string>

--- a/feature/player/video/src/main/res/values-ko/strings.xml
+++ b/feature/player/video/src/main/res/values-ko/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">A 지점 설정</string>
     <string name="player_video_set_b_point">B 지점 설정</string>
     <string name="player_video_clear_ab_repeat">A/B 반복 지우기</string>
+    <string name="player_audio_only">오디오 전용</string>
+    <string name="player_audio_only_on">오디오 전용 — 영상 숨김</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">밝기</string>

--- a/feature/player/video/src/main/res/values-pt/strings.xml
+++ b/feature/player/video/src/main/res/values-pt/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">Definir ponto A</string>
     <string name="player_video_set_b_point">Definir ponto B</string>
     <string name="player_video_clear_ab_repeat">Limpar repetição A/B</string>
+    <string name="player_audio_only">Som apenas</string>
+    <string name="player_audio_only_on">Som apenas — vídeo oculto</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">Brilho</string>

--- a/feature/player/video/src/main/res/values-zh/strings.xml
+++ b/feature/player/video/src/main/res/values-zh/strings.xml
@@ -169,6 +169,8 @@
     <string name="player_video_set_a_point">设置 A 点</string>
     <string name="player_video_set_b_point">设置 B 点</string>
     <string name="player_video_clear_ab_repeat">清除 A/B 重复</string>
+    <string name="player_audio_only">仅音频</string>
+    <string name="player_audio_only_on">仅音频 — 视频已隐藏</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">亮度</string>

--- a/feature/player/video/src/main/res/values/strings.xml
+++ b/feature/player/video/src/main/res/values/strings.xml
@@ -173,6 +173,8 @@
     <string name="player_video_set_a_point">Set A Point</string>
     <string name="player_video_set_b_point">Set B Point</string>
     <string name="player_video_clear_ab_repeat">Clear A/B Repeat</string>
+    <string name="player_audio_only">Audio only</string>
+    <string name="player_audio_only_on">Audio only on — video hidden</string>
 
     <!-- Video filter sheet -->
     <string name="player_video_brightness">Brightness</string>

--- a/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekControllerTest.kt
+++ b/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekControllerTest.kt
@@ -1,0 +1,230 @@
+package com.raulshma.jellyplay.feature.player.video.state
+
+import com.raulshma.jellyplay.feature.player.video.engine.MediaEngine
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * JVM tests for [GestureSeekController] using fake lambdas (no Compose, no
+ * Android `Window`/`AudioManager`). Pins the commit-vs-cancel asymmetry and the
+ * cast-volume persistence fix.
+ *
+ * Uses the default [runTest] dispatcher (StandardTestDispatcher) so the
+ * dismiss-delay coroutine launched by `onClearOverlays` doesn't run eagerly —
+ * only the dismiss-specific tests advance virtual time.
+ */
+class GestureSeekControllerTest {
+
+    private fun engine(currentPositionMs: Long = 0L, durationMs: Long = 120_000L): MediaEngine =
+        mockk(relaxed = true) {
+            every { this@mockk.currentPositionMs } returns currentPositionMs
+            every { this@mockk.durationMs } returns durationMs
+        }
+
+    private data class FakeIo(
+        var windowBrightness: Float = -1f,
+        var streamCurrent: Int = 5,
+        val streamMax: Int = 10,
+        var restoredBrightness: Float? = null,
+    )
+
+    private fun controller(
+        scope: TestScope,
+        engine: MediaEngine,
+        swipeSeekMaxMs: Long = 120_000L,
+        castConnected: Boolean = false,
+        castVolume: Float = 1f,
+        io: FakeIo = FakeIo(),
+        doSeekTo: (Long) -> Unit = {},
+        saveBrightness: (Float) -> Unit = {},
+        saveVolume: (Float) -> Unit = {},
+        setCastVolume: (Float) -> Unit = {},
+    ) = GestureSeekController(
+        scope = scope,
+        getEngine = { engine },
+        getSwipeSeekMaxMs = { swipeSeekMaxMs },
+        isCastConnected = { castConnected },
+        getCastVolume = { castVolume },
+        readWindowBrightness = { io.windowBrightness },
+        writeWindowBrightness = { io.windowBrightness = it },
+        restoreWindowBrightness = { restored ->
+            io.restoredBrightness = restored
+            io.windowBrightness = if (restored >= 0f) restored else -1f
+        },
+        readStreamVolume = { io.streamCurrent to io.streamMax },
+        writeStreamVolume = { steps -> io.streamCurrent = steps },
+        doSeekTo = doSeekTo,
+        saveBrightness = saveBrightness,
+        saveVolume = saveVolume,
+        setCastVolume = setCastVolume,
+        dismissDelayMs = 800L,
+    )
+
+    // ---- onClearOverlays commits ----
+
+    @Test
+    fun `onClearOverlays seeks to the clamped target`() = runTest {
+        val engine = engine(currentPositionMs = 60_000L, durationMs = 120_000L)
+        var seekTarget: Long? = null
+        val c = controller(this, engine, doSeekTo = { seekTarget = it })
+
+        c.onSeekGesture(30_000L) // 60s + 30s = 90s
+        c.onClearOverlays()
+
+        assertEquals(90_000L, seekTarget)
+    }
+
+    @Test
+    fun `onClearOverlays persists brightness when in range`() = runTest {
+        val engine = engine()
+        val io = FakeIo(windowBrightness = 0.4f)
+        var savedBrightness: Float? = null
+        val c = controller(this, engine, io = io, saveBrightness = { savedBrightness = it })
+
+        c.onBrightnessGesture(0.2f) // 0.4 + 0.2 = 0.6
+        c.onClearOverlays()
+
+        assertEquals(0.6f, savedBrightness!!, 0.0001f)
+    }
+
+    @Test
+    fun `onClearOverlays does not persist brightness when never touched`() = runTest {
+        val engine = engine()
+        var savedBrightness: Float? = null
+        val c = controller(this, engine, saveBrightness = { savedBrightness = it })
+
+        c.onClearOverlays()
+
+        assertEquals(null, savedBrightness)
+    }
+
+    @Test
+    fun `onClearOverlays local volume persists normalized stream volume`() = runTest {
+        val engine = engine()
+        val io = FakeIo(streamCurrent = 5, streamMax = 10)
+        var savedVolume: Float? = null
+        val c = controller(this, engine, io = io, saveVolume = { savedVolume = it })
+
+        c.onVolumeGesture(0.3f) // ~3 steps up → streamCurrent 8
+        c.onClearOverlays()
+
+        // After the gesture, streamCurrent advanced to 8/10.
+        assertEquals(0.8f, savedVolume!!, 0.0001f)
+    }
+
+    @Test
+    fun `onClearOverlays cast volume persists volumeOverlay via saveVolume`() = runTest {
+        // Behavior fix: previously the cast branch re-read AudioManager (a no-op)
+        // and never persisted the cast session's volume. Now it persists volumeOverlay.
+        val engine = engine()
+        var savedVolume: Float? = null
+        val c = controller(this, engine, castConnected = true, castVolume = 0.4f, saveVolume = { savedVolume = it })
+
+        c.onVolumeGesture(0.3f) // 0.4 + 0.3 = 0.7
+        c.onClearOverlays()
+
+        assertEquals(0.7f, savedVolume!!, 0.0001f)
+    }
+
+    @Test
+    fun `onClearOverlays schedules delayed indicator hide`() = runTest {
+        val engine = engine()
+        val io = FakeIo(windowBrightness = 0.5f)
+        val c = controller(this, engine, io = io, saveBrightness = {})
+
+        c.onBrightnessGesture(0.2f)
+        assertEquals(0.7f, c.brightnessOverlay.value, 0.0001f)
+        c.onClearOverlays()
+        // Immediately after commit, the indicator is still visible (delay not elapsed).
+        assertEquals(0.7f, c.brightnessOverlay.value, 0.0001f)
+
+        advanceTimeBy(801L)
+        assertEquals(-1f, c.brightnessOverlay.value, 0.0001f)
+    }
+
+    // ---- onCancelOverlays discards ----
+
+    @Test
+    fun `onCancelOverlays does NOT seek`() = runTest {
+        val engine = engine(currentPositionMs = 60_000L)
+        var seekTarget: Long? = null
+        val c = controller(this, engine, doSeekTo = { seekTarget = it })
+
+        c.onSeekGesture(30_000L)
+        c.onCancelOverlays()
+
+        assertEquals(null, seekTarget)
+    }
+
+    @Test
+    fun `onCancelOverlays restores brightness captured at gesture start`() = runTest {
+        val engine = engine()
+        val io = FakeIo(windowBrightness = 0.3f)
+        val c = controller(this, engine, io = io)
+
+        c.onStartGesture() // captures 0.3f
+        io.windowBrightness = 0.8f // simulate a brightness gesture mid-flight
+        c.onBrightnessGesture(0.1f)
+        c.onCancelOverlays()
+
+        assertEquals(0.3f, io.restoredBrightness!!, 0.0001f)
+    }
+
+    @Test
+    fun `onCancelOverlays clears overlays immediately`() = runTest {
+        val engine = engine()
+        val io = FakeIo(windowBrightness = 0.5f)
+        val c = controller(this, engine, io = io)
+
+        c.onBrightnessGesture(0.2f)
+        c.onVolumeGesture(0.3f)
+        c.onCancelOverlays()
+
+        assertEquals(-1f, c.brightnessOverlay.value, 0.0001f)
+        assertEquals(-1f, c.volumeOverlay.value, 0.0001f)
+        assertEquals(false, c.isSeeking.value)
+    }
+
+    @Test
+    fun `onCancelOverlays cancels pending dismiss job`() = runTest {
+        val engine = engine()
+        val io = FakeIo(windowBrightness = 0.5f)
+        val c = controller(this, engine, io = io, saveBrightness = {})
+
+        c.onBrightnessGesture(0.2f)
+        c.onClearOverlays() // schedules dismiss
+        c.onCancelOverlays() // should cancel it
+        advanceTimeBy(801L)
+        // After cancel + delay, nothing re-hides (already -1f from cancel).
+        assertEquals(-1f, c.brightnessOverlay.value, 0.0001f)
+    }
+
+    // ---- cast vs local volume branches ----
+
+    @Test
+    fun `onVolumeGesture cast branch calls setCastVolume immediately`() = runTest {
+        val engine = engine()
+        var castVol: Float? = null
+        val c = controller(this, engine, castConnected = true, castVolume = 0.4f, setCastVolume = { castVol = it })
+
+        c.onVolumeGesture(0.3f)
+
+        assertEquals(0.7f, castVol!!, 0.0001f)
+    }
+
+    @Test
+    fun `onVolumeGesture local branch quantizes to hardware steps`() = runTest {
+        val engine = engine()
+        val io = FakeIo(streamCurrent = 5, streamMax = 10)
+        val c = controller(this, engine, io = io)
+
+        c.onVolumeGesture(0.3f) // 3 steps → streamCurrent 8
+
+        assertEquals(8, io.streamCurrent)
+    }
+}

--- a/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekMathTest.kt
+++ b/feature/player/video/src/test/java/com/raulshma/jellyplay/feature/player/video/state/GestureSeekMathTest.kt
@@ -1,0 +1,162 @@
+package com.raulshma.jellyplay.feature.player.video.state
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM tests for [GestureSeekMath] — the clamp/accumulator/position math that
+ * previously had zero coverage (`VideoPlayerSeekStateTest` re-implements the
+ * math inline and never calls production code). Pins the live-stream cap, the
+ * VOD clamp, and the volume/brightness clamps.
+ */
+class GestureSeekMathTest {
+
+    // ---- seekTarget ----
+
+    @Test
+    fun `seekTarget VOD clamps to zero`() {
+        val target = GestureSeekMath.seekTarget(
+            startPositionMs = 10_000L,
+            totalDeltaMs = -50_000L,
+            durationMs = 120_000L,
+            swipeSeekMaxMs = 120_000L,
+        )
+        assertEquals(0L, target)
+    }
+
+    @Test
+    fun `seekTarget VOD clamps to duration`() {
+        val target = GestureSeekMath.seekTarget(
+            startPositionMs = 110_000L,
+            totalDeltaMs = 50_000L,
+            durationMs = 120_000L,
+            swipeSeekMaxMs = 120_000L,
+        )
+        assertEquals(120_000L, target)
+    }
+
+    @Test
+    fun `seekTarget VOD applies delta within bounds`() {
+        val target = GestureSeekMath.seekTarget(
+            startPositionMs = 60_000L,
+            totalDeltaMs = 30_000L,
+            durationMs = 120_000L,
+            swipeSeekMaxMs = 120_000L,
+        )
+        assertEquals(90_000L, target)
+    }
+
+    @Test
+    fun `seekTarget live caps per-gesture delta to positive swipeSeekMaxMs`() {
+        // durationMs <= 0 means live: a 500s delta must cap at swipeSeekMaxMs (120s).
+        val target = GestureSeekMath.seekTarget(
+            startPositionMs = 1_000L,
+            totalDeltaMs = 500_000L,
+            durationMs = 0L,
+            swipeSeekMaxMs = 120_000L,
+        )
+        assertEquals(121_000L, target)
+    }
+
+    @Test
+    fun `seekTarget live caps per-gesture delta to negative swipeSeekMaxMs`() {
+        val target = GestureSeekMath.seekTarget(
+            startPositionMs = 100_000L,
+            totalDeltaMs = -500_000L,
+            durationMs = -1L,
+            swipeSeekMaxMs = 120_000L,
+        )
+        assertEquals(0L, target) // capped to -120s → -20s → floored at 0
+    }
+
+    @Test
+    fun `seekTarget live floors at zero`() {
+        val target = GestureSeekMath.seekTarget(
+            startPositionMs = 5_000L,
+            totalDeltaMs = -120_000L,
+            durationMs = 0L,
+            swipeSeekMaxMs = 120_000L,
+        )
+        assertEquals(0L, target)
+    }
+
+    // ---- localVolumeStep ----
+
+    @Test
+    fun `localVolumeStep quantizes positive accumulation to whole steps`() {
+        // accumulator 0.3 with threshold 0.1 → 3 steps, 0 remainder.
+        val (steps, remainder) = GestureSeekMath.localVolumeStep(accumulator = 0.3f, stepThreshold = 0.1f, maxSteps = 15)
+        assertEquals(3, steps)
+        assertEquals(0f, remainder, 0.0001f)
+    }
+
+    @Test
+    fun `localVolumeStep quantizes negative accumulation`() {
+        val (steps, remainder) = GestureSeekMath.localVolumeStep(accumulator = -0.25f, stepThreshold = 0.1f, maxSteps = 15)
+        assertEquals(-2, steps)
+        assertEquals(-0.05f, remainder, 0.0001f)
+    }
+
+    @Test
+    fun `localVolumeStep carries fractional remainder`() {
+        // accumulator 0.15 with threshold 0.1 → 1 step, 0.05 remainder.
+        val (steps, remainder) = GestureSeekMath.localVolumeStep(accumulator = 0.15f, stepThreshold = 0.1f, maxSteps = 15)
+        assertEquals(1, steps)
+        assertEquals(0.05f, remainder, 0.0001f)
+    }
+
+    @Test
+    fun `localVolumeStep zero accumulator yields zero steps`() {
+        val (steps, remainder) = GestureSeekMath.localVolumeStep(accumulator = 0f, stepThreshold = 0.1f, maxSteps = 15)
+        assertEquals(0, steps)
+        assertEquals(0f, remainder, 0.0001f)
+    }
+
+    @Test
+    fun `localVolumeStep clamps to maxSteps`() {
+        // A huge delta can't overshoot the stream range.
+        val (steps, _) = GestureSeekMath.localVolumeStep(accumulator = 100f, stepThreshold = 0.1f, maxSteps = 15)
+        assertEquals(15, steps)
+    }
+
+    @Test
+    fun `localVolumeStep zero threshold is a no-op`() {
+        val (steps, remainder) = GestureSeekMath.localVolumeStep(accumulator = 0.5f, stepThreshold = 0f, maxSteps = 15)
+        assertEquals(0, steps)
+        assertEquals(0.5f, remainder, 0.0001f)
+    }
+
+    // ---- castVolumeTarget ----
+
+    @Test
+    fun `castVolumeTarget clamps above 1`() {
+        assertEquals(1f, GestureSeekMath.castVolumeTarget(currentNorm = 0.9f, accumulator = 0.5f), 0.0001f)
+    }
+
+    @Test
+    fun `castVolumeTarget clamps below 0`() {
+        assertEquals(0f, GestureSeekMath.castVolumeTarget(currentNorm = 0.1f, accumulator = -0.5f), 0.0001f)
+    }
+
+    @Test
+    fun `castVolumeTarget applies delta in range`() {
+        assertEquals(0.6f, GestureSeekMath.castVolumeTarget(currentNorm = 0.4f, accumulator = 0.2f), 0.0001f)
+    }
+
+    // ---- brightnessTarget ----
+
+    @Test
+    fun `brightnessTarget clamps above 1`() {
+        assertEquals(1f, GestureSeekMath.brightnessTarget(current = 0.9f, delta = 0.5f), 0.0001f)
+    }
+
+    @Test
+    fun `brightnessTarget clamps below 0`() {
+        assertEquals(0f, GestureSeekMath.brightnessTarget(current = 0.1f, delta = -0.5f), 0.0001f)
+    }
+
+    @Test
+    fun `brightnessTarget applies delta in range`() {
+        assertEquals(0.55f, GestureSeekMath.brightnessTarget(current = 0.3f, delta = 0.25f), 0.0001f)
+    }
+}

--- a/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestListItem.kt
+++ b/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestListItem.kt
@@ -1,7 +1,7 @@
 package com.raulshma.jellyplay.feature.requests
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,11 +51,14 @@ fun RequestListItem(
     mediaInfo: RequestMediaInfo?,
     isAdmin: Boolean,
     actionInProgress: Boolean,
+    selectionMode: Boolean = false,
+    isSelected: Boolean = false,
     onApprove: () -> Unit = {},
     onDecline: () -> Unit = {},
     onRetry: () -> Unit = {},
     onDelete: () -> Unit = {},
     onClick: () -> Unit = {},
+    onLongClick: () -> Unit = {},
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val requestStatus = remember(request.status) { SeerrRequestStatus.fromValue(request.status) }
@@ -93,9 +96,13 @@ fun RequestListItem(
             .fillMaxWidth()
             .clip(ShapeCache.smooth16)
             .focusIndicator()
-            .clickable { onClick() },
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+            ),
         shape = ShapeCache.smooth16,
-        color = colorScheme.surfaceContainer.copy(alpha = 0.6f),
+        color = if (isSelected) colorScheme.primaryContainer.copy(alpha = 0.5f)
+        else colorScheme.surfaceContainer.copy(alpha = 0.6f),
         tonalElevation = 1.dp,
     ) {
         Row(
@@ -104,6 +111,26 @@ fun RequestListItem(
                 .padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            // Selection checkbox — only rendered while in selection mode.
+            if (selectionMode) {
+                Box(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(CircleShape)
+                        .background(if (isSelected) colorScheme.primary else colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (isSelected) {
+                        Text(
+                            "✓",
+                            color = colorScheme.onPrimary,
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                    }
+                }
+                Spacer(Modifier.width(12.dp))
+            }
             Box(
                 modifier = Modifier
                     .size(width = 48.dp, height = 72.dp)

--- a/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestsFilterBar.kt
+++ b/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestsFilterBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -37,23 +38,27 @@ import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.seerr.SeerrRequestFilter
 import com.raulshma.jellyplay.core.model.seerr.SeerrRequestSort
 import com.raulshma.jellyplay.core.ui.animation.horizontalFadingEdges
+import com.raulshma.jellyplay.core.ui.components.SearchField
 import com.raulshma.jellyplay.core.ui.components.focusIndicator
 import com.raulshma.jellyplay.feature.requests.R
 
 @Composable
 fun RequestsFilterBar(
-    currentFilter: SeerrRequestFilter,
-    currentMediaType: String?,
-    currentSort: SeerrRequestSort,
-    currentSortDirection: String,
-    showMyRequestsOnly: Boolean,
+    filters: RequestsFilterState,
     isAdmin: Boolean,
     onFilterChange: (SeerrRequestFilter) -> Unit,
     onMediaTypeChange: (String?) -> Unit,
     onSortChange: (SeerrRequestSort) -> Unit,
     onSortDirectionToggle: () -> Unit,
     onMyRequestsToggle: () -> Unit,
+    onSearchChange: (String) -> Unit,
 ) {
+    val currentFilter = filters.filter
+    val currentMediaType = filters.mediaType
+    val currentSort = filters.sort
+    val currentSortDirection = filters.sortDirection
+    val showMyRequestsOnly = filters.showMyRequestsOnly
+    val searchQuery = filters.searchQuery
     val colorScheme = MaterialTheme.colorScheme
     val filterScrollState = rememberScrollState()
     val optionsScrollState = rememberScrollState()
@@ -64,6 +69,14 @@ fun RequestsFilterBar(
             .padding(horizontal = 16.dp, vertical = 6.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
+        // Free-text search. Debounced at the VM layer so each keystroke
+        // doesn't fire a request.
+        SearchField(
+            value = searchQuery,
+            onValueChange = onSearchChange,
+            placeholder = stringResource(R.string.requests_search_placeholder),
+        )
+
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestsScreen.kt
+++ b/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestsScreen.kt
@@ -45,6 +45,7 @@ import com.composables.icons.tabler.outline.ArrowLeft
 import com.composables.icons.tabler.outline.ChevronLeft
 import com.composables.icons.tabler.outline.ChevronRight
 import com.composables.icons.tabler.outline.Inbox
+import com.composables.icons.tabler.outline.X
 import com.raulshma.jellyplay.core.designsystem.theme.ShapeCache
 import com.raulshma.jellyplay.core.model.seerr.SeerrRequestItem
 import com.raulshma.jellyplay.core.ui.components.JellyPlayCircularProgressIndicator
@@ -86,17 +87,14 @@ fun RequestsScreen(
                 modifier = Modifier.fillMaxSize(),
             ) {
                 RequestsFilterBar(
-                    currentFilter = state.filter,
-                    currentMediaType = state.mediaType,
-                    currentSort = state.sort,
-                    currentSortDirection = state.sortDirection,
-                    showMyRequestsOnly = state.showMyRequestsOnly,
+                    filters = state.filters,
                     isAdmin = isAdmin,
                     onFilterChange = { viewModel.setFilter(it) },
                     onMediaTypeChange = { viewModel.setMediaType(it) },
                     onSortChange = { viewModel.setSort(it) },
                     onSortDirectionToggle = { viewModel.toggleSortDirection() },
                     onMyRequestsToggle = { viewModel.toggleMyRequestsOnly() },
+                    onSearchChange = { viewModel.setSearchQuery(it) },
                 )
 
                 PullToRefreshBox(
@@ -177,11 +175,17 @@ fun RequestsScreen(
                                     mediaInfo = state.mediaInfo[request.media.tmdbId],
                                     isAdmin = isAdmin,
                                     actionInProgress = state.actionInProgress,
+                                    selectionMode = state.selectionMode,
+                                    isSelected = request.id in state.selectedRequestIds,
                                     onApprove = { viewModel.approveRequest(request.id) },
                                     onDecline = { viewModel.declineRequest(request.id) },
                                     onRetry = { viewModel.retryRequest(request.id) },
                                     onDelete = { viewModel.deleteRequest(request.id) },
-                                    onClick = { selectedRequest = request },
+                                    onClick = {
+                                        if (state.selectionMode) viewModel.toggleSelection(request)
+                                        else selectedRequest = request
+                                    },
+                                    onLongClick = { viewModel.toggleSelection(request) },
                                 )
                             }
                             item {
@@ -292,6 +296,80 @@ fun RequestsScreen(
                         onNavigateToDetail(tmdbId, mediaType)
                         selectedRequest = null
                     },
+                )
+            }
+
+            // Bulk-selection action bar.
+            if (state.selectionMode) {
+                SelectionActionBar(
+                    selectedCount = state.selectedRequestIds.size,
+                    actionInProgress = state.actionInProgress,
+                    onSelectAll = { viewModel.selectAll() },
+                    onClear = { viewModel.clearSelection() },
+                    onApprove = { viewModel.approveSelected() },
+                    onDecline = { viewModel.declineSelected() },
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectionActionBar(
+    selectedCount: Int,
+    actionInProgress: Boolean,
+    onSelectAll: () -> Unit,
+    onClear: () -> Unit,
+    onApprove: () -> Unit,
+    onDecline: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    androidx.compose.material3.Surface(
+        modifier = modifier,
+        shape = ShapeCache.smooth16,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        tonalElevation = 3.dp,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.requests_selected_count, selectedCount),
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f),
+            )
+            androidx.compose.material3.TextButton(onClick = onSelectAll, enabled = !actionInProgress) {
+                Text(stringResource(R.string.requests_select_all))
+            }
+            androidx.compose.material3.FilledTonalButton(
+                onClick = onApprove,
+                enabled = !actionInProgress && selectedCount > 0,
+            ) {
+                Text(stringResource(R.string.requests_action_approve))
+            }
+            androidx.compose.material3.FilledTonalButton(
+                onClick = onDecline,
+                enabled = !actionInProgress && selectedCount > 0,
+                colors = androidx.compose.material3.ButtonDefaults.filledTonalButtonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+            ) {
+                Text(stringResource(R.string.requests_action_decline))
+            }
+            androidx.compose.material3.IconButton(onClick = onClear, enabled = !actionInProgress) {
+                Icon(
+                    Tabler.Outline.X,
+                    contentDescription = stringResource(com.raulshma.jellyplay.core.ui.R.string.core_cancel),
                 )
             }
         }

--- a/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestsViewModel.kt
+++ b/feature/requests/src/main/java/com/raulshma/jellyplay/feature/requests/RequestsViewModel.kt
@@ -2,6 +2,7 @@ package com.raulshma.jellyplay.feature.requests
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.snapshotFlow
 import com.raulshma.jellyplay.core.data.repository.ArrRepository
 import com.raulshma.jellyplay.core.data.repository.SeerrRepository
 import com.raulshma.jellyplay.core.datastore.experimental.ExperimentalStore
@@ -16,7 +17,10 @@ import com.raulshma.jellyplay.core.model.seerr.SeerrRequestItem
 import com.raulshma.jellyplay.core.model.seerr.SeerrRequestSort
 import com.raulshma.jellyplay.core.ui.viewmodel.JellyPlayViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -50,10 +54,42 @@ data class RequestsUiState(
     val sortDirection: String = "desc",
     val mediaType: String? = null,
     val showMyRequestsOnly: Boolean = false,
+    /** Free-text search term forwarded to the Seerr `search` query param. */
+    val searchQuery: String = "",
     val actionInProgress: Boolean = false,
+    /** Selection-mode state for bulk approve/decline. */
+    val selectionMode: Boolean = false,
+    val selectedRequestIds: Set<Int> = emptySet(),
     val actionError: String? = null,
+) {
+    /** The filter-axis fields, bundled for hand-off to [RequestsFilterBar]. */
+    val filters: RequestsFilterState
+        get() = RequestsFilterState(
+            filter = filter,
+            mediaType = mediaType,
+            sort = sort,
+            sortDirection = sortDirection,
+            showMyRequestsOnly = showMyRequestsOnly,
+            searchQuery = searchQuery,
+        )
+}
+
+/**
+ * The six request-filter fields that travel together from
+ * [RequestsUiState] into [RequestsFilterBar]. Kept as a value so the bar's
+ * signature is one parameter (plus the callbacks) rather than six loose ones.
+ */
+@Immutable
+data class RequestsFilterState(
+    val filter: SeerrRequestFilter = SeerrRequestFilter.PENDING,
+    val mediaType: String? = null,
+    val sort: SeerrRequestSort = SeerrRequestSort.ADDED,
+    val sortDirection: String = "desc",
+    val showMyRequestsOnly: Boolean = false,
+    val searchQuery: String = "",
 )
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class RequestsViewModel @Inject constructor(
     private val seerrRepository: SeerrRepository,
@@ -102,6 +138,14 @@ class RequestsViewModel @Inject constructor(
             }
             loadRequests(refresh = true)
         }
+        // Debounced search: re-runs the query 400ms after the user stops typing,
+        // so each keystroke doesn't hit the Seerr API.
+        launch {
+            snapshotFlow { _state.value.searchQuery }
+                .distinctUntilChanged()
+                .debounce(400)
+                .collect { loadRequests(refresh = true) }
+        }
     }
 
     override fun onCleared() {
@@ -126,6 +170,7 @@ class RequestsViewModel @Inject constructor(
                 sortDirection = s.sortDirection,
                 requestedBy = requestedBy,
                 mediaType = s.mediaType,
+                search = s.searchQuery.takeIf { it.isNotBlank() },
             ).onSuccess { response ->
                 _state.value = _state.value.copy(
                     requests = response.results,
@@ -286,6 +331,67 @@ class RequestsViewModel @Inject constructor(
         val newValue = !_state.value.showMyRequestsOnly
         _state.value = _state.value.copy(showMyRequestsOnly = newValue, currentPage = 1)
         loadRequests(refresh = true)
+    }
+
+    /**
+     * Updates the free-text [searchQuery]. The actual request is fired on a
+     * 400ms debounce (collected in [init]) so each keystroke doesn't hit the
+     * Seerr API. Clears back to page 1.
+     */
+    fun setSearchQuery(query: String) {
+        _state.value = _state.value.copy(searchQuery = query, currentPage = 1)
+    }
+
+    fun clearSearch() {
+        if (_state.value.searchQuery.isBlank()) return
+        _state.value = _state.value.copy(searchQuery = "", currentPage = 1)
+        loadRequests(refresh = true)
+    }
+
+    // ── Bulk selection ──────────────────────────────────────────────────────
+
+    /** Toggles [request]'s membership in the selection; enters selection mode on first pick. */
+    fun toggleSelection(request: SeerrRequestItem) {
+        val current = _state.value.selectedRequestIds
+        val next = if (request.id in current) current - request.id else current + request.id
+        _state.value = _state.value.copy(
+            selectedRequestIds = next,
+            selectionMode = next.isNotEmpty(),
+        )
+    }
+
+    fun selectAll() {
+        _state.value = _state.value.copy(
+            selectedRequestIds = _state.value.requests.map { it.id }.toSet(),
+            selectionMode = true,
+        )
+    }
+
+    fun clearSelection() {
+        _state.value = _state.value.copy(selectedRequestIds = emptySet(), selectionMode = false)
+    }
+
+    /** Approves every selected request; clears selection + refreshes on completion. */
+    fun approveSelected() = runBulk { id -> seerrRepository.approveRequest(id) }
+
+    /** Declines every selected request; clears selection + refreshes on completion. */
+    fun declineSelected() = runBulk { id -> seerrRepository.declineRequest(id) }
+
+    /**
+     * Shared body for [approveSelected] / [declineSelected]: flips
+     * [actionInProgress], runs [action] against each selected id, then clears
+     * selection and refreshes the list. Per-item failures are surfaced inside
+     * the Seerr result by the repository; here we only drive the fan-out.
+     */
+    private fun runBulk(action: suspend (Int) -> Unit) {
+        val ids = _state.value.selectedRequestIds.toList()
+        if (ids.isEmpty()) return
+        launch {
+            _state.value = _state.value.copy(actionInProgress = true, actionError = null)
+            ids.forEach { id -> action(id) }
+            _state.value = _state.value.copy(actionInProgress = false, selectedRequestIds = emptySet(), selectionMode = false)
+            loadRequests(refresh = true)
+        }
     }
 
     fun nextPage() {

--- a/feature/requests/src/main/res/values-de/strings.xml
+++ b/feature/requests/src/main/res/values-de/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">Geändert</string>
     <string name="requests_filter_mine">Meine</string>
     <string name="requests_cd_sort_direction">Sortierrichtung</string>
+    <string name="requests_search_placeholder">Anfragen durchsuchen</string>
 
     <string name="requests_status_declined">Abgelehnt</string>
     <string name="requests_status_failed">Fehlgeschlagen</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">Genehmigen</string>
     <string name="requests_action_decline">Ablehnen</string>
+    <string name="requests_selected_count">%1$d ausgewählt</string>
+    <string name="requests_select_all">Alle auswählen</string>
     <string name="requests_action_delete">Löschen</string>
     <string name="requests_action_delete_confirm">Sicher?</string>
 

--- a/feature/requests/src/main/res/values-es/strings.xml
+++ b/feature/requests/src/main/res/values-es/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">Modificadas</string>
     <string name="requests_filter_mine">Mías</string>
     <string name="requests_cd_sort_direction">Dirección de orden</string>
+    <string name="requests_search_placeholder">Buscar solicitudes</string>
 
     <string name="requests_status_declined">Rechazada</string>
     <string name="requests_status_failed">Fallida</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">Aprobar</string>
     <string name="requests_action_decline">Rechazar</string>
+    <string name="requests_selected_count">%1$d seleccionados</string>
+    <string name="requests_select_all">Seleccionar todo</string>
     <string name="requests_action_delete">Eliminar</string>
     <string name="requests_action_delete_confirm">¿Seguro?</string>
 

--- a/feature/requests/src/main/res/values-fr/strings.xml
+++ b/feature/requests/src/main/res/values-fr/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">Modifiées</string>
     <string name="requests_filter_mine">Les miennes</string>
     <string name="requests_cd_sort_direction">Direction du tri</string>
+    <string name="requests_search_placeholder">Rechercher des demandes</string>
 
     <string name="requests_status_declined">Refusée</string>
     <string name="requests_status_failed">Échouée</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">Approuver</string>
     <string name="requests_action_decline">Refuser</string>
+    <string name="requests_selected_count">%1$d sélectionné(s)</string>
+    <string name="requests_select_all">Tout sélectionner</string>
     <string name="requests_action_delete">Supprimer</string>
     <string name="requests_action_delete_confirm">Sûr ?</string>
 

--- a/feature/requests/src/main/res/values-it/strings.xml
+++ b/feature/requests/src/main/res/values-it/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">Modificate</string>
     <string name="requests_filter_mine">Mie</string>
     <string name="requests_cd_sort_direction">Direzione di ordinamento</string>
+    <string name="requests_search_placeholder">Cerca richieste</string>
 
     <string name="requests_status_declined">Rifiutata</string>
     <string name="requests_status_failed">Non riuscita</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">Approva</string>
     <string name="requests_action_decline">Rifiuta</string>
+    <string name="requests_selected_count">%1$d selezionati</string>
+    <string name="requests_select_all">Seleziona tutto</string>
     <string name="requests_action_delete">Elimina</string>
     <string name="requests_action_delete_confirm">Sicuro?</string>
 

--- a/feature/requests/src/main/res/values-ja/strings.xml
+++ b/feature/requests/src/main/res/values-ja/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">変更順</string>
     <string name="requests_filter_mine">自分</string>
     <string name="requests_cd_sort_direction">並び替えの方向</string>
+    <string name="requests_search_placeholder">リクエストを検索</string>
 
     <string name="requests_status_declined">却下</string>
     <string name="requests_status_failed">失敗</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">承認</string>
     <string name="requests_action_decline">却下</string>
+    <string name="requests_selected_count">%1$d件選択中</string>
+    <string name="requests_select_all">すべて選択</string>
     <string name="requests_action_delete">削除</string>
     <string name="requests_action_delete_confirm">本当ですか？</string>
 

--- a/feature/requests/src/main/res/values-ko/strings.xml
+++ b/feature/requests/src/main/res/values-ko/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">수정됨</string>
     <string name="requests_filter_mine">내 요청</string>
     <string name="requests_cd_sort_direction">정렬 방향</string>
+    <string name="requests_search_placeholder">요청 검색</string>
 
     <string name="requests_status_declined">거부됨</string>
     <string name="requests_status_failed">실패</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">승인</string>
     <string name="requests_action_decline">거부</string>
+    <string name="requests_selected_count">%1$d개 선택됨</string>
+    <string name="requests_select_all">모두 선택</string>
     <string name="requests_action_delete">삭제</string>
     <string name="requests_action_delete_confirm">확실합니까?</string>
 

--- a/feature/requests/src/main/res/values-pt/strings.xml
+++ b/feature/requests/src/main/res/values-pt/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">Modificados</string>
     <string name="requests_filter_mine">Meus</string>
     <string name="requests_cd_sort_direction">Direção da ordenação</string>
+    <string name="requests_search_placeholder">Pesquisar pedidos</string>
 
     <string name="requests_status_declined">Recusado</string>
     <string name="requests_status_failed">Falhou</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">Aprovar</string>
     <string name="requests_action_decline">Recusar</string>
+    <string name="requests_selected_count">%1$d selecionado(s)</string>
+    <string name="requests_select_all">Selecionar tudo</string>
     <string name="requests_action_delete">Excluir</string>
     <string name="requests_action_delete_confirm">Certeza?</string>
 

--- a/feature/requests/src/main/res/values-zh/strings.xml
+++ b/feature/requests/src/main/res/values-zh/strings.xml
@@ -25,6 +25,7 @@
     <string name="requests_sort_modified">已修改</string>
     <string name="requests_filter_mine">我的</string>
     <string name="requests_cd_sort_direction">排序方向</string>
+    <string name="requests_search_placeholder">搜索请求</string>
 
     <string name="requests_status_declined">已拒绝</string>
     <string name="requests_status_failed">失败</string>
@@ -39,6 +40,8 @@
 
     <string name="requests_action_approve">批准</string>
     <string name="requests_action_decline">拒绝</string>
+    <string name="requests_selected_count">已选择 %1$d 项</string>
+    <string name="requests_select_all">全选</string>
     <string name="requests_action_delete">删除</string>
     <string name="requests_action_delete_confirm">确定吗？</string>
 

--- a/feature/requests/src/main/res/values/strings.xml
+++ b/feature/requests/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="requests_sort_modified">Modified</string>
     <string name="requests_filter_mine">Mine</string>
     <string name="requests_cd_sort_direction">Sort direction</string>
+    <string name="requests_search_placeholder">Search requests</string>
 
     <!-- Item / status labels -->
     <string name="requests_status_declined">Declined</string>
@@ -44,6 +45,8 @@
     <!-- Item actions -->
     <string name="requests_action_approve">Approve</string>
     <string name="requests_action_decline">Decline</string>
+    <string name="requests_selected_count">%1$d selected</string>
+    <string name="requests_select_all">Select all</string>
     <string name="requests_action_delete">Delete</string>
     <string name="requests_action_delete_confirm">Sure?</string>
 

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AboutScreen.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AboutScreen.kt
@@ -269,6 +269,14 @@ fun AboutScreen(
                     checked = viewModel.selfUpdateCheckEnabled,
                     onCheckedChange = { viewModel.updateSelfUpdateCheckPref(it) },
                 )
+                SettingToggleItem(
+                    icon = Tabler.Outline.Download,
+                    title = stringResource(R.string.settings_download_updates_automatically),
+                    subtitle = stringResource(R.string.settings_download_updates_subtitle),
+                    checked = viewModel.selfUpdateDownloadEnabled,
+                    enabled = viewModel.selfUpdateCheckEnabled,
+                    onCheckedChange = { viewModel.updateSelfUpdateDownloadPref(it) },
+                )
                 if (viewModel.selfUpdateCheckEnabled) {
                     SettingListItem(
                         icon = Tabler.Outline.Refresh,

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AboutViewModel.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AboutViewModel.kt
@@ -54,11 +54,15 @@ class AboutViewModel @Inject constructor(
     var selfUpdateCheckEnabled by composeState(true)
         private set
 
+    var selfUpdateDownloadEnabled by composeState(false)
+        private set
+
     init {
         loadServerInfo()
         launch {
             experimentalStore.experimental.collect { prefs ->
                 selfUpdateCheckEnabled = prefs.selfUpdateCheckEnabled
+                selfUpdateDownloadEnabled = prefs.selfUpdateDownloadEnabled
             }
         }
     }
@@ -93,6 +97,10 @@ class AboutViewModel @Inject constructor(
 
     fun updateSelfUpdateCheckPref(enabled: Boolean) {
         launch { experimentalStore.setSelfUpdateCheckEnabled(enabled) }
+    }
+
+    fun updateSelfUpdateDownloadPref(enabled: Boolean) {
+        launch { experimentalStore.setSelfUpdateDownloadEnabled(enabled) }
     }
 
     private fun collectLogs(): Uri? {

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AppearanceSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AppearanceSettingsScreen.kt
@@ -809,6 +809,16 @@ fun AppearanceSettingsScreen(
                     )
 
                     SettingToggleItem(
+                        icon = Tabler.Outline.AlertTriangle,
+                        title = stringResource(R.string.settings_confirm_library_reset),
+                        subtitle = stringResource(R.string.settings_confirm_library_reset_subtitle),
+                        checked = preferences.confirmLibraryReset,
+                        highlighted = highlightSettingId == "confirm_library_reset",
+                        index = cardIdx++, count = cardTotal,
+                        onCheckedChange = { viewModel.setConfirmLibraryReset(it) },
+                    )
+
+                    SettingToggleItem(
                         icon = Tabler.Outline.PlayerSkipForward,
                         title = stringResource(R.string.settings_skip_special_episodes),
                         subtitle = stringResource(R.string.settings_skip_special_episodes_subtitle),

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AppearanceSettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/AppearanceSettingsViewModel.kt
@@ -97,6 +97,8 @@ class AppearanceSettingsViewModel @Inject constructor(
         editor.edit { library.setSkipSpecials(enabled) }
     fun setCompactEpisodeList(enabled: Boolean) =
         editor.edit { library.setCompactEpisodeList(enabled) }
+    fun setConfirmLibraryReset(enabled: Boolean) =
+        editor.edit { library.setConfirmLibraryReset(enabled) }
     fun setLibraryViewMode(mode: LibraryViewMode) =
         editor.edit { library.setLibraryViewMode(mode) }
     fun setShowShareMediaOption(enabled: Boolean) =

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/PreferenceCategoryPresentation.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/PreferenceCategoryPresentation.kt
@@ -413,6 +413,7 @@ private fun experimentalFields(prefs: UserPreferences, factory: UserPreferences)
 private fun miscAppFields(prefs: UserPreferences, factory: UserPreferences): List<PreferenceField> = listOf(
     PreferenceField("Haptics", prefs.hapticsEnabled.onOff(), factory.hapticsEnabled.onOff()),
     PreferenceField("Self-Update Check", prefs.selfUpdateCheckEnabled.onOff(), factory.selfUpdateCheckEnabled.onOff()),
+    PreferenceField("Self-Update Auto Download", prefs.selfUpdateDownloadEnabled.onOff(), factory.selfUpdateDownloadEnabled.onOff()),
     PreferenceField("App Language", prefs.appLanguage ?: "System", factory.appLanguage ?: "System"),
     PreferenceField("User Data Sync", prefs.userDataSyncEnabled.onOff(), factory.userDataSyncEnabled.onOff()),
     PreferenceField("Share Media Option", prefs.showShareMediaOption.onOff(), factory.showShareMediaOption.onOff()),

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsScreen.kt
@@ -887,6 +887,8 @@ fun SettingsScreen(
                                 title = stringResource(R.string.settings_requests),
                                 subtitle = stringResource(R.string.settings_requests_subtitle),
                                 index = 4, count = insightsCount,
+                                trailingText = viewModel.pendingRequestCount.collectAsStateWithLifecycle().value
+                                    .takeIf { it > 0 }?.toString(),
                                 highlighted = lastClickedSettingId == "requests",
                                 onClick = {
                                     lastClickedSettingId = "requests"

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import com.raulshma.jellyplay.core.data.repository.AuthRepository
+import com.raulshma.jellyplay.core.data.repository.SeerrRepository
 import com.raulshma.jellyplay.core.datastore.BackupSliceKey
 import com.raulshma.jellyplay.core.datastore.LegacySettingsBackup
 import com.raulshma.jellyplay.core.datastore.PreferencesEditor
@@ -46,6 +47,7 @@ class SettingsViewModel @Inject constructor(
     private val preferencesStore: UserPreferencesStore,
     private val projections: PreferenceProjections,
     private val authRepository: AuthRepository,
+    private val seerrRepository: SeerrRepository,
     private val apiClient: com.raulshma.jellyplay.core.network.JellyfinApiClient,
     private val editor: PreferencesEditor,
 ) : JellyPlayViewModel() {
@@ -82,6 +84,9 @@ class SettingsViewModel @Inject constructor(
     val currentServerAddress = authRepository.currentServer
         .map { it?.address ?: "" }
         .stateIn(scope, SharingStarted.WhileSubscribed(5_000), "")
+
+    val pendingRequestCount: kotlinx.coroutines.flow.StateFlow<Int> = seerrRepository.pendingRequestCount
+        .stateIn(scope, SharingStarted.WhileSubscribed(5_000), 0)
 
     var activeSessions by composeState<List<com.raulshma.jellyplay.core.model.SessionInfo>>(emptyList())
         private set
@@ -122,6 +127,7 @@ class SettingsViewModel @Inject constructor(
                 isLoadingUsers = false
             }
         }
+        seerrRepository.startPolling()
     }
 
     /**
@@ -212,6 +218,7 @@ class SettingsViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         sessionRefreshJob?.cancel()
+        seerrRepository.stopPolling()
     }
 
     fun setShowAdvancedSettings(enabled: Boolean) {

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/StorageSettingsScreen.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/StorageSettingsScreen.kt
@@ -63,7 +63,7 @@ private fun streamingQualityLabelRes(quality: StreamingQuality): Int = when (qua
 
 private val STORAGE_CACHE_GROUP_IDS = setOf("clear_cache", "clear_image_cache", "wifi_only_downloads", "download_connections", "max_concurrent_downloads", "auto_delete_cache", "max_cache_size")
 private val STORAGE_NETWORK_GROUP_IDS = setOf("offline_mode", "auto_offline", "adaptive_bitrate", "bandwidth_cap", "metered_network_behavior", "cellular_streaming_quality", "cellular_download_warning", "data_saver", "network_timeout", "verbose_logging", "user_data_sync")
-private val STORAGE_DOWNLOADS_GROUP_IDS = setOf("download_quality", "smart_downloads", "auto_download_new_episodes", "download_schedule", "download_schedule_start", "download_schedule_end", "download_schedule_wifi_only", "max_download_storage_limit", "download_storage_location")
+private val STORAGE_DOWNLOADS_GROUP_IDS = setOf("download_quality", "smart_downloads", "auto_download_new_episodes", "download_schedule", "download_schedule_start", "download_schedule_end", "download_schedule_wifi_only", "max_download_storage_limit", "download_storage_location", "auto_delete_after_watch")
 
 @OptIn(ExperimentalMaterial3Api::class, androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
@@ -495,7 +495,7 @@ fun StorageSettingsScreen(
                     modifier = Modifier.padding(vertical = 8.dp),
                     initiallyExpanded = true,
                 ) {
-                    val downloadTotal = 7
+                    val downloadTotal = 8
                     var downloadIdx = 0
 
                     val downloadQualityTitle = stringResource(R.string.settings_download_quality)
@@ -624,23 +624,62 @@ fun StorageSettingsScreen(
 
                     val internalLabel = stringResource(R.string.settings_storage_internal)
                     val externalLabel = stringResource(R.string.settings_storage_external)
+                    val sdCardLabel = stringResource(R.string.storage_sd_card)
                     val storageLocationTitle = stringResource(R.string.settings_download_storage_location)
+                    // Build the picker from the *real*
+                    // available mounts (primary + any SD/USB) instead of the
+                    // hardcoded INTERNAL/EXTERNAL pair. Falls back to the
+                    // legacy pair if mount enumeration hasn't resolved yet.
+                    // NOTE: string resolution happens here in the @Composable
+                    // body; the lambda below only closes over the resolved
+                    // CharSequences so it can be invoked from non-composable
+                    // callbacks (onClick) too.
+                    val mounts = viewModel.storageMounts
+                    val mountLabel = { kind: com.raulshma.jellyplay.core.data.repository.StorageMountKind ->
+                        when (kind) {
+                            com.raulshma.jellyplay.core.data.repository.StorageMountKind.INTERNAL -> internalLabel
+                            com.raulshma.jellyplay.core.data.repository.StorageMountKind.PRIMARY_EXTERNAL -> externalLabel
+                            com.raulshma.jellyplay.core.data.repository.StorageMountKind.REMOVABLE -> sdCardLabel
+                            com.raulshma.jellyplay.core.data.repository.StorageMountKind.EXTERNAL -> externalLabel
+                        }
+                    }
+                    val selectedMountLabel = mounts.firstOrNull { it.prefValue == preferences.downloadStorageLocation }
+                        ?.let { mountLabel(it.kind) }
+                        ?: if (preferences.downloadStorageLocation == "INTERNAL") internalLabel else externalLabel
                     SettingListItem(
                         icon = Tabler.Outline.Folder,
                         title = storageLocationTitle,
                         subtitle = stringResource(R.string.settings_download_storage_location_subtitle),
-                        trailingText = if (preferences.downloadStorageLocation == "INTERNAL") internalLabel else externalLabel,
+                        trailingText = selectedMountLabel,
                         highlighted = highlightSettingId == "download_storage_location",
-                        index = downloadIdx, count = downloadTotal,
+                        index = downloadIdx++, count = downloadTotal,
                         onClick = {
+                            val items = if (mounts.isNotEmpty()) mounts else emptyList()
                             activePicker = PickerState.List(
                                 title = storageLocationTitle,
-                                items = listOf("INTERNAL", "EXTERNAL"),
-                                label = { if (it == "INTERNAL") internalLabel else externalLabel },
-                                isSelected = { it == preferences.downloadStorageLocation },
-                                onSelect = { viewModel.setDownloadStorageLocation(it) },
+                                items = items,
+                                label = { mount ->
+                                    val label = mountLabel(mount.kind)
+                                    if (mount.availableBytes > 0L) {
+                                        "$label (${mount.availableBytes / (1024L * 1024 * 1024)} GB)"
+                                    } else {
+                                        label
+                                    }
+                                },
+                                isSelected = { it.prefValue == preferences.downloadStorageLocation },
+                                onSelect = { viewModel.setDownloadStorageLocation(it.prefValue) },
                             )
                         }
+                    )
+
+                    SettingToggleItem(
+                        icon = Tabler.Outline.Trash,
+                        title = stringResource(R.string.downloads_auto_delete_after_watch),
+                        subtitle = stringResource(R.string.downloads_auto_delete_after_watch_subtitle),
+                        checked = preferences.autoDeleteAfterWatch,
+                        highlighted = highlightSettingId == "auto_delete_after_watch",
+                        index = downloadIdx, count = downloadTotal,
+                        onCheckedChange = { viewModel.setAutoDeleteAfterWatch(it) }
                     )
                 }
             }

--- a/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/StorageSettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/raulshma/jellyplay/feature/settings/StorageSettingsViewModel.kt
@@ -2,6 +2,8 @@ package com.raulshma.jellyplay.feature.settings
 
 import android.content.Context
 import androidx.compose.runtime.Immutable
+import com.raulshma.jellyplay.core.data.repository.DownloadStorageLayout
+import com.raulshma.jellyplay.core.data.repository.StorageMount
 import com.raulshma.jellyplay.core.data.worker.AutoDownloadScheduler
 import com.raulshma.jellyplay.core.datastore.PreferencesEditor
 import com.raulshma.jellyplay.core.model.DownloadQuality
@@ -50,9 +52,33 @@ class StorageSettingsViewModel @Inject constructor(
     private val appearanceStore: com.raulshma.jellyplay.core.datastore.appearance.AppearanceStore,
     private val editor: PreferencesEditor,
     private val autoDownloadScheduler: AutoDownloadScheduler,
+    private val storageLayout: DownloadStorageLayout,
 ) : JellyPlayViewModel() {
 
     val preferences: StateFlow<StoragePreferences> = projections.storagePreferences
+
+    /**
+     * Storage mounts the user can pick for downloads.
+     * Computed once on construction from `DownloadStorageLayout.availableMounts`
+     * (which reads `Context.getExternalFilesDirs`); recomputed cheaply only when
+     * the user re-enters the screen, since the mount set only changes when a
+     * card/USB is inserted or removed between screen entries.
+     */
+    var storageMounts by composeState<List<StorageMount>>(emptyList())
+        private set
+
+    init {
+        refreshStorageMounts()
+    }
+
+    private fun refreshStorageMounts() {
+        launch {
+            val mounts = withContext(Dispatchers.IO) {
+                runCatching { storageLayout.availableMounts() }.getOrDefault(emptyList())
+            }
+            storageMounts = mounts
+        }
+    }
 
     val showAdvancedSettings: StateFlow<Boolean> = appearanceStore.showAdvancedSettings
 
@@ -193,6 +219,9 @@ class StorageSettingsViewModel @Inject constructor(
 
     fun setDownloadStorageLocation(location: String) =
         editor.edit { downloads.setDownloadStorageLocation(location) }
+
+    fun setAutoDeleteAfterWatch(enabled: Boolean) =
+        editor.edit { downloads.setAutoDeleteAfterWatch(enabled) }
 
     fun setMaxDownloadStorageGb(gb: Int) =
         editor.edit { downloads.setMaxDownloadStorageGb(gb) }

--- a/feature/settings/src/main/res/values-de/strings.xml
+++ b/feature/settings/src/main/res/values-de/strings.xml
@@ -752,6 +752,16 @@
     <string name="settings_storage_internal">Interner Speicher</string>
     <string name="settings_storage_external">Externe SD-Karte</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">Nach dem Ansehen löschen</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">Downloads entfernen, sobald vollständig angesehen</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">Interner Speicher</string>
+    <string name="storage_sd_card">SD-Karte</string>
+    <string name="storage_usb">USB-Speicher</string>
+    <string name="storage_external">Externer Speicher</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">Einschlaftimer-Dauer</string>
     <string name="settings_sleep_timer_15_min">15 Minuten</string>

--- a/feature/settings/src/main/res/values-es/strings.xml
+++ b/feature/settings/src/main/res/values-es/strings.xml
@@ -752,6 +752,16 @@
     <string name="settings_storage_internal">Almacenamiento interno</string>
     <string name="settings_storage_external">Tarjeta SD externa</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">Eliminar tras ver</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">Eliminar descargas una vez vistas por completo</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">Almacenamiento interno</string>
+    <string name="storage_sd_card">Tarjeta SD</string>
+    <string name="storage_usb">Almacenamiento USB</string>
+    <string name="storage_external">Almacenamiento externo</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">Duración del temporizador de sueño</string>
     <string name="settings_sleep_timer_15_min">15 minutos</string>

--- a/feature/settings/src/main/res/values-fr/strings.xml
+++ b/feature/settings/src/main/res/values-fr/strings.xml
@@ -752,6 +752,16 @@
     <string name="settings_storage_internal">Stockage interne</string>
     <string name="settings_storage_external">Carte SD externe</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">Supprimer après visionnage</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">Supprimer les téléchargements une fois entièrement regardés</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">Stockage interne</string>
+    <string name="storage_sd_card">Carte SD</string>
+    <string name="storage_usb">Stockage USB</string>
+    <string name="storage_external">Stockage externe</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">Durée du minuteur de sommeil</string>
     <string name="settings_sleep_timer_15_min">15 minutes</string>

--- a/feature/settings/src/main/res/values-it/strings.xml
+++ b/feature/settings/src/main/res/values-it/strings.xml
@@ -752,6 +752,16 @@
     <string name="settings_storage_internal">Memoria interna</string>
     <string name="settings_storage_external">SD card esterna</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">Elimina dopo la visione</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">Elimina i download una volta visti completamente</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">Memoria interna</string>
+    <string name="storage_sd_card">Scheda SD</string>
+    <string name="storage_usb">Memoria USB</string>
+    <string name="storage_external">Memoria esterna</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">Durata timer di spegnimento</string>
     <string name="settings_sleep_timer_15_min">15 minuti</string>

--- a/feature/settings/src/main/res/values-ja/strings.xml
+++ b/feature/settings/src/main/res/values-ja/strings.xml
@@ -750,6 +750,16 @@
     <string name="settings_storage_internal">内部ストレージ</string>
     <string name="settings_storage_external">外部 SD カード</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">視聴後に削除</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">視聴完了したダウンロードを削除します</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">内部ストレージ</string>
+    <string name="storage_sd_card">SDカード</string>
+    <string name="storage_usb">USBストレージ</string>
+    <string name="storage_external">外部ストレージ</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">スリープタイマーの時間</string>
     <string name="settings_sleep_timer_15_min">15 分</string>

--- a/feature/settings/src/main/res/values-ko/strings.xml
+++ b/feature/settings/src/main/res/values-ko/strings.xml
@@ -750,6 +750,16 @@
     <string name="settings_storage_internal">내부 저장공간</string>
     <string name="settings_storage_external">외부 SD 카드</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">시청 후 삭제</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">시청을 마친 다운로드를 삭제합니다</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">내부 저장공간</string>
+    <string name="storage_sd_card">SD 카드</string>
+    <string name="storage_usb">USB 저장공간</string>
+    <string name="storage_external">외부 저장공간</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">취침 타이머 기간</string>
     <string name="settings_sleep_timer_15_min">15분</string>

--- a/feature/settings/src/main/res/values-pt/strings.xml
+++ b/feature/settings/src/main/res/values-pt/strings.xml
@@ -752,6 +752,16 @@
     <string name="settings_storage_internal">Armazenamento interno</string>
     <string name="settings_storage_external">Cartão SD externo</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">Eliminar após ver</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">Eliminar transferências depois de totalmente vistas</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">Armazenamento interno</string>
+    <string name="storage_sd_card">Cartão SD</string>
+    <string name="storage_usb">Armazenamento USB</string>
+    <string name="storage_external">Armazenamento externo</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">Duração do temporizador de adormecer</string>
     <string name="settings_sleep_timer_15_min">15 minutos</string>

--- a/feature/settings/src/main/res/values-zh/strings.xml
+++ b/feature/settings/src/main/res/values-zh/strings.xml
@@ -752,6 +752,16 @@
     <string name="settings_storage_internal">内部存储</string>
     <string name="settings_storage_external">外部 SD 卡</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">观看后删除</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">观看完毕后删除下载</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">内部存储</string>
+    <string name="storage_sd_card">SD 卡</string>
+    <string name="storage_usb">USB 存储</string>
+    <string name="storage_external">外部存储</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">睡眠定时器时长</string>
     <string name="settings_sleep_timer_15_min">15 分钟</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -171,6 +171,8 @@
     <string name="settings_send_logs_chooser">Send Logs</string>
     <string name="settings_check_updates_automatically">Check for Updates Automatically</string>
     <string name="settings_check_updates_subtitle">Periodically check GitHub for new releases</string>
+    <string name="settings_download_updates_automatically">Download Updates Automatically</string>
+    <string name="settings_download_updates_subtitle">New updates download right away instead of waiting for you to tap Download</string>
     <string name="settings_checking_for_updates">Checking for updates\u2026</string>
     <string name="settings_update_available">Update available: v%1$s</string>
     <string name="settings_up_to_date">Up to date (v%1$s)</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -906,6 +906,8 @@
     <string name="settings_hide_episode_thumbnails_subtitle">Hide episode preview images to avoid spoilers</string>
     <string name="settings_compact_episode_list">Compact Episode List</string>
     <string name="settings_compact_episode_list_subtitle">Show episodes as a vertical list on mobile instead of a horizontal row</string>
+    <string name="settings_confirm_library_reset">Confirm Library Reset</string>
+    <string name="settings_confirm_library_reset_subtitle">Show a confirmation dialog before resetting the library to defaults</string>
     <string name="settings_skip_special_episodes">Skip Special Episodes</string>
     <string name="settings_skip_special_episodes_subtitle">Exclude specials/bonus episodes from episode lists</string>
     <string name="settings_haptic_feedback">Haptic Feedback</string>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -817,6 +817,16 @@
     <string name="settings_storage_internal">Internal Storage</string>
     <string name="settings_storage_external">External SD Card</string>
 
+    <!-- DownloadsSettingsScreen.kt: auto-delete after watching -->
+    <string name="downloads_auto_delete_after_watch">Auto-delete after watching</string>
+    <string name="downloads_auto_delete_after_watch_subtitle">Remove downloads once fully watched</string>
+
+    <!-- StorageSettingsScreen.kt: real storage mounts -->
+    <string name="storage_internal">Internal storage</string>
+    <string name="storage_sd_card">SD card</string>
+    <string name="storage_usb">USB storage</string>
+    <string name="storage_external">External storage</string>
+
     <!-- AudioSettingsScreen.kt -->
     <string name="settings_sleep_timer_duration">Sleep Timer Duration</string>
     <string name="settings_sleep_timer_15_min">15 minutes</string>


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to Picture-in-Picture (PiP) handling, app update management, and dependency injection. The most significant changes include a full refactor of PiP parameter management for better reliability, enhancements to app update download and prompt logic, and the addition of new widget configuration activities.

**Picture-in-Picture (PiP) improvements:**
* Refactored PiP parameter handling in `MainActivity` to centralize logic in `buildPipParams`, improving reliability and preventing crashes on malformed aspect ratios or source rects. Added robust guards and logging for PiP actions and state changes. (`app/src/main/java/com/raulshma/jellyplay/MainActivity.kt`) [[1]](diffhunk://#diff-7e788cd47e5c37d4988e7224583af99a9e0b023bb4b05b9c597850cae61848c9R151-R168) [[2]](diffhunk://#diff-7e788cd47e5c37d4988e7224583af99a9e0b023bb4b05b9c597850cae61848c9L518-R620) [[3]](diffhunk://#diff-7e788cd47e5c37d4988e7224583af99a9e0b023bb4b05b9c597850cae61848c9L598-R679) [[4]](diffhunk://#diff-7e788cd47e5c37d4988e7224583af99a9e0b023bb4b05b9c597850cae61848c9L620-R703) [[5]](diffhunk://#diff-7e788cd47e5c37d4988e7224583af99a9e0b023bb4b05b9c597850cae61848c9R733)
* Improved PiP auto-exit behavior by observing a new ViewModel signal and reusing the existing dismiss path, ensuring smoother user experience. (`app/src/main/java/com/raulshma/jellyplay/MainActivity.kt`)

**App update management enhancements:**
* Added support for auto-downloading app updates when the user has opted in, skipping the update prompt and starting the download immediately. The update sheet now reflects download progress and allows toggling the auto-download preference. (`app/src/main/java/com/raulshma/jellyplay/MainViewModel.kt`) [[1]](diffhunk://#diff-80adf2e4ab3c9d2629b436fe9678c4261cd6578097c6fa71666e75b928691e0fR187-R194) [[2]](diffhunk://#diff-80adf2e4ab3c9d2629b436fe9678c4261cd6578097c6fa71666e75b928691e0fL202-R228) [[3]](diffhunk://#diff-80adf2e4ab3c9d2629b436fe9678c4261cd6578097c6fa71666e75b928691e0fR323-R328) [[4]](diffhunk://#diff-80adf2e4ab3c9d2629b436fe9678c4261cd6578097c6fa71666e75b928691e0fL314-R344) [[5]](diffhunk://#diff-80adf2e4ab3c9d2629b436fe9678c4261cd6578097c6fa71666e75b928691e0fR358-R367)
* Deferred construction of `AppUpdateRepository` at startup to improve cold-start performance and added cleanup of orphaned APKs left by prior updates. (`app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt`) [[1]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dR70-R76) [[2]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dR98-R112)

**Dependency injection and background services:**
* Injected new providers for notification reconnect listeners and app update repository, and started these listeners at application startup for improved reliability. (`app/src/main/java/com/raulshma/jellyplay/JellyPlayApplication.kt`) [[1]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dR70-R76) [[2]](diffhunk://#diff-481b38dd2932413752c812647395e1e84f29319d5c1e9cde3e8327001ae5743dR98-R112)

**AndroidManifest and widget configuration:**
* Added configuration activities for "Continue Watching" and "Now Playing" widgets, and removed the old `JellyPlayPlaybackService` declaration. Also expanded `configChanges` for the main activity to include more device states and enabled activity resizing. (`app/src/main/AndroidManifest.xml`) [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdL65-R66) [[2]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdL107-L117) [[3]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR198-R217)

These changes collectively improve user experience with PiP, streamline the app update process, and lay groundwork for new widget features.