### PR TITLE
chore: remove Dependabot version updates config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  # Workflows pin third-party actions to commit SHAs (see codeql.yml);
-  # Dependabot keeps those pins current with upstream releases.
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly


### PR DESCRIPTION
Stops Dependabot from opening version-update PRs (weekly github-actions bumps). Security updates and vulnerability alerts are already disabled; this removes the remaining PR source.